### PR TITLE
upstream-fixes/macos-widget: update to prevent parent overlap

### DIFF
--- a/patches/upstream-fixes/fix-macos-widget-rect.patch
+++ b/patches/upstream-fixes/fix-macos-widget-rect.patch
@@ -1,24 +1,20 @@
 --- a/components/remote_cocoa/app_shim/native_widget_mac_nswindow.mm
 +++ b/components/remote_cocoa/app_shim/native_widget_mac_nswindow.mm
-@@ -352,12 +352,12 @@ struct NSEdgeAndCornerThicknesses {
+@@ -352,8 +352,12 @@ struct NSEdgeAndCornerThicknesses {
  }
  
  - (NSRect)constrainFrameRect:(NSRect)frameRect toScreen:(NSScreen*)screen {
 -  // Headless windows should not be constrained within the physical screen.
 -  if (_isHeadless) {
--    return frameRect;
--  }
--
--  return [super constrainFrameRect:frameRect toScreen:screen];
-+  // AppKit's default implementation moves child windows down to avoid
-+  // the menu bar. We don't want that behavior, because widgets like the
-+  // Omnibox may have a big shadow that could cause invisible menu bar collision
-+  // in fullscreen/maximized state. We override it here to return the original
-+  // frameRect before the adjustment.
-+  return frameRect;
- }
++  if (_isHeadless || self.parentWindow) {
++    // AppKit's default implementation moves child windows down to avoid
++    // the menu bar. We don't want that behavior, because widgets like the
++    // Omnibox may have a big shadow that could cause invisible menu bar
++    // collision in fullscreen/maximized state. We override it here to
++    // return the original frameRect before the adjustment.
+     return frameRect;
+   }
  
- // Private methods.
 --- a/components/remote_cocoa/app_shim/native_widget_mac_overlay_nswindow.mm
 +++ b/components/remote_cocoa/app_shim/native_widget_mac_overlay_nswindow.mm
 @@ -6,8 +6,6 @@


### PR DESCRIPTION
fixes the main window being clipped by the menu bar

partial copy of chromium/chromium@4f0076b