### PR TITLE
helium/split-view: reload only focused half of split view

### DIFF
--- a/patches/helium/core/split-view.patch
+++ b/patches/helium/core/split-view.patch
@@ -603,3 +603,19 @@
  
    raw_ptr<TabStripModel> tab_strip_model_ = nullptr;
  
+--- a/chrome/browser/ui/browser_commands.cc
++++ b/chrome/browser/ui/browser_commands.cc
+@@ -498,8 +498,12 @@ void ReloadInternal(Browser* browser,
+       browser->tab_strip_model()->GetActiveWebContents();
+ 
+   std::vector<WebContents*> tabs_to_reload;
++  const bool only_active_split_tab_selected =
++      browser->tab_strip_model()->IsActiveTabSplit() &&
++      browser->tab_strip_model()->selection_model().size() == 2;
+ 
+-  if (base::FeatureList::IsEnabled(features::kReloadSelectionModel)) {
++  if (base::FeatureList::IsEnabled(features::kReloadSelectionModel)
++      || only_active_split_tab_selected) {
+     tabs_to_reload.push_back(
+         browser->tab_strip_model()->GetActiveWebContents());
+   } else {


### PR DESCRIPTION
fixes #118