### PR TITLE
helium/core/autoscroll: enable by default only on windows

### DIFF
--- a/patches/helium/core/add-middle-click-autoscroll-flag.patch
+++ b/patches/helium/core/add-middle-click-autoscroll-flag.patch
@@ -37,7 +37,7 @@
  
 +BASE_FEATURE(kHeliumMiddleClickAutoscroll,
 +             "HeliumMiddleClickAutoscroll",
-+#if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_LINUX)
++#if BUILDFLAG(IS_WIN)
 +             base::FEATURE_ENABLED_BY_DEFAULT
 +#else
 +             base::FEATURE_DISABLED_BY_DEFAULT


### PR DESCRIPTION
closes imputnet/helium#369 