### PR TITLE
helium/ui/cat: fix crash when opening the guest window

### DIFF
--- a/patches/helium/ui/experiments/compact-action-toolbar.patch
+++ b/patches/helium/ui/experiments/compact-action-toolbar.patch
@@ -197,7 +197,7 @@
    show_avatar_button_.Init(
        prefs::kShowAvatarButton, prefs,
        base::BindRepeating(&ToolbarView::OnShowAvatarButtonChanged,
-@@ -573,12 +596,27 @@ void ToolbarView::Init() {
+@@ -573,12 +596,30 @@ void ToolbarView::Init() {
  
    InitLayout();
  
@@ -218,14 +218,17 @@
 +  if (features::IsHeliumCatEnabled()) {
 +    pinned_toolbar_actions_container_->SetProperty(
 +        views::kFlexBehaviorKey, flex_preferred);
-+    extensions_container_->SetProperty(
-+        views::kFlexBehaviorKey, flex_preferred);
++
++    if (extensions_container_) {
++      extensions_container_->SetProperty(
++          views::kFlexBehaviorKey, flex_preferred);
++    }
 +  }
 +
    if (browser_view_->GetSupportsTabStrip()) {
      browser()->GetTabStripModel()->AddObserver(this);
    }
-@@ -703,6 +741,24 @@ bool ToolbarView::IsRectInWindowCaption(
+@@ -703,6 +744,24 @@ bool ToolbarView::IsRectInWindowCaption(
      return gfx::ToEnclosingRect(rect_in_target_coords_f);
    };
  
@@ -250,7 +253,7 @@
    // Check each child view in container_view_ to see if the rect intersects with
    // any clickable elements. If it does, check if the click is actually on that
    // element. False if on a clickable element, true if not on a clickable element.
-@@ -982,8 +1038,12 @@ void ToolbarView::InitLayout() {
+@@ -982,8 +1041,12 @@ void ToolbarView::InitLayout() {
    constexpr int kToolbarActionsFlexOrder = kOrderOffset + 2;
    constexpr int kExtensionsFlexOrder = kOrderOffset + 3;
  
@@ -264,7 +267,7 @@
                                 views::MaximumFlexSizeRule::kUnbounded)
            .WithOrder(kLocationBarFlexOrder);
  
-@@ -999,6 +1059,12 @@ void ToolbarView::InitLayout() {
+@@ -999,6 +1062,12 @@ void ToolbarView::InitLayout() {
    location_bar_->SetProperty(views::kMarginsKey,
                               gfx::Insets::VH(0, location_bar_margin));
  


### PR DESCRIPTION
extensions container is nullptr there, so trying to set its flex property was causing a crash