### PR TITLE
helium/core: override browser protocol in copied page urls and tab hover card

### DIFF
--- a/patches/helium/core/override-chrome-protocol.patch
+++ b/patches/helium/core/override-chrome-protocol.patch
@@ -340,3 +340,39 @@
      }
    } else {
      // Match input about: or |embedderAbout| URL input against builtin URLs.
+--- a/chrome/browser/ui/browser_commands.cc
++++ b/chrome/browser/ui/browser_commands.cc
+@@ -169,6 +169,7 @@
+ #include "components/tabs/public/tab_interface.h"
+ #include "components/translate/core/browser/language_state.h"
+ #include "components/translate/core/browser/translate_manager.h"
++#include "components/url_formatter/url_formatter.h"
+ #include "components/user_education/common/feature_promo/feature_promo_controller.h"
+ #include "components/web_modal/web_contents_modal_dialog_manager.h"
+ #include "components/webapps/common/web_app_id.h"
+@@ -2386,7 +2387,12 @@ bool IsDebuggerAttachedToCurrentTab(Brow
+ 
+ void CopyURL(BrowserWindowInterface* bwi, content::WebContents* web_contents) {
+   ui::ScopedClipboardWriter scw(ui::ClipboardBuffer::kCopyPaste);
+-  scw.WriteText(base::UTF8ToUTF16(web_contents->GetVisibleURL().spec()));
++  const std::u16string formatted_url =
++      url_formatter::FormatUrl(web_contents->GetVisibleURL(),
++                               url_formatter::kFormatReplaceChromeProtocol,
++                               base::UnescapeRule::NORMAL, nullptr,
++                               nullptr, nullptr);
++  scw.WriteText(formatted_url);
+ 
+ #if !BUILDFLAG(IS_ANDROID)
+   if (toast_features::IsEnabled(toast_features::kLinkCopiedToast)) {
+--- a/chrome/browser/ui/views/tabs/tab_hover_card_bubble_view.cc
++++ b/chrome/browser/ui/views/tabs/tab_hover_card_bubble_view.cc
+@@ -557,7 +557,8 @@ void TabHoverCardBubbleView::UpdateCardC
+             url_formatter::kFormatUrlOmitDefaults |
+                 url_formatter::kFormatUrlOmitHTTPS |
+                 url_formatter::kFormatUrlOmitTrivialSubdomains |
+-                url_formatter::kFormatUrlTrimAfterHost,
++                url_formatter::kFormatUrlTrimAfterHost |
++                url_formatter::kFormatReplaceChromeProtocol,
+             base::UnescapeRule::NORMAL, nullptr, nullptr, nullptr);
+       }
+ 

--- a/patches/helium/core/split-view.patch
+++ b/patches/helium/core/split-view.patch
@@ -625,7 +625,7 @@
  
 --- a/chrome/browser/ui/browser_commands.cc
 +++ b/chrome/browser/ui/browser_commands.cc
-@@ -499,8 +499,12 @@ void ReloadInternal(BrowserWindowInterfa
+@@ -500,8 +500,12 @@ void ReloadInternal(BrowserWindowInterfa
    WebContents* const active_contents = tab_strip_model->GetActiveWebContents();
  
    std::vector<WebContents*> tabs_to_reload;


### PR DESCRIPTION
https://github.com/user-attachments/assets/8222712c-e004-4283-b6f7-8a5f85efecc6

i feel like there was an issue that complained about this but i couldn't find it