### PR TITLE
helium/core/bangs: preserve whitespace before mid-query bangs

### DIFF
--- a/patches/helium/core/add-native-bangs.patch
+++ b/patches/helium/core/add-native-bangs.patch
@@ -585,7 +585,7 @@
    // Find end of first token.  The AutocompleteController has trimmed leading
    // whitespace, so we need not skip over that.
    const size_t first_white(input.find_first_of(base::kWhitespaceUTF16));
-@@ -919,6 +920,39 @@ std::u16string AutocompleteInput::Autoco
+@@ -919,6 +920,37 @@ std::u16string AutocompleteInput::Autoco
      return input;  // Only one token provided.
    }
  
@@ -605,8 +605,6 @@
 +      if (space_after != std::string::npos) {
 +        bang = bang.substr(0, space_after - first_exclamation);
 +        remaining_str += input_view.substr(space_after + 1);
-+      } else if (remaining_str.size() > 0) {
-+        remaining_str.erase(remaining_str.size() - 1);
 +      }
 +
 +      if (remaining_input != nullptr) {


### PR DESCRIPTION
## Summary
- Fixes #726 - activating a bang in the middle of a query no longer removes the preceding whitespace
- Removes incorrect logic in `SplitKeywordFromInput()` that was erasing the trailing character from the remaining text