### PR TITLE
utils/name_substitution: use utf-8 encoding when opening locale files

### DIFF
--- a/utils/name_substitution.py
+++ b/utils/name_substitution.py
@@ -89,7 +89,7 @@ async def substitute_file(tree, path, tarball = None):
     arcname = str(path.relative_to(tree))
     text = None
 
-    with open(path, 'r') as f:
+    with open(path, 'r', encoding='utf-8') as f:
         text = f.read()
 
     replaced = replace(text)
@@ -97,7 +97,7 @@ async def substitute_file(tree, path, tarball = None):
         print(f"Replaced strings in {arcname}")
         if tarball:
             tarball.add(path, arcname=arcname, recursive=False)
-        with open(path, 'w') as f:
+        with open(path, 'w', encoding='utf-8') as f:
             f.write(replaced)
 
 def do_unsubstitution(tree, tarpath):


### PR DESCRIPTION
When opening a file Python [uses](https://docs.python.org/3/library/functions.html#open) the result of [`locale.getencoding()`](https://docs.python.org/3/library/locale.html#locale.getencoding) as the encoding if the `encoding` argument is not explicitly specified. 

On Windows `locale.getencoding()` returns `cp1251` which doesn't support a lot of characters used by Chromium translation files, for example Amharic language in `android_webview\java\strings\translations\android_webview_strings_am.xtb`. This causes name substitution script to fail with `UnicodeDecodeError` exception.

This PR fixes this issue by explicitly setting the `utf-8` encoding when opening files for reading/writing and makes this script consistently work no matter the system encoding.