### PR TITLE
helium/cat: elide location icon text when in CAT mode

### DIFF
--- a/patches/helium/ui/experiments/compact-action-toolbar.patch
+++ b/patches/helium/ui/experiments/compact-action-toolbar.patch
@@ -310,3 +310,22 @@
    return gfx::Size(
        GetFontList().GetExpectedTextWidth(kMinCharacters) + GetInsets().width(),
        GetPreferredSize().height());
+--- a/chrome/browser/ui/views/location_bar/location_icon_view.cc
++++ b/chrome/browser/ui/views/location_bar/location_icon_view.cc
+@@ -13,6 +13,7 @@
+ #include "chrome/browser/ui/layout_constants.h"
+ #include "chrome/browser/ui/omnibox/omnibox_edit_model.h"
+ #include "chrome/browser/ui/page_info/page_info_dialog.h"
++#include "chrome/browser/ui/ui_features.h"
+ #include "chrome/browser/ui/view_ids.h"
+ #include "chrome/browser/ui/views/location_bar/icon_label_bubble_view.h"
+ #include "chrome/browser/ui/views/location_bar/location_bar_util.h"
+@@ -193,7 +194,7 @@ bool LocationIconView::GetShowText() con
+       url.SchemeIs(extensions::kExtensionScheme) ||
+       url.SchemeIs(url::kFileScheme) ||
+       url.SchemeIs(dom_distiller::kDomDistillerScheme)) {
+-    return true;
++    return !features::IsHeliumCatEnabled();
+   }
+ 
+   return !location_bar_model->GetSecureDisplayText().empty();


### PR DESCRIPTION
Fixes #450

Before:
<img width="697" height="99" alt="Screenshot 2025-11-22 at 12 15 31" src="https://github.com/user-attachments/assets/fc5ce96f-3993-4dad-8a3a-b4482561ed75" />


After:
<img width="585" height="97" alt="Screenshot 2025-11-22 at 12 20 32" src="https://github.com/user-attachments/assets/79b677f9-4f98-4f9e-8ec4-44ed5d146c0d" />
