### PR TITLE
helium/cat: prevent common actions from going into overflow menu

### DIFF
--- a/patches/helium/ui/experiments/compact-action-toolbar.patch
+++ b/patches/helium/ui/experiments/compact-action-toolbar.patch
@@ -172,11 +172,10 @@
    show_avatar_button_.Init(
        prefs::kShowAvatarButton, prefs,
        base::BindRepeating(&ToolbarView::OnShowAvatarButtonChanged,
-@@ -564,10 +587,16 @@ void ToolbarView::Init() {
+@@ -564,10 +587,15 @@ void ToolbarView::Init() {
  
    InitLayout();
  
-+
 +  auto flex_preferred = views::FlexSpecification(
 +                          views::MinimumFlexSizeRule::kPreferred,
 +                          views::MaximumFlexSizeRule::kPreferred);
@@ -189,7 +188,7 @@
      }
    }
    if (browser_view_->GetSupportsTabStrip()) {
-@@ -700,6 +729,24 @@ bool ToolbarView::IsRectInWindowCaption(
+@@ -700,6 +728,24 @@ bool ToolbarView::IsRectInWindowCaption(
      return gfx::ToEnclosingRect(rect_in_target_coords_f);
    };
  
@@ -214,7 +213,7 @@
    // Check each child view in container_view_ to see if the rect intersects with
    // any clickable elements. If it does, check if the click is actually on that
    // element. False if on a clickable element, true if not on a clickable element.
-@@ -998,6 +1045,12 @@ void ToolbarView::InitLayout() {
+@@ -998,6 +1044,12 @@ void ToolbarView::InitLayout() {
    location_bar_->SetProperty(views::kMarginsKey,
                               gfx::Insets::VH(0, location_bar_margin));
  


### PR DESCRIPTION
fixes #438
fixes #440, but introduces a problem of icons getting cut off when the window is really small which needs to be fixed before merge:

<img width="446" height="411" alt="Screenshot 2025-11-14 at 23 26 24" src="https://github.com/user-attachments/assets/d64c4b74-c573-4d40-8e4b-914a6acd2ade" />
