### PR TITLE
domain_regex.list: exclude chromiumapp.org from substitution

### DIFF
--- a/domain_regex.list
+++ b/domain_regex.list
@@ -2,7 +2,7 @@ fonts(\\*?)\.googleapis(\\*?)\.com#f0ntz\g<1>.9oo91e8p1\g<2>.qjz9zk
 google([A-Za-z\-]*?\\*?)\.com(?!mon)#9oo91e\g<1>.qjz9zk
 gstatic([A-Za-z\-]*?\\*?)\.com#95tat1c\g<1>.qjz9zk
 chrome([A-Za-z\-]*?\\*?)\.com(?!ponent)#ch40me\g<1>.qjz9zk
-chromium([A-Za-z\-]*?\\*?)\.org#ch40m1um\g<1>.qjz9zk
+chromium(?!app)([A-Za-z\-]*?\\*?)\.org#ch40m1um\g<1>.qjz9zk
 mozilla([A-Za-z\-]*?\\*?)\.org#m0z111a\g<1>.qjz9zk
 facebook([A-Za-z\-]*?\\*?)\.com#f8c3b00k\g<1>.qjz9zk
 appspot([A-Za-z\-]*?\\*?)\.com#8pp2p8t\g<1>.qjz9zk

--- a/domain_substitution.list
+++ b/domain_substitution.list
@@ -1068,7 +1068,6 @@ chrome/browser/extensions/api/extension_action/browser_action_interactive_test.c
 chrome/browser/extensions/api/extension_action/extension_action_apitest.cc
 chrome/browser/extensions/api/feedback_private/feedback_browsertest.cc
 chrome/browser/extensions/api/identity/identity_apitest.cc
-chrome/browser/extensions/api/identity/identity_launch_web_auth_flow_function.cc
 chrome/browser/extensions/api/image_writer_private/removable_storage_provider.cc
 chrome/browser/extensions/api/image_writer_private/removable_storage_provider_linux.cc
 chrome/browser/extensions/api/messaging/externally_connectable_messaging_apitest.cc
@@ -2322,7 +2321,6 @@ chrome/common/extensions/api/enterprise_device_attributes.idl
 chrome/common/extensions/api/file_system_provider.idl
 chrome/common/extensions/api/gcm.json
 chrome/common/extensions/api/generated_externs_list.txt
-chrome/common/extensions/api/identity.idl
 chrome/common/extensions/api/instance_id.json
 chrome/common/extensions/api/printing.idl
 chrome/common/extensions/api/privacy.json
@@ -2475,7 +2473,6 @@ chrome/renderer/extensions/api/extension_hooks_delegate_unittest.cc
 chrome/renderer/google_accounts_private_api_extension.h
 chrome/renderer/media/flash_embed_rewrite.cc
 chrome/renderer/media/flash_embed_rewrite_unittest.cc
-chrome/renderer/resources/extensions/identity_custom_bindings.js
 chrome/renderer/searchbox/searchbox.h
 chrome/renderer/searchbox/searchbox_extension.cc
 chrome/renderer/searchbox/searchbox_extension.h
@@ -3497,7 +3494,6 @@ components/policy/test/data/pref_mapping/DisabledSchemes.json
 components/policy/test/data/pref_mapping/DnsOverHttpsExcludedDomains.json
 components/policy/test/data/pref_mapping/DnsOverHttpsIncludedDomains.json
 components/policy/test/data/pref_mapping/ExtensionInstallForcelist.json
-components/policy/test/data/pref_mapping/ExtensionOAuthRedirectUrls.json
 components/policy/test/data/pref_mapping/ExtensionSettings.json
 components/policy/test/data/pref_mapping/FloatingSsoDomainBlocklist.json
 components/policy/test/data/pref_mapping/FloatingSsoDomainBlocklistExceptions.json


### PR DESCRIPTION
fixes #545 (related: ungoogled-software/ungoogled-chromium#3597)

used by chromium for extension oauth flow. chromium just intercepts the request and takes the token