### PR TITLE
helium/ui: detach find bar from location bar, fix padding

### DIFF
--- a/patches/helium/ui/find-bar.patch
+++ b/patches/helium/ui/find-bar.patch
@@ -1,0 +1,132 @@
+--- a/chrome/browser/ui/views/toolbar/toolbar_view.cc
++++ b/chrome/browser/ui/views/toolbar/toolbar_view.cc
+@@ -1162,18 +1162,7 @@ AppMenuButton* ToolbarView::GetAppMenuBu
+ }
+ 
+ gfx::Rect ToolbarView::GetFindBarBoundingBox(int contents_bottom) {
+-  if (!browser_->SupportsWindowFeature(Browser::FEATURE_LOCATIONBAR)) {
+-    return gfx::Rect();
+-  }
+-
+-  if (!location_bar_->IsDrawn()) {
+-    return gfx::Rect();
+-  }
+-
+-  gfx::Rect bounds =
+-      location_bar_->ConvertRectToWidget(location_bar_->GetLocalBounds());
+-  return gfx::Rect(bounds.x(), bounds.bottom(), bounds.width(),
+-                   contents_bottom - bounds.bottom());
++  return gfx::Rect();
+ }
+ 
+ void ToolbarView::FocusToolbar() {
+--- a/chrome/browser/ui/views/location_bar/location_bar_view.cc
++++ b/chrome/browser/ui/views/location_bar/location_bar_view.cc
+@@ -428,7 +428,6 @@ void LocationBarView::Init() {
+       params.types_enabled.push_back(PageActionIconType::kIntentPicker);
+     }
+     params.types_enabled.push_back(PageActionIconType::kPwaInstall);
+-    params.types_enabled.push_back(PageActionIconType::kFind);
+     params.types_enabled.push_back(PageActionIconType::kTranslate);
+     params.types_enabled.push_back(PageActionIconType::kZoom);
+     params.types_enabled.push_back(PageActionIconType::kFileSystemAccess);
+--- a/chrome/browser/ui/find_bar/find_bar_controller.cc
++++ b/chrome/browser/ui/find_bar/find_bar_controller.cc
+@@ -323,25 +323,4 @@ std::u16string FindBarController::GetSel
+   return selected_text;
+ }
+ 
+-void FindBarController::UpdatePageAction() {
+-  CHECK(IsPageActionMigrated(PageActionIconType::kFind));
+-  tabs::TabInterface* tab = tabs::TabInterface::GetFromContents(web_contents());
+-  tabs::TabFeatures* tab_features = tab->GetTabFeatures();
+-  if (!tab_features) {
+-    return;
+-  }
+-  // Page actions don't exist for non-normal windows.
+-  page_actions::PageActionController* controller =
+-      tab_features->page_action_controller();
+-  if (!controller) {
+-    return;
+-  }
+-
+-  if (!find_bar_->IsFindBarVisible()) {
+-    find_bar_page_action_activity_.reset();
+-    controller->Hide(kActionFind);
+-  } else {
+-    controller->Show(kActionFind);
+-    find_bar_page_action_activity_ = controller->AddActivity(kActionFind);
+-  }
+-}
++void FindBarController::UpdatePageAction() {}
+--- a/chrome/browser/ui/views/find_bar_host.cc
++++ b/chrome/browser/ui/views/find_bar_host.cc
+@@ -627,11 +627,11 @@ gfx::Rect FindBarHost::GetDialogPosition
+   // Place the view in the top right corner of the widget boundaries (top left
+   // for RTL languages). Adjust for the view insets to ensure the border lines
+   // up with the location bar.
+-  int x = find_bar_bounds.x() - insets.left();
++  int x = find_bar_bounds.x();
+   if (!base::i18n::IsRTL()) {
+     x += find_bar_bounds.width() - prefsize.width() + insets.width();
+   }
+-  int y = find_bar_bounds.y() - insets.top();
++  int y = find_bar_bounds.y();
+   const gfx::Rect view_location(x, y, prefsize.width(), prefsize.height());
+ 
+   // When we get Find results back, we specify a selection rect, which we
+--- a/chrome/browser/ui/views/find_bar_view.cc
++++ b/chrome/browser/ui/views/find_bar_view.cc
+@@ -65,6 +65,10 @@ void SetCommonButtonAttributes(views::Im
+   views::ConfigureVectorImageButton(button);
+   views::InstallCircleHighlightPathGenerator(button);
+ }
++
++constexpr int kBasePadding = 4;
++constexpr int kHorizontalGap = 6;
++
+ }  // namespace
+ 
+ DEFINE_CLASS_ELEMENT_IDENTIFIER_VALUE(FindBarView, kElementId);
+@@ -164,18 +168,14 @@ FindBarView::FindBarView(FindBarHost* ho
+ 
+   ChromeLayoutProvider* layout_provider = ChromeLayoutProvider::Get();
+   const auto horizontal_margin =
+-      gfx::Insets::VH(0, layout_provider->GetDistanceMetric(
+-                             views::DISTANCE_UNRELATED_CONTROL_HORIZONTAL) /
+-                             2);
++      gfx::Insets::VH(0, kHorizontalGap);
+   const gfx::Insets vector_button =
+       layout_provider->GetInsetsMetric(views::INSETS_VECTOR_IMAGE_BUTTON);
+   const auto vector_button_horizontal_margin =
+       gfx::Insets::TLBR(0, horizontal_margin.left() - vector_button.left(), 0,
+                         horizontal_margin.right() - vector_button.right());
+-  const auto toast_control_vertical_margin = gfx::Insets::VH(
+-      layout_provider->GetDistanceMetric(DISTANCE_TOAST_CONTROL_VERTICAL), 0);
+-  const auto toast_label_vertical_margin = gfx::Insets::VH(
+-      layout_provider->GetDistanceMetric(DISTANCE_TOAST_LABEL_VERTICAL), 0);
++  const auto toast_control_vertical_margin = gfx::Insets::VH(kBasePadding, 0);
++  const auto toast_label_vertical_margin = gfx::Insets::VH(kBasePadding, 0);
+   const auto image_button_margins =
+       toast_control_vertical_margin + vector_button_horizontal_margin;
+ 
+@@ -197,8 +197,7 @@ FindBarView::FindBarView(FindBarHost* ho
+       views::Builder<views::BoxLayoutView>()
+           .SetOrientation(views::BoxLayout::Orientation::kHorizontal)
+           .SetInsideBorderInsets(
+-              gfx::Insets(layout_provider->GetInsetsMetric(INSETS_TOAST) -
+-                          horizontal_margin))
++              gfx::Insets::VH(0, kBasePadding * 2))
+           .AddChildren(
+               views::Builder<views::Textfield>()
+                   .CopyAddressTo(&find_text_)
+@@ -292,8 +291,7 @@ FindBarView::FindBarView(FindBarHost* ho
+     auto border = std::make_unique<views::BubbleBorder>(
+         views::BubbleBorder::NONE, views::BubbleBorder::STANDARD_SHADOW);
+     border->SetColor(kColorFindBarBackground);
+-    border->set_md_shadow_elevation(
+-        layout_provider->GetCornerRadiusMetric(views::Emphasis::kHigh));
++    border->set_md_shadow_elevation(kBasePadding);
+     border->set_rounded_corners(gfx::RoundedCornersF(corner_radius));
+ 
+     SetBackground(std::make_unique<views::BubbleBackground>(border.get()));

--- a/patches/series
+++ b/patches/series
@@ -259,4 +259,5 @@ helium/ui/ublock-show-in-settings.patch
 helium/ui/licenses-in-credits.patch
 helium/ui/remove-autofill-link-to-password-manager.patch
 helium/ui/fix-caption-button-tab-strip-align.patch
+helium/ui/find-bar.patch
 helium/ui/experiments/compact-action-toolbar.patch


### PR DESCRIPTION
- no longer animates from the middle of the toolbar
- no longer feels awkward in CAT layout
- just looks better

before (regular):

https://github.com/user-attachments/assets/fba88c2f-5d4c-411a-973e-c3b45b10849b


after (regular):

https://github.com/user-attachments/assets/66c2f14a-0855-420c-aed0-b20e2f89825a


before (CAT):

https://github.com/user-attachments/assets/7bbcb332-61dd-4c8a-acdb-2ae70159aa11


after (CAT):

https://github.com/user-attachments/assets/4f2bfade-ed69-4a37-9fbc-4485999e8782
