### PR TITLE
helium/flags: drop unsupported OSes from kOsAll and kOsDesktop

### DIFF
--- a/patches/helium/core/flags-setup.patch
+++ b/patches/helium/core/flags-setup.patch
@@ -1,5 +1,20 @@
 --- a/chrome/browser/about_flags.cc
 +++ b/chrome/browser/about_flags.cc
+@@ -392,11 +392,11 @@ namespace about_flags {
+ 
+ namespace {
+ 
+-const unsigned kOsAll = kOsMac | kOsWin | kOsLinux | kOsCrOS | kOsAndroid;
+-const unsigned kOsDesktop = kOsMac | kOsWin | kOsLinux | kOsCrOS;
++const unsigned kOsAll = kOsMac | kOsWin | kOsLinux;
++const unsigned kOsDesktop = kOsMac | kOsWin | kOsLinux;
+ 
+ #if defined(USE_AURA)
+-const unsigned kOsAura = kOsWin | kOsLinux | kOsCrOS;
++const unsigned kOsAura = kOsWin | kOsLinux;
+ #endif  // USE_AURA
+ 
+ #if defined(USE_AURA)
 @@ -5001,11 +5001,13 @@ const FeatureEntry::FeatureVariation kSe
  // calculate and verify checksum.
  //


### PR DESCRIPTION
makes flag descriptions cleaner and not deceptive:

<img width="728" height="112" alt="image" src="https://github.com/user-attachments/assets/8c62a700-0be2-45d0-ae6b-3c1af6e6f99f" />
