### PR TITLE
helium/ui: shrink pdf viewer's ui

### DIFF
--- a/patches/helium/ui/pdf-viewer.patch
+++ b/patches/helium/ui/pdf-viewer.patch
@@ -1,0 +1,110 @@
+--- a/chrome/browser/resources/pdf/elements/viewer_page_selector.css
++++ b/chrome/browser/resources/pdf/elements/viewer_page_selector.css
+@@ -14,7 +14,6 @@
+   color: #fff;
+   direction: ltr;
+   display: flex;
+-  font-size: 0.81rem;
+   text-align: center;
+ 
+   --page-selector-spacing: 4px;
+@@ -46,3 +45,8 @@ input {
+ #divider {
+   margin: 0 var(--page-selector-spacing);
+ }
++
++#content,
++input {
++  font-size: 12px;
++}
+--- a/chrome/browser/resources/pdf/elements/viewer_thumbnail.css
++++ b/chrome/browser/resources/pdf/elements/viewer_thumbnail.css
+@@ -29,18 +29,22 @@
+   margin-inline-end: auto;
+   margin-inline-start: auto;
+   width: 108px;
++  outline-offset: 3px;
++  border-radius: 1px;
+ }
+ 
+ :host([is-active]) #thumbnail {
+-  box-shadow: 0 0 0 6px var(--focus-border-color);
++  outline: 2px solid var(--focus-border-color);
+ }
+ 
+ :host(:focus-visible) #thumbnail {
+-  box-shadow: 0 0 0 2px var(--focus-border-color);
++  outline: 2px solid var(--focus-border-color);
++  outline-offset: 4px;
+ }
+ 
+ :host([is-active]:focus-visible) #thumbnail {
+-  box-shadow: 0 0 0 8px var(--focus-border-color);
++  outline: 2px solid var(--focus-border-color);
++  outline-offset: 3px;
+ }
+ 
+ #canvas-container {
+--- a/chrome/browser/resources/pdf/elements/viewer_toolbar.css
++++ b/chrome/browser/resources/pdf/elements/viewer_toolbar.css
+@@ -10,7 +10,7 @@
+  * #css_wrapper_metadata_end */
+ 
+ :host {
+-  --viewer-pdf-toolbar-height: 56px;
++  --viewer-pdf-toolbar-height: 36px;
+   position: relative;
+ }
+ 
+@@ -25,13 +25,13 @@
+   color: white;
+   display: flex;
+   height: var(--viewer-pdf-toolbar-height);
+-  padding: 0 16px;
++  padding: 0 8px;
+ }
+ 
+ #title {
+-  font-size: 0.87rem;
++  font-size: 13px;
+   font-weight: 500;
+-  margin-inline-start: 16px;
++  margin-inline-start: 7px;
+   overflow: hidden;
+   text-overflow: ellipsis;
+   white-space: nowrap;
+@@ -130,6 +130,7 @@ input {
+   padding: 0 4px;
+   text-align: center;
+   width: 5ch;
++  font-size: 12px;
+ }
+ 
+ #fit {
+--- a/chrome/browser/resources/pdf/pdf_viewer.css
++++ b/chrome/browser/resources/pdf/pdf_viewer.css
+@@ -13,7 +13,7 @@
+  * #css_wrapper_metadata_end */
+ 
+ :host {
+-  --viewer-pdf-sidenav-width: 300px;
++  --viewer-pdf-sidenav-width: 180px;
+   display: flex;
+   flex-direction: column;
+   height: 100%;
+--- a/chrome/browser/resources/pdf/elements/viewer_thumbnail_bar.css
++++ b/chrome/browser/resources/pdf/elements/viewer_thumbnail_bar.css
+@@ -14,11 +14,11 @@
+   box-sizing: border-box;
+   height: 100%;
+   overflow: auto;
++  padding-top: 6px;
+   padding-bottom: 24px;
+-  padding-inline-end: var(--viewer-thumbnail-bar-padding-inline-end);
+   text-align: center;
+ }
+ 
+ viewer-thumbnail {
+-  padding-top: 24px;
++  padding-top: 18px;
+ }

--- a/patches/series
+++ b/patches/series
@@ -271,3 +271,4 @@ helium/ui/fix-caption-button-bounds.patch
 helium/ui/find-bar.patch
 helium/ui/remove-zoom-action.patch
 helium/ui/experiments/compact-action-toolbar.patch
+helium/ui/pdf-viewer.patch


### PR DESCRIPTION
- shrunk the toolbar padding
- shrunk the side panel with thumbnails
- fixed different font sizes in the toolbar
- made file title a bit smaller, reduced its margin
- remade the stroke of the selected thumbnail

before:
<img width="1116" height="858" alt="image" src="https://github.com/user-attachments/assets/d7f299c7-c107-4024-88ea-2b61d1a5d203" />

after:
<img width="1115" height="858" alt="image" src="https://github.com/user-attachments/assets/75374cc7-93cc-44f1-807c-331963cde2a8" />

as a result, a lot more content fits on the screen at once!
