### PR TITLE
helium/ui: remove zoom page action

### DIFF
--- a/patches/helium/ui/remove-zoom-action.patch
+++ b/patches/helium/ui/remove-zoom-action.patch
@@ -1,0 +1,20 @@
+--- a/chrome/browser/ui/views/location_bar/location_bar_view.cc
++++ b/chrome/browser/ui/views/location_bar/location_bar_view.cc
+@@ -429,7 +429,6 @@ void LocationBarView::Init() {
+     }
+     params.types_enabled.push_back(PageActionIconType::kPwaInstall);
+     params.types_enabled.push_back(PageActionIconType::kTranslate);
+-    params.types_enabled.push_back(PageActionIconType::kZoom);
+     params.types_enabled.push_back(PageActionIconType::kFileSystemAccess);
+ 
+     params.types_enabled.push_back(PageActionIconType::kMemorySaver);
+--- a/chrome/browser/ui/web_applications/app_browser_controller.cc
++++ b/chrome/browser/ui/web_applications/app_browser_controller.cc
+@@ -403,7 +403,6 @@ AppBrowserController::GetTitleBarPageAct
+ 
+   std::vector<PageActionIconType> types_enabled;
+   types_enabled.push_back(PageActionIconType::kFind);
+-  types_enabled.push_back(PageActionIconType::kZoom);
+   types_enabled.push_back(PageActionIconType::kFileSystemAccess);
+ 
+   return types_enabled;

--- a/patches/series
+++ b/patches/series
@@ -261,4 +261,5 @@ helium/ui/licenses-in-credits.patch
 helium/ui/remove-autofill-link-to-password-manager.patch
 helium/ui/fix-caption-button-tab-strip-align.patch
 helium/ui/find-bar.patch
+helium/ui/remove-zoom-action.patch
 helium/ui/experiments/compact-action-toolbar.patch


### PR DESCRIPTION
cleans up space, eliminates "zoom shaming". i just like scaling down websites without being constantly reminded about it. safari behaves the same way as helium does with this change, and no one complains, so i guess it's fine :3