### PR TITLE
helium/ui: add specific error for disabled services extension error

### DIFF
--- a/patches/helium/ui/add-specific-error-for-disabled-extension-downloads.patch
+++ b/patches/helium/ui/add-specific-error-for-disabled-extension-downloads.patch
@@ -1,0 +1,186 @@
+--- a/chrome/browser/download/download_commands.h
++++ b/chrome/browser/download/download_commands.h
+@@ -47,8 +47,9 @@ class DownloadCommands {
+     OPEN_WITH_MEDIA_APP = 21,  // Open file using the ChromeOS media app.
+     EDIT_WITH_MEDIA_APP = 22,  // Open file using the ChromeOS media app with
+                                // an editing hint.
++    OPEN_HELIUM_SERVICES = 23,  // Open the Services page in settings.
+ 
+-    kMaxValue = EDIT_WITH_MEDIA_APP,  // Keep last.
++    kMaxValue = OPEN_HELIUM_SERVICES,  // Keep last.
+   };
+ 
+   // |model| must outlive DownloadCommands.
+--- a/chrome/browser/download/download_ui_model.cc
++++ b/chrome/browser/download/download_ui_model.cc
+@@ -32,6 +32,7 @@
+ #include "components/download/public/common/download_danger_type.h"
+ #include "components/enterprise/common/proto/connectors.pb.h"
+ #include "components/google/core/common/google_util.h"
++#include "components/helium_services/helium_services_helpers.h"
+ #include "components/safe_browsing/buildflags.h"
+ #include "components/safe_browsing/core/common/safebrowsing_referral_methods.h"
+ #include "components/strings/grit/components_strings.h"
+@@ -629,6 +630,7 @@ bool DownloadUIModel::IsCommandEnabled(
+     case DownloadCommands::BYPASS_DEEP_SCANNING_AND_OPEN:
+     case DownloadCommands::RETRY:
+     case DownloadCommands::CANCEL_DEEP_SCAN:
++    case DownloadCommands::OPEN_HELIUM_SERVICES:
+       return true;
+     case DownloadCommands::REVIEW:
+ #if BUILDFLAG(ENTERPRISE_CONTENT_ANALYSIS)
+@@ -671,6 +673,7 @@ bool DownloadUIModel::IsCommandChecked(
+     case DownloadCommands::CANCEL_DEEP_SCAN:
+     case DownloadCommands::OPEN_WITH_MEDIA_APP:
+     case DownloadCommands::EDIT_WITH_MEDIA_APP:
++    case DownloadCommands::OPEN_HELIUM_SERVICES:
+       return false;
+   }
+   return false;
+@@ -721,6 +724,14 @@ void DownloadUIModel::ExecuteCommand(Dow
+                                  ui::PAGE_TRANSITION_LINK, false),
+           /*navigation_handle_callback=*/{});
+       break;
++    case DownloadCommands::OPEN_HELIUM_SERVICES:
++      download_commands->GetBrowser()->OpenURL(
++          content::OpenURLParams(GURL("chrome://settings/privacy/services"),
++                                 content::Referrer(),
++                                 WindowOpenDisposition::NEW_FOREGROUND_TAB,
++                                 ui::PAGE_TRANSITION_LINK, false),
++          /*navigation_handle_callback=*/{});
++      break;
+     case DownloadCommands::OPEN_SAFE_BROWSING_SETTING:
+       chrome::ShowSafeBrowsingEnhancedProtectionWithIph(
+           download_commands->GetBrowser(),
+@@ -1200,6 +1211,9 @@ DownloadUIModel::BubbleStatusTextBuilder
+       break;
+     case FailState::FILE_BLOCKED:
+       string_id = IDS_POLICY_ACTION_BLOCKED_BY_ORGANIZATION;
++      if (model_->GetURL().host() == helium::GetDummyURL().host()) {
++        string_id = IDS_DOWNLOAD_BUBBLE_INTERRUPTED_EXTENSION_DL_DISABLED;
++      }
+       break;
+     case FailState::FILE_SECURITY_CHECK_FAILED:
+       string_id = IDS_DOWNLOAD_INTERRUPTED_STATUS_SECURITY_CHECK_FAILED;
+--- a/chrome/browser/ui/download/download_bubble_security_view_info.cc
++++ b/chrome/browser/ui/download/download_bubble_security_view_info.cc
+@@ -17,6 +17,7 @@
+ #include "chrome/grit/branded_strings.h"
+ #include "chrome/grit/generated_resources.h"
+ #include "components/enterprise/buildflags/buildflags.h"
++#include "components/helium_services/helium_services_helpers.h"
+ #include "components/offline_items_collection/core/fail_state.h"
+ #include "components/vector_icons/vector_icons.h"
+ #include "ui/base/l10n/l10n_util.h"
+@@ -223,6 +224,15 @@ void DownloadBubbleSecurityViewInfo::Pop
+     case FailState::FILE_BLOCKED:
+       warning_summary_ = l10n_util::GetStringUTF16(
+           IDS_DOWNLOAD_BUBBLE_INTERRUPTED_SUBPAGE_SUMMARY_BLOCKED_ORGANIZATION);
++
++      if (model.GetURL().host() == helium::GetDummyURL().host()) {
++        warning_summary_ = l10n_util::GetStringUTF16(
++            IDS_DOWNLOAD_BUBBLE_INTERRUPTED_SUBPAGE_SUMMARY_HELIUM_SERVICES_DISABLED);
++        PopulatePrimarySubpageButton(
++            l10n_util::GetStringUTF16(
++                IDS_SYNC_ERROR_USER_MENU_CONFIRM_SYNC_SETTINGS_BUTTON),
++            DownloadCommands::Command::OPEN_HELIUM_SERVICES);
++      }
+       return;
+     case FailState::FILE_NAME_TOO_LONG:
+       warning_summary_ = l10n_util::GetStringUTF16(
+--- a/chrome/app/generated_resources.grd
++++ b/chrome/app/generated_resources.grd
+@@ -3039,6 +3039,10 @@ are declared in tools/grit/grit_args.gni
+                desc="Status text for a download item that was interrupted because the file path name is too long.">
+         File name or location is too long
+       </message>
++      <message name="IDS_DOWNLOAD_BUBBLE_INTERRUPTED_SUBPAGE_SUMMARY_HELIUM_SERVICES_DISABLED"
++               desc="Subpage summary text for a extension download item that was interrupted because Helium services are disabled.">
++        Extension downloads are disabled. Enable this feature in Helium services settings and try again.
++      </message>
+       <message name="IDS_DOWNLOAD_BUBBLE_INTERRUPTED_SUBPAGE_SUMMARY_PATH_TOO_LONG"
+                desc="Subpage summary text for a download item that was interrupted because the file path name is too long.">
+         Try using a shorter file name or saving to a different folder
+@@ -3067,6 +3071,10 @@ are declared in tools/grit/grit_args.gni
+                desc="Status text for a download item that had something go wrong.">
+         Something went wrong
+       </message>
++      <message name="IDS_DOWNLOAD_BUBBLE_INTERRUPTED_EXTENSION_DL_DISABLED"
++               desc="Status text for when Helium services extension downloading is disabled.">
++        Extension downloads are disabled
++      </message>
+       <message name="IDS_DOWNLOAD_BUBBLE_INTERRUPTED_STATUS_NETWORK_ERROR"
+                desc="Status text for a download item with a network error.">
+         Check internet connection
+--- a/chrome/browser/download/bubble/download_bubble_ui_controller.cc
++++ b/chrome/browser/download/bubble/download_bubble_ui_controller.cc
+@@ -337,6 +337,7 @@ void DownloadBubbleUIController::Process
+     case DownloadCommands::ALWAYS_OPEN_TYPE:
+     case DownloadCommands::CANCEL_DEEP_SCAN:
+     case DownloadCommands::OPEN_SAFE_BROWSING_SETTING:
++    case DownloadCommands::OPEN_HELIUM_SERVICES:
+       commands.ExecuteCommand(command);
+       break;
+     default:
+--- a/chrome/browser/download/download_item_model.cc
++++ b/chrome/browser/download/download_item_model.cc
+@@ -708,6 +708,7 @@ bool DownloadItemModel::IsCommandEnabled
+     case DownloadCommands::REVIEW:
+     case DownloadCommands::RETRY:
+     case DownloadCommands::CANCEL_DEEP_SCAN:
++    case DownloadCommands::OPEN_HELIUM_SERVICES:
+       return DownloadUIModel::IsCommandEnabled(download_commands, command);
+   }
+   NOTREACHED();
+@@ -751,6 +752,7 @@ bool DownloadItemModel::IsCommandChecked
+     case DownloadCommands::CANCEL_DEEP_SCAN:
+     case DownloadCommands::OPEN_WITH_MEDIA_APP:
+     case DownloadCommands::EDIT_WITH_MEDIA_APP:
++    case DownloadCommands::OPEN_HELIUM_SERVICES:
+       return false;
+   }
+   return false;
+@@ -858,6 +860,7 @@ void DownloadItemModel::ExecuteCommand(D
+     case DownloadCommands::RETRY:
+     case DownloadCommands::OPEN_WITH_MEDIA_APP:
+     case DownloadCommands::EDIT_WITH_MEDIA_APP:
++    case DownloadCommands::OPEN_HELIUM_SERVICES:
+       DownloadUIModel::ExecuteCommand(download_commands, command);
+       break;
+     case DownloadCommands::DEEP_SCAN: {
+--- a/chrome/browser/download/offline_item_model.cc
++++ b/chrome/browser/download/offline_item_model.cc
+@@ -333,6 +333,7 @@ bool OfflineItemModel::IsCommandEnabled(
+     case DownloadCommands::REVIEW:
+     case DownloadCommands::RETRY:
+     case DownloadCommands::CANCEL_DEEP_SCAN:
++    case DownloadCommands::OPEN_HELIUM_SERVICES:
+       return DownloadUIModel::IsCommandEnabled(download_commands, command);
+   }
+   NOTREACHED();
+@@ -368,6 +369,7 @@ bool OfflineItemModel::IsCommandChecked(
+     case DownloadCommands::CANCEL_DEEP_SCAN:
+     case DownloadCommands::OPEN_WITH_MEDIA_APP:
+     case DownloadCommands::EDIT_WITH_MEDIA_APP:
++    case DownloadCommands::OPEN_HELIUM_SERVICES:
+       return false;
+   }
+   return false;
+@@ -401,6 +403,7 @@ void OfflineItemModel::ExecuteCommand(Do
+     case DownloadCommands::CANCEL_DEEP_SCAN:
+     case DownloadCommands::OPEN_WITH_MEDIA_APP:
+     case DownloadCommands::EDIT_WITH_MEDIA_APP:
++    case DownloadCommands::OPEN_HELIUM_SERVICES:
+       DownloadUIModel::ExecuteCommand(download_commands, command);
+       break;
+   }
+--- a/chrome/browser/download/download_stats.cc
++++ b/chrome/browser/download/download_stats.cc
+@@ -173,6 +173,7 @@ DownloadUiContextMenuAction DownloadComm
+     case DownloadCommands::Command::BYPASS_DEEP_SCANNING:
+     case DownloadCommands::Command::OPEN_WITH_MEDIA_APP:
+     case DownloadCommands::Command::EDIT_WITH_MEDIA_APP:
++    case DownloadCommands::Command::OPEN_HELIUM_SERVICES:
+       NOTREACHED();
+   }
+ }

--- a/patches/helium/ui/ublock-show-in-settings.patch
+++ b/patches/helium/ui/ublock-show-in-settings.patch
@@ -87,7 +87,7 @@
    };
 --- a/chrome/app/generated_resources.grd
 +++ b/chrome/app/generated_resources.grd
-@@ -13444,6 +13444,9 @@ Check your passwords anytime in <ph name
+@@ -13452,6 +13452,9 @@ Check your passwords anytime in <ph name
          <message name="IDS_EXTENSIONS_INSTALL_LOCATION_SHARED_MODULE" desc="The text explaining the the installation of the extension was because of extensions that depend on this shared module">
            Installed because of dependent extension(s).
          </message>

--- a/patches/series
+++ b/patches/series
@@ -229,6 +229,7 @@ helium/ui/side-panel.patch
 helium/ui/remove-dead-toolbar-actions.patch
 helium/ui/remove-dead-profile-actions.patch
 helium/ui/clean-up-installed-extension-bubble.patch
+helium/ui/add-specific-error-for-disabled-extension-downloads.patch
 helium/ui/selected-keyword-view.patch
 helium/ui/bookmark-button-bg-fix.patch
 helium/ui/restyle-ntp-tiles.patch


### PR DESCRIPTION
before:

https://github.com/user-attachments/assets/effe6cc5-2d93-4cb1-add1-0b4303ed7d8e

after:

https://github.com/user-attachments/assets/e46e7849-4cca-4848-9b29-90b8a745df5f

