### PR TITLE
helium/ui/tabs: tab muting, move indicator to left

### DIFF
--- a/patches/helium/ui/tabs.patch
+++ b/patches/helium/ui/tabs.patch
@@ -444,3 +444,56 @@
  
  #if BUILDFLAG(ENABLE_PLATFORM_HEVC)
  // Enables HEVC hardware accelerated decoding.
+--- a/chrome/browser/ui/views/tabs/alert_indicator_button.cc
++++ b/chrome/browser/ui/views/tabs/alert_indicator_button.cc
+@@ -160,27 +160,8 @@ void AlertIndicatorButton::TransitionToA
+     UpdateIconForAlertState(next_state.value());
+   }
+ 
+-  if ((alert_state_ == tabs::TabAlert::AUDIO_PLAYING &&
+-       next_state == tabs::TabAlert::AUDIO_MUTING) ||
+-      (alert_state_ == tabs::TabAlert::AUDIO_MUTING &&
+-       next_state == tabs::TabAlert::AUDIO_PLAYING)) {
+-    // Instant user feedback: No fade animation.
+-    showing_alert_state_ = next_state;
+-    fade_animation_.reset();
+-  } else {
+-    if (!next_state) {
+-      showing_alert_state_ = alert_state_;  // Fading-out indicator.
+-    } else {
+-      showing_alert_state_ = next_state;  // Fading-in to next indicator.
+-    }
+-    fade_animation_ = CreateTabAlertIndicatorFadeAnimation(next_state);
+-    if (!fade_animation_delegate_) {
+-      fade_animation_delegate_ = std::make_unique<FadeAnimationDelegate>(this);
+-    }
+-    fade_animation_->set_delegate(fade_animation_delegate_.get());
+-    fade_animation_->Start();
+-  }
+-
++  showing_alert_state_ = next_state;
++  fade_animation_.reset();
+   alert_state_ = next_state;
+ 
+   if (previous_alert_showing_state != showing_alert_state_) {
+@@ -289,20 +270,7 @@ bool AlertIndicatorButton::IsTriggerable
+ }
+ 
+ void AlertIndicatorButton::PaintButtonContents(gfx::Canvas* canvas) {
+-  double opaqueness = 1.0;
+-  if (fade_animation_) {
+-    opaqueness = fade_animation_->GetCurrentValue();
+-    if (!alert_state_) {
+-      opaqueness = 1.0 - opaqueness;  // Fading out, not in.
+-    }
+-  }
+-  if (opaqueness < 1.0) {
+-    canvas->SaveLayerAlpha(opaqueness * SK_AlphaOPAQUE);
+-  }
+   ImageButton::PaintButtonContents(canvas);
+-  if (opaqueness < 1.0) {
+-    canvas->Restore();
+-  }
+ }
+ 
+ gfx::ImageSkia AlertIndicatorButton::GetImageToPaint() {


### PR DESCRIPTION
https://github.com/user-attachments/assets/c5f485dd-e778-4bb9-812c-30ebeecd7e22

- enabled the tab muting feature by default
- fixed the UX issue with the alert indicator and the close button swapping places on hover
- incresed the minimum width for close buttons to prevent mute & close buttons from overlapping each other

closes #324