### PR TITLE
helium: fix crash when creating a split in tab group with a detached tab

### DIFF
--- a/patches/helium/upstream-fixes/fix-tab-group-split-insertion.patch
+++ b/patches/helium/upstream-fixes/fix-tab-group-split-insertion.patch
@@ -1,0 +1,17 @@
+--- a/chrome/browser/ui/views/frame/multi_contents_view_delegate.cc
++++ b/chrome/browser/ui/views/frame/multi_contents_view_delegate.cc
+@@ -126,9 +126,12 @@ void MultiContentsViewDelegateImpl::Hand
+   const int new_tab_idx =
+       tab_strip_model_->active_index() +
+       (side == MultiContentsDropTargetView::DropSide::START ? 0 : 1);
++
++  tabs::TabInterface* active_tab = tab_strip_model_->GetActiveTab();
+   const int inserted_tab_idx = tab_strip_model_->InsertDetachedTabAt(
+-      new_tab_idx, std::move(detached_tab), AddTabTypes::ADD_NONE,
+-      std::nullopt);
++      new_tab_idx, std::move(detached_tab),
++      active_tab->IsPinned() ? AddTabTypes::ADD_PINNED : AddTabTypes::ADD_NONE,
++      active_tab->GetGroup());
+   tab_strip_model_->AddToNewSplit(
+       {inserted_tab_idx}, split_data,
+       split_tabs::SplitTabCreatedSource::kDragAndDropTab);

--- a/patches/series
+++ b/patches/series
@@ -108,6 +108,8 @@ extra/brave/chrome-importer-files.patch
 extra/brave/custom-importer.patch
 extra/brave/fix-component-content-settings-store.patch
 
+helium/upstream-fixes/fix-tab-group-split-insertion.patch
+
 helium/core/add-zen-importer.patch
 helium/core/disable-unsupported-importers.patch
 helium/core/fix-building-without-safebrowsing.patch


### PR DESCRIPTION
taken from upstream:
[7032449](https://chromium-review.googlesource.com/c/chromium/src/+/7032449)

fixes #345