### PR TITLE
helium/core/components: allow WidevineCdm component

### DIFF
--- a/patches/helium/core/component-updates.patch
+++ b/patches/helium/core/component-updates.patch
@@ -147,6 +147,7 @@
 +      base::sorted_unique,
 +        {
 +          "hfnkpimlhhgieaddgfemjhofmfblmnib", // CRLSet
++          "oimompecagnajdejgnnjijobebaeigek", // WidevineCdm
 +        }
 +    );
 +


### PR DESCRIPTION
For your pull request to not get closed without review, please confirm that:

- [x]  An issue exists where the maintainers agreed that this should be implemented.
- [ ] If such issue did not exist before, I opened one.
- [x]  I tested that my contribution works locally, and does not break anything, otherwise I have marked my PR as draft.
- [x] If my contribution is non-trivial, I did not use AI to write most of it.
- [x]  I understand that I will be permanently banned from interacting with this
organization if I lied by checking any of these checkboxes.

Tested on (check one or more):

- [ ]  Windows
- [x] macOS
- [ ] Linux

## Summary

- Add WidevineCdm (`oimompecagnajdejgnnjijobebaeigek`) to the allowed components list

This enables users to sideload Widevine CDM for DRM content playback on streaming services like Netflix, Disney+, Peacock, etc.

## Context

In v0.7.4.1, component installers were restricted to an allowlist containing only CRLSet. This broke the ability to sideload Widevine CDM, which previously worked for users who manually copied the WidevineCdm folder from Google Chrome.

A maintainer acknowledged in #669 that "we could probably re-enable the widevine component even though we don't/can't ship it."

This PR does exactly that - it adds the Widevine CDM component ID to the allowlist while keeping all other components restricted.

## Test plan

- [ ] Build Helium with this patch
- [ ] Copy WidevineCdm from Google Chrome to Helium's Libraries folder
- [ ] Verify WidevineCdm appears in `helium://components/`
- [ ] Test DRM playback on a streaming service

Fixes #669