### PR TITLE
UI: overcorrect rounding errors in split view, update flags webui

### DIFF
--- a/patches/helium/core/split-view.patch
+++ b/patches/helium/core/split-view.patch
@@ -79,7 +79,20 @@
  
    MultiContentsView(BrowserView* browser_view,
                      std::unique_ptr<MultiContentsViewDelegate> delegate);
-@@ -157,10 +156,6 @@ class MultiContentsView : public views::
+@@ -133,12 +132,6 @@ class MultiContentsView : public views::
+     return *drop_target_controller_;
+   }
+ 
+-  gfx::Insets& start_contents_view_inset() {
+-    return start_contents_view_inset_;
+-  }
+-
+-  gfx::Insets& end_contents_view_inset() { return end_contents_view_inset_; }
+-
+   bool is_drag_and_drop_enabled() const { return is_drag_and_drop_enabled_; }
+ 
+   void set_min_contents_width_for_testing(int width) {
+@@ -157,10 +150,6 @@ class MultiContentsView : public views::
      return contents_container_views_[1]->GetContentsView();
    }
  
@@ -90,6 +103,17 @@
   private:
    static constexpr int kMinWebContentsWidth = 200;
    static constexpr double kMinWebContentsWidthPercentage = 0.1;
+@@ -226,10 +215,6 @@ class MultiContentsView : public views::
+   // Nullopt if not currently resizing.
+   std::optional<double> initial_start_width_on_resize_;
+ 
+-  // Insets of the start and end contents view when in split view
+-  gfx::Insets start_contents_view_inset_;
+-  gfx::Insets end_contents_view_inset_;
+-
+   bool show_inactive_scrim_ = false;
+ 
+   // This is needed because drag and drop is broken on Wayland. Once that is
 --- a/chrome/browser/resources/tab_search/split_view/app.css
 +++ b/chrome/browser/resources/tab_search/split_view/app.css
 @@ -50,7 +50,7 @@ picture {
@@ -111,6 +135,56 @@
  #include "chrome/browser/ui/views/frame/scrim_view.h"
  #include "chrome/browser/ui/views/frame/top_container_background.h"
  #include "chrome/browser/ui/views/new_tab_footer/footer_web_view.h"
+@@ -42,11 +41,7 @@ MultiContentsView::MultiContentsView(
+     BrowserView* browser_view,
+     std::unique_ptr<MultiContentsViewDelegate> delegate)
+     : browser_view_(browser_view),
+-      delegate_(std::move(delegate)),
+-      start_contents_view_inset_(
+-          gfx::Insets(kSplitViewContentInset).set_top(0).set_right(0)),
+-      end_contents_view_inset_(
+-          gfx::Insets(kSplitViewContentInset).set_top(0).set_left(0)) {
++      delegate_(std::move(delegate)) {
+ #if BUILDFLAG(IS_OZONE)
+   if (!ui::OzonePlatform::GetInstance()
+            ->GetPlatformProperties()
+@@ -233,11 +228,8 @@ void MultiContentsView::OnResize(int res
+         std::make_optional(contents_container_views_[0]->size().width());
+   }
+   double total_width = contents_container_views_[0]->size().width() +
+-                       contents_container_views_[0]->GetInsets().width() +
+-                       contents_container_views_[1]->size().width() +
+-                       contents_container_views_[1]->GetInsets().width();
++                       contents_container_views_[1]->size().width();
+   double end_width = (initial_start_width_on_resize_.value() +
+-                      contents_container_views_[0]->GetInsets().width() +
+                       static_cast<double>(resize_amount));
+ 
+   // If end_width is within the snap point widths, update to the snap point.
+@@ -343,11 +335,6 @@ views::ProposedLayout MultiContentsView:
+     }
+   }
+ 
+-  if (IsInSplitView()) {
+-    start_rect.Inset(start_contents_view_inset_);
+-    end_rect.Inset(end_contents_view_inset_);
+-  }
+-
+   layouts.child_layouts.emplace_back(contents_container_views_[0],
+                                      contents_container_views_[0]->GetVisible(),
+                                      start_rect);
+@@ -376,8 +363,10 @@ MultiContentsView::ViewWidths MultiConte
+     widths.resize_width = resize_area_->GetPreferredSize().width();
+     widths.start_width =
+         start_ratio_ * (available_space.width() - widths.resize_width);
++
++    // +1 to overcorrect for rounding errors that cause a gap on the very edge
+     widths.end_width =
+-        available_space.width() - widths.start_width - widths.resize_width;
++        available_space.width() - widths.start_width - widths.resize_width + 1;
+   } else {
+     CHECK(!contents_container_views_[1]->GetVisible());
+     widths.drop_target_width =
 --- a/chrome/browser/ui/views/frame/contents_container_view.cc
 +++ b/chrome/browser/ui/views/frame/contents_container_view.cc
 @@ -14,7 +14,6 @@
@@ -420,3 +494,80 @@
  
  // Enabls adding an aim shortcut in the typed state.
  BASE_FEATURE(kOmniboxAimShortcutTypedState,
+--- a/chrome/browser/ui/views/frame/browser_view_layout.cc
++++ b/chrome/browser/ui/views/frame/browser_view_layout.cc
+@@ -824,9 +824,6 @@ void BrowserViewLayout::LayoutContentsCo
+       CalculateContentsContainerLayout(available_bounds);
+   const bool is_in_split = delegate_->IsActiveTabSplit();
+ 
+-  if (is_in_split) {
+-    UpdateSplitViewInsets();
+-  }
+   contents_container_->SetBoundsRect(layout_result.contents_container_bounds);
+ 
+   if (unified_side_panel_) {
+@@ -848,35 +845,6 @@ void BrowserViewLayout::LayoutContentsCo
+     left_aligned_side_panel_separator_->SetBoundsRect(
+         layout_result.separator_bounds);
+   }
+-
+-  if (side_panel_rounded_corner_) {
+-    SetViewVisibility(side_panel_rounded_corner_,
+-                      layout_result.side_panel_visible && !is_in_split);
+-    if (layout_result.side_panel_visible) {
+-      // This can return nullptr when there is no Widget (for context, see
+-      // http://crbug.com/40178332). The nullptr dereference does not always
+-      // crash due to compiler optimizations, so CHECKing here ensures we crash.
+-      CHECK(side_panel_rounded_corner_->GetLayoutProvider());
+-      // Adjust the rounded corner bounds based on the side panel bounds.
+-      const float corner_radius =
+-          side_panel_rounded_corner_->GetLayoutProvider()
+-              ->GetCornerRadiusMetric(
+-                  views::ShapeContextTokens::kSidePanelPageContentRadius);
+-      const float corner_size = corner_radius + views::Separator::kThickness;
+-      if (layout_result.contents_container_after_side_panel) {
+-        side_panel_rounded_corner_->SetBounds(
+-            layout_result.side_panel_bounds.right(),
+-            layout_result.side_panel_bounds.y() - views::Separator::kThickness,
+-            corner_size, corner_size);
+-      } else {
+-        side_panel_rounded_corner_->SetBounds(
+-            layout_result.side_panel_bounds.x() - corner_radius -
+-                views::Separator::kThickness,
+-            layout_result.side_panel_bounds.y() - views::Separator::kThickness,
+-            corner_size, corner_size);
+-      }
+-    }
+-  }
+ }
+ 
+ void BrowserViewLayout::UpdateTopContainerBounds(
+@@ -988,27 +956,5 @@ bool BrowserViewLayout::IsInfobarVisible
+ // no toolbar or presence of infobar. Similarly the insets for the left and
+ // right of the split view is determined by the side panel.
+ void BrowserViewLayout::UpdateSplitViewInsets() {
+-  SidePanel* side_panel = views::AsViewClass<SidePanel>(unified_side_panel_);
+-  bool has_side_panel = side_panel->GetVisible();
+-  bool is_right_aligned = side_panel->IsRightAligned();
+-  bool is_in_full_screen = browser_view_->IsFullscreen();
+-  bool has_infobar = infobar_container_->GetVisible();
+-
+-  CHECK(multi_contents_view_);
+-
+-  multi_contents_view_->start_contents_view_inset()
+-      .set_left(has_side_panel && !is_right_aligned
+-                    ? 0
+-                    : MultiContentsView::kSplitViewContentInset)
+-      .set_top(!is_in_full_screen && !has_infobar
+-                   ? 0
+-                   : MultiContentsView::kSplitViewContentInset);
+-
+-  multi_contents_view_->end_contents_view_inset()
+-      .set_right(has_side_panel && is_right_aligned
+-                     ? 0
+-                     : MultiContentsView::kSplitViewContentInset)
+-      .set_top(!is_in_full_screen && !has_infobar
+-                   ? 0
+-                   : MultiContentsView::kSplitViewContentInset);
++  return;
+ }

--- a/patches/helium/ui/helium-color-scheme.patch
+++ b/patches/helium/ui/helium-color-scheme.patch
@@ -420,3 +420,44 @@
    base: {value: 0xff757575},
  };
  
+--- a/components/webui/flags/resources/app.css
++++ b/components/webui/flags/resources/app.css
+@@ -18,14 +18,15 @@
+   --ease-in-out: cubic-bezier(0.4, 0.0, 0.2, 1);
+   --shadow-color: rgba(0, 0, 0, 0.1);
+ 
+-  --google-blue-300-rgb: 138, 180, 248;
++  --google-blue-300-rgb: 180, 201, 255; /* #b4c9ff */
+   --google-blue-300: rgb(var(--google-blue-300-rgb));
+-  --google-blue-400: rgb(102, 157, 246);
+-  --google-blue-500-rgb: 66, 133, 244;
++  --google-blue-400: rgb(151, 177, 255); /* #97b1ff */
++  --google-blue-500-rgb: 122, 151, 251; /* #7a97fb */
+   --google-blue-500: rgb(var(--google-blue-500-rgb));
+-  --google-blue-600-rgb: 26, 115, 232;
++  --google-blue-600-rgb: 94, 122, 232; /* #5e7ae8 */
+   --google-blue-600: rgb(var(--google-blue-600-rgb));
+-  --google-blue-700: rgb(25, 103, 210);
++  --google-blue-700: rgb(67, 91, 205); /* #435bcd */
++
+   --google-grey-100: rgb(241, 243, 244);
+   --google-grey-200-rgb: 232, 234, 237;
+   --google-grey-200: rgb(var(--google-grey-200-rgb));
+@@ -44,7 +45,7 @@
+   --secondary-color: var(--google-grey-700);
+   --warning-color: var(--google-red-700);
+ 
+-  --focus-shadow-color: rgb(11, 87, 208);
++  --focus-shadow-color: rgb(76, 102, 217);
+   --input-background: var(--google-grey-100);
+   --link-color: var(--google-blue-700);
+   --separator-color: rgba(0, 0, 0, .06);
+@@ -60,7 +61,7 @@
+     --secondary-color: var(--google-grey-500);
+     --warning-color: var(--google-red-300);
+ 
+-    --focus-shadow-color: rgb(168, 199, 250);
++    --focus-shadow-color: var(--google-blue-400);
+     --input-background: rgba(0, 0, 0, .3);
+     --link-color: var(--google-blue-300);
+     --separator-color: rgba(255, 255, 255, .1);

--- a/patches/helium/ui/improve-flags-webui.patch
+++ b/patches/helium/ui/improve-flags-webui.patch
@@ -1,0 +1,71 @@
+--- a/components/webui/flags/resources/app.css
++++ b/components/webui/flags/resources/app.css
+@@ -105,8 +106,8 @@ button {
+ }
+ 
+ :focus-visible {
+-  box-shadow: 0 0 0 2px var(--focus-shadow-color);
+-  outline: none;
++  outline: var(--focus-shadow-color) 2px solid;
++  outline-offset: 2px;
+ }
+ 
+ @media (forced-colors: active) {
+@@ -159,7 +160,7 @@ button {
+ #header .flex-container {
+   box-sizing: border-box;
+   margin: 0 auto;
+-  max-width: 700px;
++  max-width: calc(700px + 2rem);
+ }
+ 
+ #header .flex-container .flex:first-child {
+@@ -185,14 +186,18 @@ button {
+   background: var(--input-background)
+       url(chrome://resources/images/icon_search.svg) no-repeat 8px 50%;
+   border: 1px solid transparent;
+-  border-radius: 3px;
++  border-radius: 8px;
+   box-sizing: border-box;
+   color: inherit;
+-  font-size: .8125rem;
+-  padding: 12px 36px;
++  font-size: 14px;
++  padding: 9px 38px;
+   width: 100%;
+ }
+ 
++#header .flex-container .flex:last-child {
++  flex: unset;
++}
++
+ #search::placeholder {
+   color: rgba(var(--google-grey-900-rgb), .71);
+ }
+--- a/components/webui/flags/resources/experiment.css
++++ b/components/webui/flags/resources/experiment.css
+@@ -12,8 +12,8 @@
+ }
+ 
+ :focus-visible {
+-  box-shadow: 0 0 0 2px var(--focus-shadow-color);
+-  outline: none;
++  outline: var(--focus-shadow-color) 2px solid;
++  outline-offset: 2px;
+ }
+ 
+ .experiment {
+@@ -89,11 +89,12 @@ select {
+   border: 1px solid var(--link-color);
+   color: var(--link-color);
+   font-size: .8125rem;
+-  height: 1.625rem;
++  height: 1.8rem;
+   letter-spacing: .01em;
+   max-width: 150px;
+   text-align-last: center;
+   width: 100%;
++  border-radius: 6px;
+ }
+ 
+ @media (prefers-color-scheme: dark) {

--- a/patches/series
+++ b/patches/series
@@ -222,3 +222,4 @@ helium/ui/status-bubble.patch
 helium/ui/clean-incognito-guest-ntp.patch
 helium/ui/enable-fluent-scrollbar.patch
 helium/ui/helium-color-scheme.patch
+helium/ui/improve-flags-webui.patch


### PR DESCRIPTION
split view:
- fixed 1px gap on very right of end split view in some rare cases
- removed code for insets
- removed side panel's rounded corner which is supposed to match split view's behavior, and we no longer have rounded corners there

flags webui:
- updated colors to use helium colors
- fixed alignment issues
- made search bar wider and less ugly
- made select dropdowns rounded
- proper outline for :focus-visible