### PR TITLE
helium/core: disable google ai starterpack options

### DIFF
--- a/patches/helium/core/disable-google-ai-starterpack-options.patch
+++ b/patches/helium/core/disable-google-ai-starterpack-options.patch
@@ -1,0 +1,42 @@
+--- a/chrome/browser/ui/search_engines/template_url_table_model.cc
++++ b/chrome/browser/ui/search_engines/template_url_table_model.cc
+@@ -119,12 +119,11 @@ void TemplateURLTableModel::Reload() {
+   for (TemplateURL* template_url : urls) {
+     // Don't include the expanded set of starter pack keywords if the expansion
+     // feature flag is not enabled.
+-    if ((template_url->starter_pack_id() ==
+-             template_url_starter_pack_data::kGemini &&
+-         !OmniboxFieldTrial::IsStarterPackExpansionEnabled()) ||
+-        (template_url->starter_pack_id() ==
+-             template_url_starter_pack_data::kPage &&
+-         !omnibox_feature_configs::ContextualSearch::Get().starter_pack_page)) {
++
++    // Disable all Google AI starter pack options
++    if (template_url->starter_pack_id() == template_url_starter_pack_data::kGemini ||
++        template_url->starter_pack_id() == template_url_starter_pack_data::kAiMode ||
++        template_url->starter_pack_id() == template_url_starter_pack_data::kPage) {
+       continue;
+     }
+ 
+--- a/components/omnibox/browser/featured_search_provider.cc
++++ b/components/omnibox/browser/featured_search_provider.cc
+@@ -291,13 +291,14 @@ void FeaturedSearchProvider::AddFeatured
+         turl->is_active() == TemplateURLData::ActiveStatus::kTrue) {
+       // Don't add the expanded set of starter pack engines unless the feature
+       // is enabled.
+-      if ((turl->starter_pack_id() == template_url_starter_pack_data::kGemini &&
+-           !OmniboxFieldTrial::IsStarterPackExpansionEnabled()) ||
+-          (turl->starter_pack_id() == template_url_starter_pack_data::kPage &&
+-           !omnibox_feature_configs::ContextualSearch::Get()
+-                .starter_pack_page)) {
++
++      // Disable all Google AI starter pack options
++      if (turl->starter_pack_id() == template_url_starter_pack_data::kGemini ||
++          turl->starter_pack_id() == template_url_starter_pack_data::kAiMode ||
++          turl->starter_pack_id() == template_url_starter_pack_data::kPage) {
+         continue;
+       }
++
+       // The history starter pack engine is disabled in incognito mode.
+       if (client_->IsOffTheRecord() &&
+           turl->starter_pack_id() == template_url_starter_pack_data::kHistory) {

--- a/patches/series
+++ b/patches/series
@@ -150,6 +150,7 @@ helium/core/add-low-power-framerate-flag.patch
 helium/core/add-update-channel-flag.patch
 helium/core/add-updater-preference.patch
 helium/core/add-disable-ech-flag.patch
+helium/core/disable-google-ai-starterpack-options.patch
 
 helium/settings/move-search-suggest.patch
 helium/settings/remove-autofill.patch


### PR DESCRIPTION
disables gemini, aimode, and page shortcuts; even if google didn't gate the features correctly, which happened with aimode

will make a pr to ungoogled chromium in a bit, so this patch will be removed on next merge i assume