### PR TITLE
helium: add an option to use MRU order when tabbing thru tabs 

### DIFF
--- a/patches/contrib/brave/tab-cycling-mru-impl.patch
+++ b/patches/contrib/brave/tab-cycling-mru-impl.patch
@@ -1,0 +1,260 @@
+Based on Brave's MRU tab cycling implementation, adapted for Helium.
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this file,
+You can obtain one at https://mozilla.org/MPL/2.0/.
+
+Copyright (c) 2025, The Brave Authors
+Copyright (c) 2025, The Helium Authors
+
+Alternatively, the contents of this file may be used under the terms
+of the GNU General Public License Version 3, as described below:
+
+Copyright (C) 2025 The Helium Authors
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+--- a/chrome/browser/ui/tabs/tab_strip_model.cc
++++ b/chrome/browser/ui/tabs/tab_strip_model.cc
+@@ -54,6 +54,7 @@
+ #include "chrome/browser/ui/browser_commands.h"
+ #include "chrome/browser/ui/browser_finder.h"
+ #include "chrome/browser/ui/browser_window.h"
++#include "chrome/browser/ui/views/frame/browser_view.h"
+ #include "chrome/browser/ui/commerce/ui_utils.h"
+ #include "chrome/browser/ui/send_tab_to_self/send_tab_to_self_bubble.h"
+ #include "chrome/browser/ui/tabs/features.h"
+@@ -3658,6 +3659,44 @@ TabStripSelectionChange TabStripModel::S
+   return selection;
+ }
+ 
++void TabStripModel::SelectMRUTab(TabRelativeDirection direction,
++                                 TabStripUserGestureDetails detail) {
++  if (mru_cycle_list_.empty()) {
++    Browser* browser = chrome::FindBrowserWithTab(GetWebContentsAt(0));
++    if (!browser) {
++      return;
++    }
++
++    for (int i = 0; i < count(); ++i) {
++      mru_cycle_list_.push_back(i);
++    }
++
++    std::sort(mru_cycle_list_.begin(), mru_cycle_list_.end(),
++              [this](int a, int b) {
++                return GetWebContentsAt(a)->GetLastActiveTimeTicks() >
++                       GetWebContentsAt(b)->GetLastActiveTimeTicks();
++              });
++
++    if (BrowserView* browser_view = browser->window()->AsBrowserView()) {
++      browser_view->StartTabCycling();
++    }
++  }
++
++  if (direction == TabRelativeDirection::kNext) {
++    std::rotate(mru_cycle_list_.begin(), mru_cycle_list_.begin() + 1,
++                mru_cycle_list_.end());
++  } else {
++    std::rotate(mru_cycle_list_.rbegin(), mru_cycle_list_.rbegin() + 1,
++                mru_cycle_list_.rend());
++  }
++
++  ActivateTabAt(mru_cycle_list_[0], detail);
++}
++
++void TabStripModel::StopMRUCycling() {
++  mru_cycle_list_.clear();
++}
++
+ void TabStripModel::SelectRelativeTab(TabRelativeDirection direction,
+                                       TabStripUserGestureDetails detail) {
+   // This may happen during automated testing or if a user somehow buffers
+--- a/chrome/browser/ui/tabs/tab_strip_model.h
++++ b/chrome/browser/ui/tabs/tab_strip_model.h
+@@ -604,6 +604,10 @@ class TabStripModel {
+       TabStripUserGestureDetails detail = TabStripUserGestureDetails(
+           TabStripUserGestureDetails::GestureType::kOther));
+ 
++  // Stops cycling through tabs in MRU order when Ctrl is released.
++  // Used in BrowserView::StopTabCycling().
++  void StopMRUCycling();
++
+   // Moves the active in the specified direction. Respects group boundaries.
+   void MoveTabNext();
+   void MoveTabPrevious();
+@@ -1132,6 +1136,11 @@ class TabStripModel {
+     kPrevious,
+   };
+ 
++  // Selects either the most recently used tab
++  // or the least recently used tab.
++  void SelectMRUTab(TabRelativeDirection direction,
++                    TabStripUserGestureDetails detail);
++
+   // Selects either the next tab (kNext), or the previous tab (kPrevious).
+   void SelectRelativeTab(TabRelativeDirection direction,
+                          TabStripUserGestureDetails detail);
+@@ -1388,6 +1397,9 @@ class TabStripModel {
+   // Tracks whether a modal UI is showing.
+   bool showing_modal_ui_ = false;
+ 
++  // List of tabs for MRU cycling
++  std::vector<int> mru_cycle_list_;
++
+   base::WeakPtrFactory<TabStripModel> weak_factory_{this};
+ };
+ 
+--- a/chrome/browser/ui/views/frame/browser_view.cc
++++ b/chrome/browser/ui/views/frame/browser_view.cc
+@@ -285,7 +285,10 @@
+ #include "ui/compositor/paint_recorder.h"
+ #include "ui/content_accelerators/accelerator_util.h"
+ #include "ui/display/screen.h"
++#include "ui/events/event.h"
++#include "ui/events/event_handler.h"
+ #include "ui/events/event_utils.h"
++#include "ui/events/keycodes/keyboard_codes.h"
+ #include "ui/gfx/animation/animation_runner.h"
+ #include "ui/gfx/canvas.h"
+ #include "ui/gfx/color_utils.h"
+@@ -303,6 +306,7 @@
+ #include "ui/views/controls/button/menu_button.h"
+ #include "ui/views/controls/textfield/textfield.h"
+ #include "ui/views/controls/webview/webview.h"
++#include "ui/views/event_monitor.h"
+ #include "ui/views/interaction/element_tracker_views.h"
+ #include "ui/views/layout/fill_layout.h"
+ #include "ui/views/view.h"
+@@ -726,6 +730,83 @@ bool ConvertedHitTest(views::View* src,
+ 
+ }  // namespace
+ 
++// Handles events during MRU tab cycling to start/stop tab cycling.
++class TabCyclingEventHandler : public ui::EventObserver,
++                               public views::WidgetObserver {
++ public:
++  explicit TabCyclingEventHandler(BrowserView* browser_view)
++      : browser_view_(browser_view) {
++    Start();
++  }
++
++  ~TabCyclingEventHandler() override { Stop(); }
++
++  TabCyclingEventHandler(const TabCyclingEventHandler&) = delete;
++  TabCyclingEventHandler& operator=(const TabCyclingEventHandler&) = delete;
++
++ private:
++  // ui::EventObserver overrides:
++  void OnEvent(const ui::Event& event) override {
++    if (event.type() == ui::EventType::kKeyReleased &&
++        event.AsKeyEvent()->key_code() == ui::VKEY_CONTROL) {
++      // Ctrl key was released, stop the tab cycling.
++      Stop();
++      return;
++    }
++
++    if (event.type() == ui::EventType::kMousePressed) {
++      Stop();
++    }
++  }
++
++  // views::WidgetObserver overrides:
++  void OnWidgetActivationChanged(views::Widget* widget, bool active) override {
++    // We should stop cycling if other application gets active state.
++    if (!active) {
++      Stop();
++    }
++  }
++
++  // Handle browser widget closing while tab cycling is in-progress.
++  void OnWidgetClosing(views::Widget* widget) override { Stop(); }
++
++  void Start() {
++    // Add the event handler.
++    auto* widget = browser_view_->GetWidget();
++    if (widget->GetNativeWindow()) {
++      monitor_ = views::EventMonitor::CreateWindowMonitor(
++          this, widget->GetNativeWindow(),
++          {ui::EventType::kMousePressed, ui::EventType::kKeyReleased});
++    }
++    widget->AddObserver(this);
++  }
++
++  void Stop() {
++    if (!monitor_) {
++      // Already stopped.
++      return;
++    }
++
++    // Remove event handler.
++    auto* widget = browser_view_->GetWidget();
++    monitor_.reset();
++    widget->RemoveObserver(this);
++    browser_view_->StopTabCycling();
++  }
++
++  raw_ptr<BrowserView> browser_view_;
++  std::unique_ptr<views::EventMonitor> monitor_;
++};
++
++void BrowserView::StartTabCycling() {
++  tab_cycling_event_handler_ = std::make_unique<TabCyclingEventHandler>(this);
++}
++
++void BrowserView::StopTabCycling() {
++  tab_cycling_event_handler_.reset();
++  browser()->tab_strip_model()->StopMRUCycling();
++}
++
+ class BrowserView::AccessibilityModeObserver : public ui::AXModeObserver {
+  public:
+   explicit AccessibilityModeObserver(BrowserView* browser_view)
+--- a/chrome/browser/ui/views/frame/browser_view.h
++++ b/chrome/browser/ui/views/frame/browser_view.h
+@@ -80,6 +80,7 @@ class LocationBarView;
+ class MultiContentsView;
+ class ScrimView;
+ class SidePanel;
++class TabCyclingEventHandler;
+ class TabDragDelegate;
+ class TabSearchBubbleHost;
+ class TabStrip;
+@@ -566,6 +567,10 @@ class BrowserView : public BrowserWindow
+   void ShowChromeLabs() override;
+   views::WebView* GetContentsWebView() override;
+   BrowserView* AsBrowserView() override;
++
++  void StartTabCycling();
++  void StopTabCycling();
++
+   SharingDialog* ShowSharingDialog(content::WebContents* contents,
+                                    SharingDialogData data) override;
+   void ShowUpdateChromeDialog() override;
+@@ -889,6 +894,7 @@ class BrowserView : public BrowserWindow
+   friend class BrowserViewLayoutDelegateImplNew;
+   friend class BrowserViewLayoutDelegateImplOld;
+   friend class BrowserViewLayoutDelegateImplBrowsertest;
++  friend class TabCyclingEventHandler;
+   friend class TopControlsSlideControllerTest;
+   FRIEND_TEST_ALL_PREFIXES(BrowserViewTest, BrowserView);
+   FRIEND_TEST_ALL_PREFIXES(BrowserViewTest, AccessibleWindowTitle);
+@@ -1395,6 +1401,8 @@ class BrowserView : public BrowserWindow
+ 
+   base::CallbackListSubscription vertical_tab_subscription_;
+ 
++  std::unique_ptr<TabCyclingEventHandler> tab_cycling_event_handler_;
++
+   mutable base::WeakPtrFactory<BrowserView> weak_ptr_factory_{this};
+ };
+ 

--- a/patches/helium/core/open-new-tabs-next-to-active-tab-option.patch
+++ b/patches/helium/core/open-new-tabs-next-to-active-tab-option.patch
@@ -24,7 +24,7 @@
    registry->RegisterBooleanPref(prefs::kShowHomeButton, false,
 --- a/chrome/browser/ui/tabs/tab_strip_model.cc
 +++ b/chrome/browser/ui/tabs/tab_strip_model.cc
-@@ -81,12 +81,14 @@
+@@ -82,12 +82,14 @@
  #include "chrome/browser/web_applications/policy/web_app_policy_manager.h"
  #include "chrome/browser/web_applications/web_app_provider.h"
  #include "chrome/browser/web_applications/web_app_tab_helper.h"
@@ -39,7 +39,7 @@
  #include "components/reading_list/core/reading_list_model.h"
  #include "components/tab_groups/tab_group_id.h"
  #include "components/tab_groups/tab_group_visual_data.h"
-@@ -1548,7 +1550,11 @@ void TabStripModel::AddTab(std::unique_p
+@@ -1549,7 +1551,11 @@ void TabStripModel::AddTab(std::unique_p
      // For all other types, respect what was passed to us, normalizing -1s and
      // values that are too large.
      if (index < 0 || index > count()) {

--- a/patches/helium/core/split-view.patch
+++ b/patches/helium/core/split-view.patch
@@ -542,7 +542,7 @@
  #include "chrome/browser/ui/views/frame/scrim_view.h"
  #include "chrome/browser/ui/views/frame/tab_modal_dialog_host.h"
  #include "chrome/browser/ui/views/frame/tab_strip_region_view.h"
-@@ -2209,12 +2208,6 @@ void BrowserView::UpdateToolbar(content:
+@@ -2290,12 +2289,6 @@ void BrowserView::UpdateToolbar(content:
    if (toolbar_) {
      toolbar_->Update(contents);
    }

--- a/patches/helium/core/tab-cycling-mru.patch
+++ b/patches/helium/core/tab-cycling-mru.patch
@@ -1,0 +1,120 @@
+--- a/chrome/common/pref_names.h
++++ b/chrome/common/pref_names.h
+@@ -1310,6 +1310,10 @@ inline constexpr char
+ // instead of tab strip end.
+ inline constexpr char kNewTabNextToActive[] = "helium.browser.new_tab_next_to_active";
+ 
++// A boolean pref set to true if MRU (Most Recently Used) order should be used when
++// cycling through tabs with Ctrl+Tab.
++inline constexpr char kTabCyclingMRU[] = "helium.browser.mru_tab_cycling";
++
+ // A boolean pref set to true if a Home button to open the Home pages should be
+ // visible on the toolbar.
+ inline constexpr char kShowHomeButton[] = "browser.show_home_button";
+--- a/chrome/browser/ui/browser_ui_prefs.cc
++++ b/chrome/browser/ui/browser_ui_prefs.cc
+@@ -112,6 +112,8 @@ void RegisterBrowserUserPrefs(user_prefs
+ 
+   registry->RegisterBooleanPref(prefs::kNewTabNextToActive, false);
+ 
++  registry->RegisterBooleanPref(prefs::kTabCyclingMRU, false);
++
+   registry->RegisterBooleanPref(prefs::kHomePageIsNewTabPage, true,
+                                 pref_registration_flags);
+   registry->RegisterBooleanPref(prefs::kShowHomeButton, false,
+--- a/chrome/browser/ui/tabs/tab_strip_model.cc
++++ b/chrome/browser/ui/tabs/tab_strip_model.cc
+@@ -1648,11 +1648,11 @@ void TabStripModel::CloseSelectedTabs()
+ }
+ 
+ void TabStripModel::SelectNextTab(TabStripUserGestureDetails detail) {
+-  SelectRelativeTab(TabRelativeDirection::kNext, detail);
++  SelectRelativeTabCycle(TabRelativeDirection::kNext, detail);
+ }
+ 
+ void TabStripModel::SelectPreviousTab(TabStripUserGestureDetails detail) {
+-  SelectRelativeTab(TabRelativeDirection::kPrevious, detail);
++  SelectRelativeTabCycle(TabRelativeDirection::kPrevious, detail);
+ }
+ 
+ void TabStripModel::SelectLastTab(TabStripUserGestureDetails detail) {
+@@ -3665,6 +3665,18 @@ TabStripSelectionChange TabStripModel::S
+   return selection;
+ }
+ 
++void TabStripModel::SelectRelativeTabCycle(TabRelativeDirection direction,
++                                           TabStripUserGestureDetails detail) {
++  const bool enable_mru =
++      profile_->GetPrefs()->GetBoolean(prefs::kTabCyclingMRU);
++
++  if (enable_mru) {
++    SelectMRUTab(direction, detail);
++  } else {
++    SelectRelativeTab(direction, detail);
++  }
++}
++
+ void TabStripModel::SelectMRUTab(TabRelativeDirection direction,
+                                  TabStripUserGestureDetails detail) {
+   if (mru_cycle_list_.empty()) {
+--- a/chrome/browser/ui/tabs/tab_strip_model.h
++++ b/chrome/browser/ui/tabs/tab_strip_model.h
+@@ -1136,6 +1136,11 @@ class TabStripModel {
+     kPrevious,
+   };
+ 
++  // Selects either the next tab or the previous tab.
++  // Uses MRU order if the user prefers it.
++  void SelectRelativeTabCycle(TabRelativeDirection direction,
++                              TabStripUserGestureDetails detail);
++
+   // Selects either the most recently used tab
+   // or the least recently used tab.
+   void SelectMRUTab(TabRelativeDirection direction,
+--- a/chrome/browser/extensions/api/settings_private/prefs_util.cc
++++ b/chrome/browser/extensions/api/settings_private/prefs_util.cc
+@@ -225,6 +225,8 @@ const PrefsUtil::TypedPrefMap& PrefsUtil
+ 
+   (*s_allowlist)[::prefs::kNewTabNextToActive] =
+       settings_api::PrefType::kBoolean;
++  (*s_allowlist)[::prefs::kTabCyclingMRU] =
++      settings_api::PrefType::kBoolean;
+ 
+   (*s_allowlist)[::prefs::kShowHomeButton] = settings_api::PrefType::kBoolean;
+   (*s_allowlist)[::prefs::kShowForwardButton] =
+--- a/chrome/app/settings_strings.grdp
++++ b/chrome/app/settings_strings.grdp
+@@ -276,6 +276,9 @@
+   <message name="IDS_SETTINGS_NEW_TAB_NEXT_TO_ACTIVE_BUTTON" desc="Label for the checkbox which enables or disables behaviour of opening new tabs next to current active tab.">
+     Open new tabs next to the active tab
+   </message>
++  <message name="IDS_SETTINGS_CYCLE_TABS_IN_MRU_ORDER" desc="Label for the checkbox which enables or disables cycling through tabs in MRU order when using Ctrl+Tab.">
++    Cycle through tabs in most recently used order with Ctrl+Tab
++  </message>
+   <message name="IDS_SETTINGS_SHOW_HOME_BUTTON" desc="Label for the checkbox which enables or disables showing the home button in the toolbar.">
+     Show home button
+   </message>
+--- a/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
++++ b/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
+@@ -516,6 +516,7 @@ void AddAppearanceStrings(content::WebUI
+       {"darkMode", IDS_NTP_CUSTOMIZE_CHROME_COLOR_SCHEME_MODE_DARK_LABEL},
+       {"systemMode", IDS_NTP_CUSTOMIZE_CHROME_COLOR_SCHEME_MODE_SYSTEM_LABEL},
+       {"openNewTabNextToActive", IDS_SETTINGS_NEW_TAB_NEXT_TO_ACTIVE_BUTTON},
++      {"cycleTabsInMRUOrder", IDS_SETTINGS_CYCLE_TABS_IN_MRU_ORDER},
+       {"showHomeButton", IDS_SETTINGS_SHOW_HOME_BUTTON},
+       {"showBookmarksBar", IDS_SETTINGS_SHOW_BOOKMARKS_BAR},
+       {"allowSplitViewDragAndDrop",
+--- a/chrome/browser/resources/settings/appearance_page/appearance_behavior_page.html
++++ b/chrome/browser/resources/settings/appearance_page/appearance_behavior_page.html
+@@ -6,6 +6,11 @@
+       label="$i18n{openNewTabNextToActive}">
+   </settings-toggle-button>
+ 
++  <settings-toggle-button class="hr" id="tabCyclingMRU"
++      pref="{{prefs.helium.browser.mru_tab_cycling}}"
++      label="$i18n{cycleTabsInMRUOrder}">
++  </settings-toggle-button>
++
+   <settings-toggle-button class="hr" id="copyPageUrlShortcut"
+       pref="{{prefs.helium.settings.a11y.copy_page_url_shortcut}}"
+       label="$i18n{copyPageUrlShortcut}">

--- a/patches/helium/settings/fix-appearance-page.patch
+++ b/patches/helium/settings/fix-appearance-page.patch
@@ -9,7 +9,7 @@
      <message name="IDS_SETTINGS_RESET_TO_DEFAULT_THEME" desc="Accessibility label of the button which resets the browser theme back to the default value">
        Reset to default theme
      </message>
-@@ -291,6 +291,9 @@
+@@ -294,6 +294,9 @@
    <message name="IDS_SETTINGS_AUTO_PIN_NEW_TAB_GROUPS" desc="Label for the checkbox which enables or disables auto pin new tab groups.">
      Automatically pin new tab groups created on any device to the bookmarks bar
    </message>
@@ -21,7 +21,7 @@
    </message>
 --- a/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
 +++ b/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
-@@ -522,7 +522,7 @@ void AddAppearanceStrings(content::WebUI
+@@ -523,7 +523,7 @@ void AddAppearanceStrings(content::WebUI
         IDS_SETTINGS_ALLOW_SPLIT_VIEW_DRAG_AND_DROP},
        {"showTabGroupsInBookmarksBar",
         IDS_SETTINGS_SHOW_TAB_GROUPS_IN_BOOKMARKS_BAR},
@@ -30,7 +30,7 @@
        {"hoverCardTitle", IDS_SETTINGS_HOVER_CARD_TITLE},
        {"showHoverCardImages", IDS_SETTINGS_SHOW_HOVER_CARD_IMAGES},
        {"showHoverCardMemoryUsage", IDS_SETTINGS_SHOW_HOVER_CARD_MEMORY_USAGE},
-@@ -554,9 +554,7 @@ void AddAppearanceStrings(content::WebUI
+@@ -555,9 +555,7 @@ void AddAppearanceStrings(content::WebUI
        {"classicTheme", IDS_SETTINGS_CLASSIC_THEME},
        {"useClassicTheme", IDS_SETTINGS_USE_CLASSIC_THEME},
  #endif

--- a/patches/helium/settings/fix-page-names.patch
+++ b/patches/helium/settings/fix-page-names.patch
@@ -11,7 +11,7 @@
        {"loading", IDS_HISTORY_LOADING},
 --- a/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
 +++ b/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
-@@ -1813,7 +1813,7 @@ void AddSyncControlsStrings(content::Web
+@@ -1814,7 +1814,7 @@ void AddSyncControlsStrings(content::Web
  void AddPeopleStrings(content::WebUIDataSource* html_source, Profile* profile) {
    static constexpr webui::LocalizedString kLocalizedStrings[] = {
        // Top level people strings:

--- a/patches/helium/settings/fix-text-on-cookies-page.patch
+++ b/patches/helium/settings/fix-text-on-cookies-page.patch
@@ -1,6 +1,6 @@
 --- a/chrome/app/settings_strings.grdp
 +++ b/chrome/app/settings_strings.grdp
-@@ -1914,6 +1914,9 @@
+@@ -1917,6 +1917,9 @@
    <message name="IDS_SETTINGS_ENABLE_DO_NOT_TRACK_DIALOG_TEXT" desc="The text of a confirmation dialog that confirms that the user want to send the 'Do Not Track' header">
      Enabling "Do Not Track" means that a request will be included with your browsing traffic. Any effect depends on whether a website responds to the request, and how the request is interpreted. For example, some websites may respond to this request by showing you ads that aren't based on other websites you've visited. Many websites will still collect and use your browsing data - for example to improve security, to provide content, services, ads and recommendations on their websites, and to generate reporting statistics.
    </message>
@@ -10,7 +10,7 @@
    <message name="IDS_SETTINGS_ENABLE_DO_NOT_TRACK_DIALOG_LEARN_MORE_ACCESSIBILITY_LABEL" desc="The accessibility label for a link to learn more about Do Not Track">
      Learn more about Do Not Track
    </message>
-@@ -3150,6 +3153,9 @@
+@@ -3153,6 +3156,9 @@
    <message name="IDS_SETTINGS_TRACKING_PROTECTION_SITES_ALLOWED_COOKIES_DESCRIPTION" desc="Description of the section on the Tracking Protection settings page that lets users manage which sites are allowed to use third-party cookies. Explains how to use a wildcard to create an exception for an entire domain.">
      Affects the sites listed here. Inserting “[*.]” before a domain name creates an exception for the entire domain. For example, adding “[*.]google.com” means that third-party cookies can also be active for mail.google.com, because it’s part of google.com.
    </message>
@@ -22,7 +22,7 @@
    </message>
 --- a/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
 +++ b/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
-@@ -1961,7 +1961,7 @@ void AddPrivacyStrings(content::WebUIDat
+@@ -1962,7 +1962,7 @@ void AddPrivacyStrings(content::WebUIDat
        {"privacyPageMore", IDS_SETTINGS_PRIVACY_MORE},
        {"doNotTrack", IDS_SETTINGS_ENABLE_DO_NOT_TRACK},
        {"doNotTrackDialogTitle", IDS_SETTINGS_ENABLE_DO_NOT_TRACK_DIALOG_TITLE},
@@ -31,7 +31,7 @@
        {"doNotTrackDialogLearnMoreA11yLabel",
         IDS_SETTINGS_ENABLE_DO_NOT_TRACK_DIALOG_LEARN_MORE_ACCESSIBILITY_LABEL},
        // TODO(crbug.com/40122957): This string is no longer used. Remove.
-@@ -2670,7 +2670,7 @@ void AddSiteSettingsStrings(content::Web
+@@ -2671,7 +2671,7 @@ void AddSiteSettingsStrings(content::Web
        {"trackingProtectionSitesAllowedCookiesTitle",
         IDS_SETTINGS_TRACKING_PROTECTION_SITES_ALLOWED_COOKIES_TITLE},
        {"trackingProtectionSitesAllowedCookiesDescription",

--- a/patches/helium/settings/privacy-page-tweaks.patch
+++ b/patches/helium/settings/privacy-page-tweaks.patch
@@ -1,6 +1,6 @@
 --- a/chrome/app/settings_strings.grdp
 +++ b/chrome/app/settings_strings.grdp
-@@ -1927,6 +1927,12 @@
+@@ -1930,6 +1930,12 @@
    users to manage security settings">
      Security
    </message>
@@ -15,7 +15,7 @@
    </message>
 --- a/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
 +++ b/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
-@@ -1966,9 +1966,9 @@ void AddPrivacyStrings(content::WebUIDat
+@@ -1967,9 +1967,9 @@ void AddPrivacyStrings(content::WebUIDat
         IDS_SETTINGS_ENABLE_DO_NOT_TRACK_DIALOG_LEARN_MORE_ACCESSIBILITY_LABEL},
        // TODO(crbug.com/40122957): This string is no longer used. Remove.
        {"permissionsPageTitle", IDS_SETTINGS_PERMISSIONS},

--- a/patches/helium/settings/update-search-suggest-text.patch
+++ b/patches/helium/settings/update-search-suggest-text.patch
@@ -24,7 +24,7 @@
      Signed in to <ph name="EMAIL">$1<ex>abcd@google.com</ex></ph>
 --- a/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
 +++ b/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
-@@ -1669,8 +1669,8 @@ void AddPersonalizationOptionsStrings(co
+@@ -1670,8 +1670,8 @@ void AddPersonalizationOptionsStrings(co
        {"enablePersonalizationLoggingDesc",
         IDS_SETTINGS_ENABLE_LOGGING_PREF_DESC},
        {"spellingDescription", IDS_SETTINGS_SPELLING_PREF_DESC},

--- a/patches/helium/ui/experiments/compact-action-toolbar.patch
+++ b/patches/helium/ui/experiments/compact-action-toolbar.patch
@@ -66,7 +66,7 @@
  BASE_DECLARE_FEATURE(kAllowWindowDragUsingSystemDragDrop);
 --- a/chrome/browser/ui/views/frame/browser_view.cc
 +++ b/chrome/browser/ui/views/frame/browser_view.cc
-@@ -792,8 +792,12 @@ BrowserView::BrowserView(Browser* browse
+@@ -873,8 +873,12 @@ BrowserView::BrowserView(Browser* browse
  
    top_container_ = AddChildView(std::make_unique<TopContainerView>(this));
  
@@ -81,7 +81,7 @@
  
    if (tabs::IsVerticalTabsFeatureEnabled()) {
      auto vertical_tab_strip_container =
-@@ -1155,7 +1159,8 @@ bool BrowserView::ShouldDrawTabStrip() c
+@@ -1236,7 +1240,8 @@ bool BrowserView::ShouldDrawTabStrip() c
    // since callers may otherwise try to access it. Note that we can't just check
    // this alone, as the tabstrip is created unconditionally even for windows
    // that won't display it.
@@ -91,7 +91,7 @@
  }
  
  bool BrowserView::GetIncognito() const {
-@@ -5097,6 +5102,12 @@ void BrowserView::AddedToWidget() {
+@@ -5178,6 +5183,12 @@ void BrowserView::AddedToWidget() {
  
    toolbar_->Init();
  

--- a/patches/helium/ui/toolbar-button-prefs.patch
+++ b/patches/helium/ui/toolbar-button-prefs.patch
@@ -1,6 +1,6 @@
 --- a/chrome/common/pref_names.h
 +++ b/chrome/common/pref_names.h
-@@ -1336,6 +1336,26 @@ inline constexpr char kSplitViewDragAndD
+@@ -1340,6 +1340,26 @@ inline constexpr char kSplitViewDragAndD
  inline constexpr char kSplitViewDragAndDropNudgeUsedCount[] =
      "browser.split_view_drag_and_drop_nudge_used_count";
  
@@ -29,7 +29,7 @@
  inline constexpr char kGeminiSettings[] = "browser.gemini_settings";
 --- a/chrome/browser/ui/browser_ui_prefs.cc
 +++ b/chrome/browser/ui/browser_ui_prefs.cc
-@@ -125,6 +125,12 @@ void RegisterBrowserUserPrefs(user_prefs
+@@ -127,6 +127,12 @@ void RegisterBrowserUserPrefs(user_prefs
    registry->RegisterBooleanPref(prefs::kPinSplitTabButton, false,
                                  pref_registration_flags);
  
@@ -44,7 +44,7 @@
    registry->RegisterBooleanPref(prefs::kWebAppCreateInAppsMenu, true);
 --- a/chrome/browser/extensions/api/settings_private/prefs_util.cc
 +++ b/chrome/browser/extensions/api/settings_private/prefs_util.cc
-@@ -234,6 +234,18 @@ const PrefsUtil::TypedPrefMap& PrefsUtil
+@@ -236,6 +236,18 @@ const PrefsUtil::TypedPrefMap& PrefsUtil
    (*s_allowlist)[::prefs::kSplitViewDragAndDropEnabled] =
        settings_api::PrefType::kBoolean;
  

--- a/patches/helium/ui/toolbar-window-frame-hit-test.patch
+++ b/patches/helium/ui/toolbar-window-frame-hit-test.patch
@@ -1,6 +1,6 @@
 --- a/chrome/browser/ui/views/frame/browser_view.cc
 +++ b/chrome/browser/ui/views/frame/browser_view.cc
-@@ -4868,6 +4868,18 @@ int BrowserView::NonClientHitTest(const
+@@ -4949,6 +4949,18 @@ int BrowserView::NonClientHitTest(const
      }
    }
  

--- a/patches/series
+++ b/patches/series
@@ -111,6 +111,7 @@ contrib/ungoogled-chromium/disable-ai-search-shortcuts.patch
 contrib/brave/chrome-importer-files.patch
 contrib/brave/custom-importer.patch
 contrib/brave/fix-component-content-settings-store.patch
+contrib/brave/tab-cycling-mru-impl.patch
 
 helium/core/add-zen-importer.patch
 helium/core/disable-unsupported-importers.patch
@@ -187,6 +188,7 @@ helium/core/add-middle-click-autoscroll-flag.patch
 helium/core/webrtc-default-handling-policy.patch
 helium/core/browser-window-context-menu.patch
 helium/core/disable-ntp-footer.patch
+helium/core/tab-cycling-mru.patch
 
 helium/settings/settings-page-icons.patch
 helium/settings/move-search-suggest.patch


### PR DESCRIPTION
closes #111

depends on #528

https://github.com/user-attachments/assets/13b2e0fa-ae73-4cc8-8af2-eda6ac30ca86

