### PR TITLE
Lower minimum window width to 375px

### DIFF
--- a/patches/helium/ui/smaller-minimum-window-width.patch
+++ b/patches/helium/ui/smaller-minimum-window-width.patch
@@ -1,0 +1,49 @@
+Index: src/chrome/browser/ui/views/frame/layout/browser_view_layout.h
+===================================================================
+--- src.orig/chrome/browser/ui/views/frame/layout/browser_view_layout.h
++++ src/chrome/browser/ui/views/frame/layout/browser_view_layout.h
+@@ -93,7 +93,7 @@ class BrowserViewLayout : public views::
+   // very small window, even on large monitors (which is why a minimum height is
+   // not specified). This value is used for the main browser window only, not
+   // for popups.
+-  static constexpr int kMainBrowserContentsMinimumWidth = 500;
++  static constexpr int kMainBrowserContentsMinimumWidth = 375;
+ 
+   // The width of the vertical tab strip.
+   static constexpr int kVerticalTabStripWidth = 240;
+Index: src/chrome/browser/ui/views/frame/tab_strip_region_view.cc
+===================================================================
+--- src.orig/chrome/browser/ui/views/frame/tab_strip_region_view.cc
++++ src/chrome/browser/ui/views/frame/tab_strip_region_view.cc
+@@ -559,7 +559,7 @@ gfx::Size TabStripRegionView::GetMinimum
+   gfx::Size tab_strip_min_size = tab_strip_->GetMinimumSize();
+   // Cap the tabstrip minimum width to a reasonable value so browser windows
+   // aren't forced to grow arbitrarily wide.
+-  const int max_min_width = 520;
++  const int max_min_width = 375;
+   tab_strip_min_size.set_width(
+       std::min(max_min_width, tab_strip_min_size.width()));
+   return tab_strip_min_size;
+Index: src/chrome/browser/ui/views/toolbar/toolbar_view.cc
+===================================================================
+--- src.orig/chrome/browser/ui/views/toolbar/toolbar_view.cc
++++ src/chrome/browser/ui/views/toolbar/toolbar_view.cc
+@@ -150,6 +150,7 @@ DEFINE_UI_CLASS_PROPERTY_KEY(bool, kActi
+ namespace {
+ 
+ constexpr int kPreferredCompactWidth = 350;
++constexpr int kCompactNavButtonsMinWidth = 500;
+ 
+ // Gets the display mode for a given browser.
+ ToolbarView::DisplayMode GetDisplayMode(Browser* browser) {
+@@ -966,6 +967,10 @@ void ToolbarView::Layout(PassKey) {
+   if (toolbar_controller_) {
+     // Need to determine whether the overflow button should be visible, and only
+     // update it if the visibility changes.
++    const bool hide_nav_buttons = width() < kCompactNavButtonsMinWidth;
++    back_->SetVisible(!hide_nav_buttons && show_back_button_.GetValue());
++    forward_->SetVisible(!hide_nav_buttons && show_forward_button_.GetValue());
++    reload_->SetVisible(!hide_nav_buttons && show_reload_button_.GetValue());
+     const bool was_overflow_button_visible =
+         toolbar_controller_->overflow_button()->GetVisible();
+     const bool show_overflow_button =

--- a/patches/series
+++ b/patches/series
@@ -271,4 +271,5 @@ helium/ui/fix-caption-button-bounds.patch
 helium/ui/find-bar.patch
 helium/ui/remove-zoom-action.patch
 helium/ui/experiments/compact-action-toolbar.patch
+helium/ui/smaller-minimum-window-width.patch
 helium/ui/pdf-viewer.patch


### PR DESCRIPTION
For your pull request to not get closed without review, please confirm that:

- [ ] An issue exists where the maintainers agreed that this should be implemented.
      If such issue did not exist before, I opened one.
- [x] I tested that my contribution works locally, and does not break anything,
      otherwise I have marked my PR as draft.
- [ ] If my contribution is non-trivial, I did not use AI to write most of it.
- [x] I understand that I will be permanently banned from interacting with this
      organization if I lied by checking any of these checkboxes.

Tested on (check one or more):
- [ ] Windows
- [x] macOS
- [ ] Linux

---

This PR changes the minimum window width such that the browser can size beyond 500px to make it easier to test responsive viewports without being forced to open devtools et al.

All of the research of this and the code was written by Codex but it seems trivial enough. I've been testing it on macOS. 

To give some added context, the [`BrowserViewLayout::GetMinimumSize`](https://chromium.googlesource.com/chromium/src/+/refs/tags/129.0.6668.85/chrome/browser/ui/views/frame/browser_view_layout.cc#237) method is responsible for computing the minimum viewport and it does that by taking multiple minimums into accounts. In addition to changing two hardcoded minimum widths, the toolbar was constrained by the omnibox minimum characters.

However, reducing the omnibox min chars clashes with [this change](https://github.com/imputnet/helium/commit/e9de843abe01ab5ed74df9a30f8571cc07c9b00f#diff-2826944ab8480d94ea497b4162f31b7ef9781cdfc282596674f87906931560c1R244-R245) in the experimental one-line toolbar. To resolve this I'm proposing we hide the back, forward, and refresh buttons in these ultra-small viewports (<500px) and keep the min chars as-is.

## Before

<img width="1384" height="2092" alt="CleanShot 2025-12-18 at 23 35 05@2x" src="https://github.com/user-attachments/assets/58874a4b-4a1e-4536-8c8e-6789f6ba514c" />

## After

https://github.com/user-attachments/assets/d0c54395-e2dc-4de8-922e-e7e9ad883547




