### PR TITLE
feat(search): add Brave Search as prepopulated engine

### DIFF
--- a/patches/helium/core/search/add-brave-search.patch
+++ b/patches/helium/core/search/add-brave-search.patch
@@ -1,0 +1,31 @@
+# Add Brave Search as a prepopulated search engine
+#
+--- a/third_party/search_engines_data/resources/definitions/prepopulated_engines.json
++++ b/third_party/search_engines_data/resources/definitions/prepopulated_engines.json
+@@ -49,6 +49,16 @@
+       "id": 12
+     },
+ 
++    "brave_search": {
++      "name": "Brave",
++      "keyword": "search.brave.com",
++      "favicon_url": "https://cdn.search.brave.com/serp/v2/static/brand/favicon.ico",
++      "search_url": "https://search.brave.com/search?q={searchTerms}",
++      "suggest_url": "https://search.brave.com/api/suggest?q={searchTerms}",
++      "type": "SEARCH_ENGINE_OTHER",
++      "id": 600
++    },
++
+     "coccoc": {
+       "name": "Cốc Cốc",
+       "keyword": "coccoc.com",
+--- a/third_party/search_engines_data/resources/definitions/regional_settings.json
++++ b/third_party/search_engines_data/resources/definitions/regional_settings.json
+@@ -6,6 +6,7 @@
+     "ZZ": {
+       // Default
+       "search_engines": [
++          "&brave_search",
+           "&duckduckgo",
+           "&ecosia",
+           "&bing",

--- a/patches/series
+++ b/patches/series
@@ -119,6 +119,7 @@ helium/core/search/engine-defaults.patch
 helium/core/search/fix-search-engine-icons.patch
 helium/core/search/force-eu-search-features.patch
 helium/core/search/remove-description-snippet-deps.patch
+helium/core/search/add-brave-search.patch
 
 helium/settings/setup-behavior-settings-page.patch
 helium/core/keyboard-shortcuts.patch


### PR DESCRIPTION
For your pull request to not get closed without review, please confirm that:

- [x] An issue exists where the maintainers agreed that this should be implemented.
      If such issue did not exist before, I opened one.
- [x] I tested that my contribution works locally, and does not break anything,
      otherwise I have marked my PR as draft.
- [x] If my contribution is non-trivial, I did not use AI to write most of it.
- [x] I understand that I will be permanently banned from interacting with this
      organization if I lied by checking any of these checkboxes.

Tested on (check one or more):
- [ ] Windows
- [ ] macOS
- [x] Linux

---

Add Brave Search (search.brave.com) as an out-of-the-box search engine option.

**Changes:**
- Add `brave_search` engine definition to `prepopulated_engines.json`
- Include Brave Search in default search engines list (`regional_settings.json`)

Fixes #92