### PR TITLE
helium/core/fingerprinting-audio: disable jitter by default

### DIFF
--- a/patches/helium/core/mitigate-fingerprinting-audio-context.patch
+++ b/patches/helium/core/mitigate-fingerprinting-audio-context.patch
@@ -30,7 +30,7 @@ https://github.com/uazo/cromite/blob/b2824377/build/patches/AudioBuffer-Analyser
  
 +BASE_FEATURE(kAudioContextJitter,
 +             "AudioContextJitter",
-+             base::FEATURE_ENABLED_BY_DEFAULT);
++             base::FEATURE_DISABLED_BY_DEFAULT);
 +
  BASE_FEATURE(kDisableLinkDrag, "DisableLinkDrag", base::FEATURE_DISABLED_BY_DEFAULT);
  BASE_FEATURE(kReducedSystemInfo, "ReducedSystemInfo", base::FEATURE_DISABLED_BY_DEFAULT);


### PR DESCRIPTION
we should polish this feature a bit more before enabling it by default again, so that it no longer causes usability issues

closes #249