### PR TITLE
helium/core: disable fedcm login nag bubble

### DIFF
--- a/patches/helium/core/disable-fedcm-bubble.patch
+++ b/patches/helium/core/disable-fedcm-bubble.patch
@@ -1,0 +1,12 @@
+--- a/chrome/browser/ui/views/webid/fedcm_account_selection_view_desktop.cc
++++ b/chrome/browser/ui/views/webid/fedcm_account_selection_view_desktop.cc
+@@ -1279,6 +1279,9 @@ gfx::Rect FedCmAccountSelectionView::Get
+ 
+ void FedCmAccountSelectionView::ShouldShowDialog(bool& should_show) {
+   if (dialog_type_ == DialogType::BUBBLE) {
++    should_show = false;
++    return;
++
+     // Hide the bubble dialog if it can't fit.
+     if (!CanFitInWebContents()) {
+       should_show = false;

--- a/patches/series
+++ b/patches/series
@@ -176,6 +176,7 @@ helium/core/infinite-tab-freezing.patch
 helium/core/disable-touch-ui.patch
 helium/core/open-new-tabs-next-to-active-tab-option.patch
 helium/core/disable-update-toast.patch
+helium/core/disable-fedcm-bubble.patch
 
 helium/settings/move-search-suggest.patch
 helium/settings/remove-autofill.patch


### PR DESCRIPTION
this PR removes the fedcm login nag that shows up on top right on top of the page. logging in via fedcm works, and the proper login modal still shows up, since this change removes just the login nag (bubble).

before:
<img width="470" height="454" alt="image" src="https://github.com/user-attachments/assets/72d11580-d783-4c7b-aa82-1e47e5456479" />

after:
<img width="538" height="496" alt="image" src="https://github.com/user-attachments/assets/143671fe-386e-42f4-a594-e3ded5bcc79f" />

regular fedcm login modal (after):
<img width="596" height="693" alt="image" src="https://github.com/user-attachments/assets/30d3ead2-9101-4656-9668-517537efb8a7" />
