### PR TITLE
ungoogled/existing-switches: fix order of webrtc policy pref

### DIFF
--- a/patches/extra/ungoogled-chromium/add-flags-for-existing-switches.patch
+++ b/patches/extra/ungoogled-chromium/add-flags-for-existing-switches.patch
@@ -23,16 +23,16 @@
 +#ifndef CHROME_BROWSER_EXISTING_SWITCH_FLAG_CHOICES_H_
 +#define CHROME_BROWSER_EXISTING_SWITCH_FLAG_CHOICES_H_
 +const FeatureEntry::Choice kWebRTCIPPolicy[] = {
-+    {"Disable non proxied udp", "", ""},
++    {"Default public interface only",
++     "webrtc-ip-handling-policy",
++     "default_public_interface_only"},
 +    {"Default",
 +     "webrtc-ip-handling-policy",
 +     "default"},
 +    {"Default public and private interfaces",
 +     "webrtc-ip-handling-policy",
 +     "default_public_and_private_interfaces"},
-+    {"Default public interface only",
-+     "webrtc-ip-handling-policy",
-+     "default_public_interface_only"},
++    {"Disable non proxied udp", "", ""},
 +};
 +#endif  // CHROME_BROWSER_EXISTING_SWITCH_FLAG_CHOICES_H_
 --- /dev/null


### PR DESCRIPTION
fixes the misleading default option on flags page

before:
<img width="728" height="102" alt="image" src="https://github.com/user-attachments/assets/604735ac-5b91-4dd8-8ce3-d0cbe315032c" />


after:
<img width="717" height="98" alt="image" src="https://github.com/user-attachments/assets/90e631d0-daf2-4615-83e8-327ed6ee4ead" />
