### PR TITLE
helium/core/split-view: close only the active tab in split view via ⌘+W

### DIFF
--- a/patches/helium/core/split-view.patch
+++ b/patches/helium/core/split-view.patch
@@ -1,5 +1,14 @@
 --- a/chrome/browser/ui/ui_features.cc
 +++ b/chrome/browser/ui/ui_features.cc
+@@ -115,7 +115,7 @@ BASE_FEATURE(kReloadSelectionModel,
+ // when it is the only tab in selection model.
+ BASE_FEATURE(kCloseActiveTabInSplitViewViaHotkey,
+              "CloseActiveTabInSplitViewViaHotkey",
+-             base::FEATURE_DISABLED_BY_DEFAULT);
++             base::FEATURE_ENABLED_BY_DEFAULT);
+ 
+ // When enabled, a scrim is shown behind window modal dialogs to cover the
+ // entire browser window. This gives user a visual cue that the browser window
 @@ -137,7 +137,7 @@ BASE_FEATURE(kShowTabGroupsMacSystemMenu
               base::FEATURE_DISABLED_BY_DEFAULT);
  #endif  // BUILDFLAG(IS_MAC)


### PR DESCRIPTION
For your pull request to not get closed without review, please confirm that:

- [X] An issue exists where the maintainers agreed that this should be implemented.
      If such issue did not exist before, I opened one.
- [X] I tested that my contribution works locally, and does not break anything,
      otherwise I have marked my PR as draft.
- [X] If my contribution is non-trivial, I did not use AI to write most of it.
- [x] I understand that I will be permanently banned from interacting with this
      organization if I lied by checking any of these checkboxes.

Tested on (check one or more):
- [ ] Windows
- [X] macOS
- [ ] Linux

---

Enables a flag by default for closing only the active tab in split views, specifically when using the hotkey. I'm curious to why Chromium didn't have this enabled by default or why it was separated into a flag.

Fixes #282 
