### PR TITLE
helium/services: disable webui toggle if onboarding is incomplete

### DIFF
--- a/patches/helium/core/add-native-bangs.patch
+++ b/patches/helium/core/add-native-bangs.patch
@@ -724,7 +724,7 @@
  COMPONENT_EXPORT(HELIUM) GURL GetDummyURL();
 --- a/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
 +++ b/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
-@@ -1957,6 +1957,9 @@ void AddPrivacyStrings(content::WebUIDat
+@@ -1959,6 +1959,9 @@ void AddPrivacyStrings(content::WebUIDat
        {"heliumServicesToggle", IDS_SETTINGS_HELIUM_SERVICES_TOGGLE},
        {"heliumServicesToggleDescription",
          IDS_SETTINGS_HELIUM_SERVICES_TOGGLE_DESCRIPTION},
@@ -736,7 +736,7 @@
        {"heliumExtProxyToggleDescription",
 --- a/chrome/app/settings_strings.grdp
 +++ b/chrome/app/settings_strings.grdp
-@@ -1931,6 +1931,12 @@
+@@ -1937,6 +1937,12 @@
    <message name="IDS_SETTINGS_HELIUM_SERVICES_EXT_PROXY_TOGGLE_DESCRIPTION" desc="Description of the toggle for enabling/disabling of downloading and proxying extensions">
      When enabled, Helium will proxy extension downloads and updates to protect your privacy. When disabled, downloading and updating extensions will not work.
    </message>
@@ -751,18 +751,18 @@
    </message>
 --- a/chrome/browser/resources/settings/privacy_page/services_page.html
 +++ b/chrome/browser/resources/settings/privacy_page/services_page.html
-@@ -12,6 +12,11 @@
-     </settings-toggle-button>
-     <div class="cr-col">
-         <cr-collapse id="servicesCollapse" opened="[[prefs.helium.services.enabled.value]]">
+@@ -49,6 +49,11 @@
+                 label="$i18n{heliumExtProxyToggle}"
+                 sub-label="$i18n{heliumExtProxyToggleDescription}">
+             </settings-toggle-button>
 +            <settings-toggle-button id="bangToggleButton"
 +                pref="{{prefs.helium.services.bangs}}"
 +                label="$i18n{heliumBangsToggle}"
 +                sub-label="$i18n{heliumBangsToggleDescription}">
 +            </settings-toggle-button>
-             <settings-toggle-button id="extProxyToggleButton"
-                 pref="{{prefs.helium.services.ext_proxy}}"
-                 label="$i18n{heliumExtProxyToggle}"
+         </cr-collapse>
+     </div>
+     </template>
 --- a/chrome/browser/ui/browser_ui_prefs.cc
 +++ b/chrome/browser/ui/browser_ui_prefs.cc
 @@ -204,6 +204,7 @@ void RegisterBrowserUserPrefs(user_prefs
@@ -783,7 +783,7 @@
 +      settings_api::PrefType::kBoolean;
    (*s_allowlist)[::prefs::kHeliumServicesOrigin] =
        settings_api::PrefType::kString;
- 
+   (*s_allowlist)[::prefs::kHeliumServicesConsented] =
 --- a/components/helium_services/pref_names.h
 +++ b/components/helium_services/pref_names.h
 @@ -24,6 +24,9 @@ inline constexpr char kHeliumDidOnboardi

--- a/patches/helium/core/add-updater-preference.patch
+++ b/patches/helium/core/add-updater-preference.patch
@@ -86,7 +86,7 @@ TODO: guard services_page.html with is_mac
    registrar.Add(prefs::kHeliumServicesEnabled, observer);
 --- a/chrome/browser/resources/settings/privacy_page/services_page.html
 +++ b/chrome/browser/resources/settings/privacy_page/services_page.html
-@@ -29,6 +29,13 @@
+@@ -61,6 +61,13 @@
                      sub-label="$i18n{heliumSpellcheckToggleDescription}">
                  </settings-toggle-button>
              </if>
@@ -99,10 +99,10 @@ TODO: guard services_page.html with is_mac
 +            </if>
          </cr-collapse>
      </div>
- </div>
+     </template>
 --- a/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
 +++ b/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
-@@ -1967,6 +1967,10 @@ void AddPrivacyStrings(content::WebUIDat
+@@ -1969,6 +1969,10 @@ void AddPrivacyStrings(content::WebUIDat
          IDS_SETTINGS_HELIUM_SERVICES_EXT_PROXY_TOGGLE},
        {"heliumExtProxyToggleDescription",
          IDS_SETTINGS_HELIUM_SERVICES_EXT_PROXY_TOGGLE_DESCRIPTION},
@@ -123,7 +123,7 @@ TODO: guard services_page.html with is_mac
 +      settings_api::PrefType::kBoolean;
    (*s_allowlist)[::prefs::kHeliumServicesOrigin] =
        settings_api::PrefType::kString;
- 
+   (*s_allowlist)[::prefs::kHeliumServicesConsented] =
 --- a/chrome/browser/ui/browser_ui_prefs.cc
 +++ b/chrome/browser/ui/browser_ui_prefs.cc
 @@ -215,6 +215,7 @@ void RegisterBrowserUserPrefs(user_prefs
@@ -136,7 +136,7 @@ TODO: guard services_page.html with is_mac
    registry->RegisterBooleanPref(
 --- a/chrome/app/settings_strings.grdp
 +++ b/chrome/app/settings_strings.grdp
-@@ -1943,6 +1943,12 @@
+@@ -1949,6 +1949,12 @@
    <message name="IDS_SETTINGS_HELIUM_SERVICES_SPELLCHECK_TOGGLE_DESCRIPTION" desc="Description of the for enabling/disabling of downloading spellcheck files">
      Helium will fetch dictionary files used for spell checking when requested. When disabled, spell checking will not work.
    </message>

--- a/patches/helium/core/keyboard-shortcuts.patch
+++ b/patches/helium/core/keyboard-shortcuts.patch
@@ -142,7 +142,7 @@
      "G",            IDC_FIND_NEXT,              VIRTKEY, CONTROL
 --- a/chrome/browser/extensions/api/settings_private/prefs_util.cc
 +++ b/chrome/browser/extensions/api/settings_private/prefs_util.cc
-@@ -579,6 +579,8 @@ const PrefsUtil::TypedPrefMap& PrefsUtil
+@@ -581,6 +581,8 @@ const PrefsUtil::TypedPrefMap& PrefsUtil
  
    (*s_allowlist)[::prefs::kCaretBrowsingEnabled] =
        settings_api::PrefType::kBoolean;

--- a/patches/helium/core/onboarding-page.patch
+++ b/patches/helium/core/onboarding-page.patch
@@ -531,3 +531,92 @@
           url.host_piece() != password_manager::kChromeUIPasswordManagerHost;
  }
  
+--- a/chrome/app/settings_strings.grdp
++++ b/chrome/app/settings_strings.grdp
+@@ -1909,6 +1909,12 @@
+   <message name="IDS_SETTINGS_HELIUM_SERVICES_DESCRIPTION" desc="Description of the controls available on the Helium services settings page">
+     Manage what Helium services are allowed in your browser
+   </message>
++  <message name="IDS_SETTINGS_HELIUM_SERVICES_SETUP_PENDING_TEXT" desc="Description shown in services settings when user has not completed onboarding">
++    Helium services are not available until setup is complete to ensure your privacy and consent.
++  </message>
++  <message name="IDS_SETTINGS_HELIUM_SERVICES_SETUP_PENDING_BUTTON" desc="Button label directing user to complete onboarding">
++    Complete setup
++  </message>
+   <message name="IDS_SETTINGS_HELIUM_SERVICES_TOGGLE" desc="Global toggle for enabling/disabling of all Helium services">
+     Allow connecting to Helium services
+   </message>
+--- a/chrome/browser/extensions/api/settings_private/prefs_util.cc
++++ b/chrome/browser/extensions/api/settings_private/prefs_util.cc
+@@ -356,6 +356,8 @@ const PrefsUtil::TypedPrefMap& PrefsUtil
+       settings_api::PrefType::kBoolean;
+   (*s_allowlist)[::prefs::kHeliumServicesOrigin] =
+       settings_api::PrefType::kString;
++  (*s_allowlist)[::prefs::kHeliumServicesConsented] =
++      settings_api::PrefType::kBoolean;
+ 
+   // Privacy Guide
+   (*s_allowlist)[::prefs::kPrivacyGuideViewed] =
+--- a/chrome/browser/resources/settings/privacy_page/services_page.html
++++ b/chrome/browser/resources/settings/privacy_page/services_page.html
+@@ -2,9 +2,41 @@
+     .label-wrapper {
+         padding: var(--cr-section-vertical-padding) 0;
+     }
++
++    #onboarding-link {
++        color: var(--text-color-action);
++        text-decoration: none;
++    }
++
++    #onboarding-text {
++        display: flex;
++        align-items: center;
++        max-width: 350px;
++        gap: calc(var(--cr-section-padding) * 0.8);
++    }
++
++    #onboarding-notice {
++        padding: calc(var(--cr-section-padding) / 2) var(--cr-section-padding);
++        justify-content: space-between;
++    }
+ </style>
+ 
+ <div class="cr-col first">
++    <template is="dom-if" if="[[!prefs.helium.services.user_consented.value]]">
++        <div class="cr-row" id="onboarding-notice">
++            <div id="onboarding-text">
++                  <cr-icon icon="cr:security" aria-hidden="true"></cr-icon>
++                  <span>$i18n{heliumServicesSetupPendingText}</span>
++            </div>
++            <cr-button class="action-button">
++                <a href="chrome://setup" target="_blank" id="onboarding-link">
++                    $i18n{heliumServicesSetupPendingButton}
++                </a>
++            </cr-button>
++        </div>
++    </template>
++
++    <template is="dom-if" if="[[prefs.helium.services.user_consented.value]]">
+     <settings-toggle-button id="servicesToggleButton"
+         pref="{{prefs.helium.services.enabled}}"
+         label="$i18n{heliumServicesToggle}"
+@@ -14,6 +46,7 @@
+         <cr-collapse id="servicesCollapse" opened="[[prefs.helium.services.enabled.value]]">
+         </cr-collapse>
+     </div>
++    </template>
+ </div>
+ 
+ 
+--- a/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
++++ b/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
+@@ -1955,6 +1955,8 @@ void AddPrivacyStrings(content::WebUIDat
+       {"securityPageDescription", IDS_SETTINGS_SECURITY_DESCRIPTION},
+       {"heliumServicesTitle", IDS_SETTINGS_HELIUM_SERVICES},
+       {"heliumServicesDescription", IDS_SETTINGS_HELIUM_SERVICES_DESCRIPTION},
++      {"heliumServicesSetupPendingText", IDS_SETTINGS_HELIUM_SERVICES_SETUP_PENDING_TEXT},
++      {"heliumServicesSetupPendingButton", IDS_SETTINGS_HELIUM_SERVICES_SETUP_PENDING_BUTTON},
+       {"heliumServicesToggle", IDS_SETTINGS_HELIUM_SERVICES_TOGGLE},
+       {"heliumServicesToggleDescription",
+         IDS_SETTINGS_HELIUM_SERVICES_TOGGLE_DESCRIPTION},

--- a/patches/helium/core/proxy-extension-downloads.patch
+++ b/patches/helium/core/proxy-extension-downloads.patch
@@ -174,7 +174,7 @@
 +      settings_api::PrefType::kBoolean;
    (*s_allowlist)[::prefs::kHeliumServicesOrigin] =
        settings_api::PrefType::kString;
- 
+   (*s_allowlist)[::prefs::kHeliumServicesConsented] =
 --- a/chrome/browser/ui/browser_ui_prefs.cc
 +++ b/chrome/browser/ui/browser_ui_prefs.cc
 @@ -204,6 +204,7 @@ void RegisterBrowserUserPrefs(user_prefs
@@ -187,7 +187,7 @@
      registry->RegisterBooleanPref(prefs::kHeliumServicesConsented, false);
 --- a/chrome/browser/resources/settings/privacy_page/services_page.html
 +++ b/chrome/browser/resources/settings/privacy_page/services_page.html
-@@ -12,6 +12,11 @@
+@@ -44,6 +44,11 @@
      </settings-toggle-button>
      <div class="cr-col">
          <cr-collapse id="servicesCollapse" opened="[[prefs.helium.services.enabled.value]]">
@@ -198,10 +198,10 @@
 +            </settings-toggle-button>
          </cr-collapse>
      </div>
- </div>
+     </template>
 --- a/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
 +++ b/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
-@@ -1957,6 +1957,10 @@ void AddPrivacyStrings(content::WebUIDat
+@@ -1959,6 +1959,10 @@ void AddPrivacyStrings(content::WebUIDat
        {"heliumServicesToggle", IDS_SETTINGS_HELIUM_SERVICES_TOGGLE},
        {"heliumServicesToggleDescription",
          IDS_SETTINGS_HELIUM_SERVICES_TOGGLE_DESCRIPTION},
@@ -214,7 +214,7 @@
          IDS_SETTINGS_HELIUM_SERVICES_OVERRIDE_DESCRIPTION},
 --- a/chrome/app/settings_strings.grdp
 +++ b/chrome/app/settings_strings.grdp
-@@ -1925,6 +1925,12 @@
+@@ -1931,6 +1931,12 @@
    <message name="IDS_SETTINGS_HELIUM_SERVICES_TOGGLE_DESCRIPTION" desc="Description of the toggle for enabling/disabling of all Helium services">
      When enabled, Helium will be able to connect to anonymous web services to provide additional functionality. When disabled, additional features will not work.
    </message>

--- a/patches/helium/core/reenable-spellcheck-downloads.patch
+++ b/patches/helium/core/reenable-spellcheck-downloads.patch
@@ -115,7 +115,7 @@
 +      settings_api::PrefType::kBoolean;
    (*s_allowlist)[::prefs::kHeliumServicesOrigin] =
        settings_api::PrefType::kString;
- 
+   (*s_allowlist)[::prefs::kHeliumServicesConsented] =
 --- a/chrome/browser/ui/browser_ui_prefs.cc
 +++ b/chrome/browser/ui/browser_ui_prefs.cc
 @@ -206,6 +206,7 @@ void RegisterBrowserUserPrefs(user_prefs
@@ -128,9 +128,9 @@
      registry->RegisterBooleanPref(prefs::kHeliumServicesConsented, false);
 --- a/chrome/browser/resources/settings/privacy_page/services_page.html
 +++ b/chrome/browser/resources/settings/privacy_page/services_page.html
-@@ -22,6 +22,13 @@
-                 label="$i18n{heliumExtProxyToggle}"
-                 sub-label="$i18n{heliumExtProxyToggleDescription}">
+@@ -54,6 +54,13 @@
+                 label="$i18n{heliumBangsToggle}"
+                 sub-label="$i18n{heliumBangsToggleDescription}">
              </settings-toggle-button>
 +            <if expr="use_renderer_spellchecker">
 +                <settings-toggle-button id="spellcheckToggleButton"
@@ -141,10 +141,10 @@
 +            </if>
          </cr-collapse>
      </div>
- </div>
+     </template>
 --- a/chrome/app/settings_strings.grdp
 +++ b/chrome/app/settings_strings.grdp
-@@ -1937,6 +1937,12 @@
+@@ -1943,6 +1943,12 @@
    <message name="IDS_SETTINGS_HELIUM_SERVICES_BANGS_TOGGLE_DESCRIPTION" desc="Description of the toggle for enabling/disabling of downloading bangs">
      Helium will fetch a list of bangs that help you browse the Internet faster, such as !w or !gh. When disabled, bangs will not work.
    </message>
@@ -159,7 +159,7 @@
    </message>
 --- a/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
 +++ b/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
-@@ -1960,6 +1960,9 @@ void AddPrivacyStrings(content::WebUIDat
+@@ -1962,6 +1962,9 @@ void AddPrivacyStrings(content::WebUIDat
        {"heliumBangsToggle", IDS_SETTINGS_HELIUM_SERVICES_BANGS_TOGGLE},
        {"heliumBangsToggleDescription",
          IDS_SETTINGS_HELIUM_SERVICES_BANGS_TOGGLE_DESCRIPTION},

--- a/patches/helium/core/search/force-eu-search-features.patch
+++ b/patches/helium/core/search/force-eu-search-features.patch
@@ -16,7 +16,7 @@
  #include "components/safe_browsing/core/common/features.h"
  #include "components/safe_browsing/core/common/hashprefix_realtime/hash_realtime_utils.h"
  #include "components/saved_tab_groups/public/features.h"
-@@ -2477,14 +2475,9 @@ void AddSearchStrings(content::WebUIData
+@@ -2479,14 +2477,9 @@ void AddSearchStrings(content::WebUIData
    html_source->AddString("searchExplanationLearnMoreURL",
                           chrome::kOmniboxLearnMoreURL);
  

--- a/patches/helium/core/services-prefs.patch
+++ b/patches/helium/core/services-prefs.patch
@@ -177,7 +177,7 @@
 +</div>
 --- /dev/null
 +++ b/chrome/browser/resources/settings/privacy_page/services_page.ts
-@@ -0,0 +1,74 @@
+@@ -0,0 +1,67 @@
 +// Copyright 2025 The Helium Authors
 +// You can use, redistribute, and/or modify this source code under
 +// the terms of the GPL-3.0 license that can be found in the LICENSE file.
@@ -204,15 +204,8 @@
 +  }
 +
 +  static get properties() {
-+    return {
-+      prefs: {
-+        type: Object,
-+        notify: true,
-+      },
-+    };
++    return {};
 +  }
-+
-+  declare prefs: {[key: string]: any} | undefined;
 +
 +  private toOrigin(thing: string) {
 +    try {

--- a/patches/helium/core/ublock-helium-services.patch
+++ b/patches/helium/core/ublock-helium-services.patch
@@ -65,7 +65,7 @@
 +      settings_api::PrefType::kBoolean;
    (*s_allowlist)[::prefs::kHeliumServicesOrigin] =
        settings_api::PrefType::kString;
- 
+   (*s_allowlist)[::prefs::kHeliumServicesConsented] =
 --- a/chrome/browser/ui/browser_ui_prefs.cc
 +++ b/chrome/browser/ui/browser_ui_prefs.cc
 @@ -216,6 +216,7 @@ void RegisterBrowserUserPrefs(user_prefs
@@ -217,7 +217,7 @@
                  if ( bin.assetSourceRegistry instanceof Object ) {
 --- a/chrome/app/settings_strings.grdp
 +++ b/chrome/app/settings_strings.grdp
-@@ -1949,6 +1949,12 @@
+@@ -1955,6 +1955,12 @@
    <message name="IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION" desc="Description of the toggle for automatic update downloads">
      Helium will automatically download and install browser updates as they become available. We recommend keeping this setting enabled to ensure you get the latest security patches and features.
    </message>
@@ -232,7 +232,7 @@
    </message>
 --- a/chrome/browser/resources/settings/privacy_page/services_page.html
 +++ b/chrome/browser/resources/settings/privacy_page/services_page.html
-@@ -36,6 +36,11 @@
+@@ -68,6 +68,11 @@
                      sub-label="$i18n{heliumUpdatesToggleDescription}">
                  </settings-toggle-button>
              </if>
@@ -243,10 +243,10 @@
 +            </settings-toggle-button>
          </cr-collapse>
      </div>
- </div>
+     </template>
 --- a/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
 +++ b/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
-@@ -1971,6 +1971,10 @@ void AddPrivacyStrings(content::WebUIDat
+@@ -1973,6 +1973,10 @@ void AddPrivacyStrings(content::WebUIDat
          IDS_SETTINGS_HELIUM_SERVICES_UPDATE},
        {"heliumUpdatesToggleDescription",
          IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION},

--- a/patches/helium/settings/fix-text-on-cookies-page.patch
+++ b/patches/helium/settings/fix-text-on-cookies-page.patch
@@ -10,7 +10,7 @@
    <message name="IDS_SETTINGS_ENABLE_DO_NOT_TRACK_DIALOG_LEARN_MORE_ACCESSIBILITY_LABEL" desc="The accessibility label for a link to learn more about Do Not Track">
      Learn more about Do Not Track
    </message>
-@@ -3101,6 +3104,9 @@
+@@ -3107,6 +3110,9 @@
    <message name="IDS_SETTINGS_TRACKING_PROTECTION_SITES_ALLOWED_COOKIES_DESCRIPTION" desc="Description of the section on the Tracking Protection settings page that lets users manage which sites are allowed to use third-party cookies. Explains how to use a wildcard to create an exception for an entire domain.">
      Affects the sites listed here. Inserting “[*.]” before a domain name creates an exception for the entire domain. For example, adding “[*.]google.com” means that third-party cookies can also be active for mail.google.com, because it’s part of google.com.
    </message>
@@ -31,7 +31,7 @@
        {"doNotTrackDialogLearnMoreA11yLabel",
         IDS_SETTINGS_ENABLE_DO_NOT_TRACK_DIALOG_LEARN_MORE_ACCESSIBILITY_LABEL},
        // TODO(crbug.com/40122957): This string is no longer used. Remove.
-@@ -2640,7 +2640,7 @@ void AddSiteSettingsStrings(content::Web
+@@ -2642,7 +2642,7 @@ void AddSiteSettingsStrings(content::Web
        {"trackingProtectionSitesAllowedCookiesTitle",
         IDS_SETTINGS_TRACKING_PROTECTION_SITES_ALLOWED_COOKIES_TITLE},
        {"trackingProtectionSitesAllowedCookiesDescription",

--- a/patches/helium/settings/privacy-page-tweaks.patch
+++ b/patches/helium/settings/privacy-page-tweaks.patch
@@ -26,7 +26,7 @@
 +      {"securityPageDescription", IDS_SETTINGS_SECURITY_DESCRIPTION_NORMAL},
        {"heliumServicesTitle", IDS_SETTINGS_HELIUM_SERVICES},
        {"heliumServicesDescription", IDS_SETTINGS_HELIUM_SERVICES_DESCRIPTION},
-       {"heliumServicesToggle", IDS_SETTINGS_HELIUM_SERVICES_TOGGLE},
+       {"heliumServicesSetupPendingText", IDS_SETTINGS_HELIUM_SERVICES_SETUP_PENDING_TEXT},
 --- a/chrome/browser/resources/settings/privacy_page/privacy_page.html
 +++ b/chrome/browser/resources/settings/privacy_page/privacy_page.html
 @@ -39,6 +39,7 @@


### PR DESCRIPTION
<img width="986" height="444" alt="image" src="https://github.com/user-attachments/assets/8d512294-23af-47d3-aee8-7dae19100c96" />

also drop duplicate "prefs" property that already exists as part of PrefsMixin

fixes #343
