### PR TITLE
deps: update onboarding

### DIFF
--- a/deps.ini
+++ b/deps.ini
@@ -7,10 +7,10 @@ sha256 = 00a87050fa3f941d04d67fb5763991e0b8ea399a88b505ab0e56dd263f06864c
 output_path = ./third_party/search_engines_data/resources_internal
 
 [onboarding]
-version = 202601021812
+version = 202601021937
 url = https://github.com/imputnet/helium-onboarding/releases/download/%(version)s/helium-onboarding-%(version)s.tar.gz
 download_filename = onboarding-page-%(version)s.tar.gz
-sha256 = c184dd8ece06c032c7202efd1c1da5a64f287f25c938e552fb43b864444ca1c2
+sha256 = c8a1f906cf6461179d4fd311c529f0f8e01fb21b63ef179f593a24190c5dca80
 output_path = ./components/helium_onboarding
 
 # If you are bumping this, you *NEED* to re-strip the assets.json


### PR DESCRIPTION
fucked up the privacy marker alignment in the previous version, my bad

before:
<img width="257" height="118" alt="image" src="https://github.com/user-attachments/assets/15328dc8-4ac0-44a2-81a4-afa3efb3b34c" />

after:
<img width="284" height="120" alt="image" src="https://github.com/user-attachments/assets/32d550a5-599d-423a-be9a-94cbc547138e" />
