### PR TITLE
helium/core: fix chrome.instanceID.getID() hanging

### DIFF
--- a/patches/helium/core/fix-instance-id-stuck.patch
+++ b/patches/helium/core/fix-instance-id-stuck.patch
@@ -1,0 +1,12 @@
+--- a/components/gcm_driver/instance_id/instance_id_impl.cc
++++ b/components/gcm_driver/instance_id/instance_id_impl.cc
+@@ -263,9 +263,6 @@ gcm::InstanceIDHandler* InstanceIDImpl::
+ }
+ 
+ void InstanceIDImpl::RunWhenReady(base::OnceClosure task) {
+-  if (!delayed_task_controller_.CanRunTaskWithoutDelay())
+-    delayed_task_controller_.AddTask(std::move(task));
+-  else
+     base::SingleThreadTaskRunner::GetCurrentDefault()->PostTask(
+         FROM_HERE, std::move(task));
+ }

--- a/patches/series
+++ b/patches/series
@@ -149,6 +149,7 @@ helium/core/enable-tab-search-toolbar-button.patch
 helium/core/clean-context-menu.patch
 helium/core/split-view.patch
 helium/core/fix-tab-sync-unreached-error.patch
+helium/core/fix-instance-id-stuck.patch
 
 helium/core/flags-setup.patch
 helium/core/add-low-power-framerate-flag.patch


### PR DESCRIPTION
fixes #434
