### PR TITLE
helium/cat: prevent pinned collapse, fixed address bar width flag

### DIFF
--- a/patches/helium/ui/experiments/compact-action-toolbar.patch
+++ b/patches/helium/ui/experiments/compact-action-toolbar.patch
@@ -1,27 +1,33 @@
 --- a/chrome/browser/helium_flag_choices.h
 +++ b/chrome/browser/helium_flag_choices.h
-@@ -30,6 +30,7 @@ namespace helium {
+@@ -30,6 +30,9 @@ namespace helium {
    constexpr const char kCanvasNoiseCommandLine[] = "fingerprinting-canvas-noise";
    constexpr const char kAudioContextJitterCommandLine[] = "fingerprinting-audio-context-jitter";
    constexpr const char kMiddleClickAutoscrollCommandLine[] = "middle-click-autoscroll";
 +  constexpr const char kHeliumCatUiCommandLine[] = "helium-cat-ui";
++  constexpr const char kHeliumCatFixedAddressBarCommandLine[] =
++      "helium-cat-fixed-address-bar";
  
  }  // namespace helium
  
 --- a/chrome/browser/helium_flag_entries.h
 +++ b/chrome/browser/helium_flag_entries.h
-@@ -28,4 +28,8 @@
+@@ -28,4 +28,12 @@
       "Middle Click Autoscroll",
       "Enables autoscroll on middle click. Helium flag, Chromium feature.",
       kOsDesktop, FEATURE_VALUE_TYPE(blink::features::kHeliumMiddleClickAutoscroll)},
 +    {helium::kHeliumCatUiCommandLine,
-+     "Helium Compact Action Toolbar UI",
++     "[CAT] Helium Compact Action Toolbar UI",
 +     "Enables the new experimental UI that merges the tab strip and toolbar into one UI component to save vertical screen estate. Early and buggy, stuff will break and/or look weird. Helium flag.",
 +     kOsDesktop, FEATURE_VALUE_TYPE(features::kHeliumCatUi)},
++    {helium::kHeliumCatFixedAddressBarCommandLine,
++     "[CAT] Fixed address bar width",
++     "Prevents the address bar from shrinking in the CAT layout. Will push toolbar actions outside of bounds on small window sizes, beware. Works only when the main CAT flag is enabled. Early and buggy, stuff will break and/or look weird. Helium flag.",
++     kOsDesktop, FEATURE_VALUE_TYPE(features::kHeliumCatFixedAddressBar)},
  #endif  /* CHROME_BROWSER_HELIUM_FLAG_ENTRIES_H_ */
 --- a/chrome/browser/ui/ui_features.cc
 +++ b/chrome/browser/ui/ui_features.cc
-@@ -17,6 +17,14 @@
+@@ -17,6 +17,22 @@
  
  namespace features {
  
@@ -29,8 +35,16 @@
 +BASE_FEATURE(kHeliumCatUi,
 +             base::FEATURE_DISABLED_BY_DEFAULT);
 +
++BASE_FEATURE(kHeliumCatFixedAddressBar,
++             base::FEATURE_DISABLED_BY_DEFAULT);
++
 +bool IsHeliumCatEnabled() {
 +  return base::FeatureList::IsEnabled(kHeliumCatUi);
++}
++
++bool IsHeliumCatFixedAddressBar() {
++  return IsHeliumCatEnabled() && base::FeatureList::IsEnabled(
++      kHeliumCatFixedAddressBar);
 +}
 +
  // Enables the tab dragging fallback when full window dragging is not supported
@@ -38,12 +52,14 @@
  BASE_FEATURE(kAllowWindowDragUsingSystemDragDrop,
 --- a/chrome/browser/ui/ui_features.h
 +++ b/chrome/browser/ui/ui_features.h
-@@ -20,6 +20,9 @@ namespace features {
+@@ -20,6 +20,11 @@ namespace features {
  // All features in alphabetical order. The features should be documented
  // alongside the definition of their values in the .cc file.
  
 +BASE_DECLARE_FEATURE(kHeliumCatUi);
++BASE_DECLARE_FEATURE(kHeliumCatFixedAddressBar);
 +bool IsHeliumCatEnabled();
++bool IsHeliumCatFixedAddressBar();
 +
  // TODO(crbug.com/40598679): Remove this when the tab dragging
  // interactive_ui_tests pass on Wayland.
@@ -172,7 +188,7 @@
    show_avatar_button_.Init(
        prefs::kShowAvatarButton, prefs,
        base::BindRepeating(&ToolbarView::OnShowAvatarButtonChanged,
-@@ -564,10 +587,15 @@ void ToolbarView::Init() {
+@@ -564,12 +587,24 @@ void ToolbarView::Init() {
  
    InitLayout();
  
@@ -187,8 +203,17 @@
 +      button->SetProperty(views::kFlexBehaviorKey, flex_preferred);
      }
    }
++
++  // Pinned actions (including downloads) should not shrink in CAT layout.
++  if (features::IsHeliumCatEnabled()) {
++    pinned_toolbar_actions_container_->SetProperty(
++        views::kFlexBehaviorKey, flex_preferred);
++  }
++
    if (browser_view_->GetSupportsTabStrip()) {
-@@ -700,6 +728,24 @@ bool ToolbarView::IsRectInWindowCaption(
+     browser()->GetTabStripModel()->AddObserver(this);
+   }
+@@ -700,6 +735,24 @@ bool ToolbarView::IsRectInWindowCaption(
      return gfx::ToEnclosingRect(rect_in_target_coords_f);
    };
  
@@ -213,7 +238,21 @@
    // Check each child view in container_view_ to see if the rect intersects with
    // any clickable elements. If it does, check if the click is actually on that
    // element. False if on a clickable element, true if not on a clickable element.
-@@ -998,6 +1044,12 @@ void ToolbarView::InitLayout() {
+@@ -981,8 +1034,12 @@ void ToolbarView::InitLayout() {
+   constexpr int kToolbarActionsFlexOrder = kOrderOffset + 2;
+   constexpr int kExtensionsFlexOrder = kOrderOffset + 3;
+ 
++  auto min_location_bar_flex = features::IsHeliumCatFixedAddressBar() ?
++                                  views::MinimumFlexSizeRule::kPreferred :
++                                  views::MinimumFlexSizeRule::kScaleToMinimum;
++
+   const views::FlexSpecification location_bar_flex_rule =
+-      views::FlexSpecification(views::MinimumFlexSizeRule::kScaleToMinimum,
++      views::FlexSpecification(min_location_bar_flex,
+                                views::MaximumFlexSizeRule::kUnbounded)
+           .WithOrder(kLocationBarFlexOrder);
+ 
+@@ -998,6 +1055,12 @@ void ToolbarView::InitLayout() {
    location_bar_->SetProperty(views::kMarginsKey,
                               gfx::Insets::VH(0, location_bar_margin));
  


### PR DESCRIPTION
fixes #443

pinned toolbar actions no longer get collapsed in CAT layout, which fixes download button's visibility and download bubble's anchor. same goes for tab search.
<img width="1635" height="170" alt="image" src="https://github.com/user-attachments/assets/60ef4fd4-a3c5-4dd9-88df-1c7fa5e1314c" />
<img width="1628" height="299" alt="image" src="https://github.com/user-attachments/assets/32491d4a-4862-49a0-884d-44fad5d87419" />

this PR also adds a flag to prevent the location bar from shrinking when a bunch of tabs are open:
<img width="1634" height="192" alt="image" src="https://github.com/user-attachments/assets/05a1df6e-4821-4239-9ccf-4558fd4cc1f7" />

ideally, i think we should make the location bar (and omnibox) expand upon selection, but maybe the location bar width shouldn't shrink. gotta see how it feels first.