### PR TITLE
upstream-fixes/macos-rect: fix on old macos too

### DIFF
--- a/patches/upstream-fixes/fix-macos-widget-rect.patch
+++ b/patches/upstream-fixes/fix-macos-widget-rect.patch
@@ -1,47 +1,24 @@
-From 45af583888facfc9bf95ca1cbd6d6169bf5ac3e5 Mon Sep 17 00:00:00 2001
-From: Keren Zhu <kerenzhu@chromium.org>
-Date: Tue, 11 Nov 2025 21:11:07 -0800
-Subject: [PATCH] mac26: fix misplaced omnibox popup due to rect constrains
-
-MacOS 26 adds new restrictions to child NSWindow positioning:
-
-* in fullscreen, prevents child windows to enter the titlebar area
-  and menubar area.
-* in non-fullscreen, prevents child windows from overlapping the
-  window border.
-
-This becomes a problem for the Omnibox popup, which due to its shadow
-area will enter the restricting area in both cases. This CL fixes that
-by overriding -constrainFrameRect: to remove the restriction. This fix
-was previously applied to only the overlay widget used in fullscreen.
-
-Fixed: 459509266
-Change-Id: Ie0a6fa2c099858754b33291a6c3c06919c137a5e
-Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7142646
-Commit-Queue: Keren Zhu <kerenzhu@chromium.org>
-Reviewed-by: Avi Drissman <avi@chromium.org>
-Cr-Commit-Position: refs/heads/main@{#1543516}
----
-
 --- a/components/remote_cocoa/app_shim/native_widget_mac_nswindow.mm
 +++ b/components/remote_cocoa/app_shim/native_widget_mac_nswindow.mm
-@@ -357,6 +357,16 @@ struct NSEdgeAndCornerThicknesses {
-     return frameRect;
-   }
- 
-+  if (base::mac::MacOSVersion() >= 26'00'00) {
-+    // Since macOS 26.0, when the main window enters full screen, the
-+    // overlay child window’s position is automatically adjusted by the system
-+    // to just below the menu bar location (even though the menu bar is hidden
-+    // at that time). During this process, [NSWindow constrainFrameRect] is
-+    // called and returns the system-adjusted position. Override this
-+    // function to return the original value frameRect before the adjustment.
-+    return frameRect;
-+  }
-+
-   return [super constrainFrameRect:frameRect toScreen:screen];
+@@ -352,12 +352,12 @@ struct NSEdgeAndCornerThicknesses {
  }
  
+ - (NSRect)constrainFrameRect:(NSRect)frameRect toScreen:(NSScreen*)screen {
+-  // Headless windows should not be constrained within the physical screen.
+-  if (_isHeadless) {
+-    return frameRect;
+-  }
+-
+-  return [super constrainFrameRect:frameRect toScreen:screen];
++  // AppKit's default implementation moves child windows down to avoid
++  // the menu bar. We don't want that behavior, because widgets like the
++  // Omnibox may have a big shadow that could cause invisible menu bar collision
++  // in fullscreen/maximized state. We override it here to return the original
++  // frameRect before the adjustment.
++  return frameRect;
+ }
+ 
+ // Private methods.
 --- a/components/remote_cocoa/app_shim/native_widget_mac_overlay_nswindow.mm
 +++ b/components/remote_cocoa/app_shim/native_widget_mac_overlay_nswindow.mm
 @@ -6,8 +6,6 @@


### PR DESCRIPTION
fixes #437

cuz older macos pushes child windows away from the menu bar too, just not as aggressively