### PR TITLE
patches/split-view: fix crash when opening link from pdf

### DIFF
--- a/patches/helium/core/split-view.patch
+++ b/patches/helium/core/split-view.patch
@@ -639,3 +639,16 @@
      tabs_to_reload.push_back(active_contents);
    } else {
      // Reloading a tab may change the selection (see crbug.com/339061099), so
+--- a/chrome/browser/renderer_context_menu/render_view_context_menu.cc
++++ b/chrome/browser/renderer_context_menu/render_view_context_menu.cc
+@@ -4944,8 +4944,8 @@ void RenderViewContextMenu::OpenLinkInSp
+ 
+   TabStripModel* const tab_strip_model = browser->tab_strip_model();
+   tabs::TabInterface* const source_tab =
+-      tabs::TabInterface::GetFromContents(source_web_contents_);
+-  if (source_tab->IsSplit()) {
++      tabs::TabInterface::MaybeGetFromContents(source_web_contents_);
++  if (source_tab && source_tab->IsSplit()) {
+     // Navigate the inactive tab to the URL
+     const split_tabs::SplitTabId split_id = source_tab->GetSplit().value();
+     for (tabs::TabInterface* tab :


### PR DESCRIPTION
essentially a backport of chromium/chromium@c992846254615af3e859705b9f36500d518e4b02

fixes #465
