### PR TITLE
helium/cat: fix DCHECK & layout breakage when entering fullscreen

### DIFF
--- a/patches/helium/ui/experiments/compact-action-toolbar.patch
+++ b/patches/helium/ui/experiments/compact-action-toolbar.patch
@@ -90,10 +90,10 @@
      if (features::HasTabSearchToolbarButton()) {
 --- a/chrome/browser/ui/views/frame/browser_view_layout.cc
 +++ b/chrome/browser/ui/views/frame/browser_view_layout.cc
-@@ -540,6 +540,13 @@ void BrowserViewLayout::LayoutTabStripRe
-     tab_strip_region_view_->SetBounds(0, 0, 0, 0);
-     return;
-   }
+@@ -535,11 +535,19 @@ void BrowserViewLayout::LayoutVerticalTa
+ 
+ void BrowserViewLayout::LayoutTabStripRegion(gfx::Rect& available_bounds) {
+   TRACE_EVENT0("ui", "BrowserViewLayout::LayoutTabStripRegion");
 +
 +  // If the CAT feature is enabled, then the tab strip is in the toolbar.
 +  // We shouldn't layout it here.
@@ -101,10 +101,16 @@
 +    return;
 +  }
 +
+   if (!delegate_->ShouldDrawTabStrip()) {
+     SetViewVisibility(tab_strip_region_view_, false);
+     tab_strip_region_view_->SetBounds(0, 0, 0, 0);
+     return;
+   }
++
    // This retrieves the bounds for the tab strip based on whether or not we show
    // anything to the left of it, like the incognito avatar.
    gfx::Rect tab_strip_region_bounds(
-@@ -587,6 +594,15 @@ void BrowserViewLayout::LayoutToolbar(gf
+@@ -587,6 +595,15 @@ void BrowserViewLayout::LayoutToolbar(gf
      toolbar_bounds.set_width(toolbar_bounds.width() -
                               BrowserView::kVerticalTabStripWidth);
      toolbar_->SetBoundsRect(toolbar_bounds);


### PR DESCRIPTION
fixes #446

Moved the CAT feature gate in `LayoutTabStripRegion()` earlier to prevent DCHECK and layout breakage when calling `SetViewVisibility()` on `tab_strip_region_view_`.

When CAT is enabled, tab_strip_region_view is no longer managed by `BrowserViewLayout`, so trying to set view visibility on a view with a different parent will seemingly not work.

Tested on macOS (ignore the lag, this is a dev component build streamed over macos screen sharing):

https://github.com/user-attachments/assets/8f55ef71-861a-44fa-b4f0-0b2b88ad8a9c

<details>

<summary>Relevant DCHECK trace</summary>

```
[34665:15063646:1117/063003.282661:FATAL:ui/views/layout/layout_manager.cc:61] DCHECK failed: !view->parent() || view->parent()->GetLayoutManager() == this || view->parent()->GetLayoutManager() == nullptr. 
0   libbase.dylib                       0x00000001052e6b3c base::debug::CollectStackTrace(base::span<void const*, 18446744073709551615ul, void const**>) + 28
1   libbase.dylib                       0x00000001052cd754 base::debug::StackTrace::StackTrace(unsigned long) + 224
2   libbase.dylib                       0x00000001051c700c logging::LogMessage::Flush() + 152
3   libbase.dylib                       0x00000001051c6eec logging::LogMessage::~LogMessage() + 36
4   libbase.dylib                       0x00000001051aab14 logging::(anonymous namespace)::DCheckLogMessage::~DCheckLogMessage() + 76
5   libbase.dylib                       0x00000001051aa34c logging::CheckError::~CheckError() + 44
6   libbase.dylib                       0x00000001051aa3ac logging::CheckError::~CheckError() + 12
7   libui_views.dylib                   0x000000011b259b38 views::LayoutManager::SetViewVisibility(views::View*, bool) + 112
8   libchrome_dll.dylib                 0x000000010f226380 BrowserViewLayout::LayoutTabStripRegion(gfx::Rect&) + 212
9   libchrome_dll.dylib                 0x000000010f225d8c BrowserViewLayout::Layout(views::View*) + 332
10  libui_views.dylib                   0x000000011b26dfa4 views::View::Layout(base::NonCopyablePassKey<views::View>) + 100
11  libchrome_dll.dylib                 0x000000010f22171c BrowserView::Layout(base::NonCopyablePassKey<views::View>) + 168
12  libui_views.dylib                   0x000000011b26b2d8 views::View::LayoutImmediately() + 156
13  libchrome_dll.dylib                 0x000000010f218654 BrowserView::UpdateUIForContents(content::WebContents*) + 100
14  libchrome_dll.dylib                 0x000000010f21a264 BrowserView::ToolbarSizeChanged(bool) + 124
15  libchrome_dll.dylib                 0x000000010f219584 BrowserView::ProcessFullscreen(bool, long long) + 116
16  libcomponents_remote_cocoa_app_shim 0x000000011c37b66c non-virtual thunk to remote_cocoa::NativeWidgetNSWindowBridge::FullscreenControllerTransitionStart(bool) + 36
17  libcomponents_remote_cocoa_app_shim 0x000000011c37f194 remote_cocoa::NativeWidgetNSWindowFullscreenController::OnWindowWillEnterFullscreen() + 120
18  CoreFoundation                      0x000000018a39b484 __CFNOTIFICATIONCENTER_IS_CALLING_OUT_TO_AN_OBSERVER__ + 148
19  CoreFoundation                      0x000000018a3fff34 ___CFXRegistrationPost_block_invoke + 92
20  CoreFoundation                      0x000000018a3ffe78 _CFXRegistrationPost + 436
21  CoreFoundation                      0x000000018a379f9c _CFXNotificationPost + 740
22  Foundation                          0x000000018c59b308 -[NSNotificationCenter postNotificationName:object:userInfo:] + 88
23  AppKit                              0x000000018f846594 -[NSWindow(NSFullScreen) _willEnterFullScreen] + 76
24  AppKit                              0x000000018f5bc254 __76-[_NSEnterFullScreenTransitionController setupWindowForAfterFullScreenEnter]_block_invoke + 192
25  AppKit                              0x000000018e7cf9f8 NSPerformVisuallyAtomicChange + 108
26  AppKit                              0x000000018f5bc188 -[_NSEnterFullScreenTransitionController setupWindowForAfterFullScreenEnter] + 96
27  AppKit                              0x000000018f5bf76c __47-[_NSEnterFullScreenTransitionController start]_block_invoke + 28
28  AppKit                              0x000000018f4b6774 -[NSWindow(NSWindow_Theme) _performHoldingResizeSnapshots:completionHandler:] + 132
29  AppKit                              0x000000018f5bf67c -[_NSEnterFullScreenTransitionController start] + 1008
30  AppKit                              0x000000018f7d3a08 -[_NSFullScreenSpace(Transitions) startTransition:] + 92
31  AppKit                              0x000000018f27e104 -[NSApplication(NSResponder) sendAction:to:from:] + 560
32  libchrome_dll.dylib                 0x000000010dbcc608 __43-[BrowserCrApplication sendAction:to:from:]_block_invoke + 60
33  libbase.dylib                       0x00000001052f0cf8 base::apple::CallWithEHFrame(void () block_pointer) + 16
34  libchrome_dll.dylib                 0x000000010dbcc4f8 -[BrowserCrApplication sendAction:to:from:] + 772
35  AppKit                              0x000000018efa10f0 -[NSControl sendAction:to:] + 72
36  AppKit                              0x000000018ef8a1a8 __26-[NSCell _sendActionFrom:]_block_invoke + 100
37  AppKit                              0x000000018ef8a0d0 -[NSCell _sendActionFrom:] + 204
38  AppKit                              0x000000018ef7f00c -[NSButtonCell _sendActionFrom:] + 96
39  AppKit                              0x000000018f55e67c -[_NSThemeZoomWidgetCell _sendActionFrom:] + 100
40  AppKit                              0x000000018e8728d4 NSControlTrackMouse + 1492
41  AppKit                              0x000000018ef8ae8c -[NSCell trackMouse:inRect:ofView:untilMouseUp:] + 144
42  AppKit                              0x000000018ef7d310 -[NSButtonCell trackMouse:inRect:ofView:untilMouseUp:] + 232
43  AppKit                              0x000000018f55e1cc -[_NSThemeZoomWidgetCell trackMouse:inRect:ofView:untilMouseUp:] + 588
44  AppKit                              0x000000018efaae00 -[NSControl(_NSTracking) _mouseDown:] + 612
45  AppKit                              0x000000018efaab70 -[NSControl(_NSTracking) mouseDown:] + 104
46  AppKit                              0x000000018f545554 -[NSWindow(NSEventRouting) _handleMouseDownEvent:isDelayedEvent:] + 3676
47  AppKit                              0x000000018f5423cc -[NSWindow(NSEventRouting) _reallySendEvent:isDelayedEvent:] + 492
48  AppKit                              0x000000018f541e5c -[NSWindow(NSEventRouting) sendEvent:] + 372
49  libcomponents_remote_cocoa_app_shim 0x000000011c36f85c -[NativeWidgetMacNSWindow sendEvent:] + 604
50  AppKit                              0x000000018f27aa98 -[NSApplication(NSEventRouting) sendEvent:] + 1276
51  libchrome_dll.dylib                 0x000000010dbcce70 __34-[BrowserCrApplication sendEvent:]_block_invoke + 332
52  libbase.dylib                       0x00000001052f0cf8 base::apple::CallWithEHFrame(void () block_pointer) + 16
53  libchrome_dll.dylib                 0x000000010dbccb4c -[BrowserCrApplication sendEvent:] + 1288
54  AppKit                              0x000000018ed0ff4c -[NSApplication _handleEvent:] + 60
55  AppKit                              0x000000018e7a67a8 -[NSApplication run] + 408
56  libbase.dylib                       0x00000001052f9c20 base::MessagePumpNSApplication::DoRun(base::MessagePump::Delegate*) + 400
57  libbase.dylib                       0x00000001052f7f7c base::MessagePumpCFRunLoopBase::Run(base::MessagePump::Delegate*) + 140
58  libbase.dylib                       0x0000000105277c68 base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run(bool, base::TimeDelta) + 728
59  libbase.dylib                       0x0000000105219188 base::RunLoop::Run(base::Location const&) + 404
60  libcontent.dylib                    0x0000000117bc3908 content::BrowserMainLoop::RunMainMessageLoop() + 232
61  libcontent.dylib                    0x0000000117bc5510 content::BrowserMainRunnerImpl::Run() + 144
62  libcontent.dylib                    0x0000000117bc105c content::BrowserMain(content::MainFunctionParams) + 132
63  libcontent.dylib                    0x00000001189b8dd4 content::RunBrowserProcessMain(content::MainFunctionParams, content::ContentMainDelegate*) + 188
64  libcontent.dylib                    0x00000001189ba3c0 content::ContentMainRunnerImpl::RunBrowser(content::MainFunctionParams, bool) + 1092
65  libcontent.dylib                    0x00000001189b9f20 content::ContentMainRunnerImpl::Run() + 712
66  libcontent.dylib                    0x00000001189b83fc content::RunContentProcess(content::ContentMainParams, content::ContentMainRunner*) + 1184
67  libcontent.dylib                    0x00000001189b8510 content::ContentMain(content::ContentMainParams) + 112
68  libchrome_dll.dylib                 0x000000010c4d7160 ChromeMain + 964
69  Helium                              0x0000000104370670 main + 288
70  dyld                                0x0000000189f3dd54 start + 7184
```

</details>