### PR TITLE
feat: add Brave Search engine option

### DIFF
--- a/patches/helium/core/search/add-brave-search-option.patch
+++ b/patches/helium/core/search/add-brave-search-option.patch
@@ -1,0 +1,12 @@
+--- a/third_party/search_engines_data/resources/definitions/regional_settings.json
++++ b/third_party/search_engines_data/resources/definitions/regional_settings.json
+@@ -11,7 +11,8 @@
+           "&bing",
+           "&break_stuff_google",
+           "&qwant",
+-          "&kagi"
++          "&kagi",
++          "&brave"
+       ]
+     }
+   },

--- a/patches/series
+++ b/patches/series
@@ -157,6 +157,7 @@ helium/core/search/force-eu-search-features.patch
 helium/core/search/remove-description-snippet-deps.patch
 helium/core/search/break-favicons.patch
 helium/core/search/omnibox-default-search-icon.patch
+helium/core/search/add-brave-search-option.patch
 
 helium/settings/setup-behavior-settings-page.patch
 helium/core/keyboard-shortcuts.patch


### PR DESCRIPTION
For your pull request to not get closed without review, please confirm that:

- [X] An issue exists where the maintainers agreed that this should be implemented.
      If such issue did not exist before, I opened one.
- [X] I tested that my contribution works locally, and does not break anything,
      otherwise I have marked my PR as draft.
- [X] If my contribution is non-trivial, I did not use AI to write most of it.
- [x] I understand that I will be permanently banned from interacting with this
      organization if I lied by checking any of these checkboxes.

Tested on (check one or more):
- [ ] Windows
- [X] macOS
- [ ] Linux

---

Adds the option to pick Brave Search as a default search engine. I'll work on a PR for onboarding to add it there too. ~~Also would someone else be able to test that the favicon loads for them in settings? The URL in the source code for it is valid but something about it causes the following error when trying to show in settings: `ERROR:third_party/blink/renderer/core/html/media/html_media_element.cc:5045] SetError: {code=4, message="MEDIA_ELEMENT_ERROR: Media load rejected by URL safety check"}`~~

Needs update to nonfree gist for favicon and to helium-onboarding.

~~Dependent on #826~~ ✅

Resolves #92
