### PR TITLE
helium/cat: prevent profile button from being collapsed

### DIFF
--- a/patches/helium/ui/experiments/compact-action-toolbar.patch
+++ b/patches/helium/ui/experiments/compact-action-toolbar.patch
@@ -364,3 +364,41 @@
      return gfx::Size(27, 0);
    }
  };
+--- a/chrome/browser/ui/views/toolbar/toolbar_controller.cc
++++ b/chrome/browser/ui/views/toolbar/toolbar_controller.cc
+@@ -24,6 +24,7 @@
+ #include "chrome/browser/ui/color/chrome_color_id.h"
+ #include "chrome/browser/ui/toolbar/pinned_toolbar/pinned_toolbar_actions_model.h"
+ #include "chrome/browser/ui/toolbar_controller_util.h"
++#include "chrome/browser/ui/ui_features.h"
+ #include "chrome/browser/ui/views/contextual_tasks/contextual_tasks_button.h"
+ #include "chrome/browser/ui/views/side_panel/side_panel_action_callback.h"
+ #include "chrome/browser/ui/views/side_panel/side_panel_enums.h"
+@@ -297,15 +298,18 @@ ToolbarController::GetDefaultResponsiveE
+                                             nullptr,
+ #endif  // BUILDFLAG(ENABLE_WEBUI_TAB_STRIP)
+                                             kToolbarNewTabButtonElementId),
+-           /*is_section_end=*/true),
+-       ToolbarController::ResponsiveElementInfo(
+-           ToolbarController::ElementIdInfo(
+-               kToolbarAvatarButtonElementId,
+-               IDS_OVERFLOW_MENU_ITEM_TEXT_PROFILE,
+-               is_incognito ? (&kIncognitoRefreshMenuIcon)
+-                            : (&kUserAccountAvatarRefreshIcon),
+-               kToolbarAvatarButtonElementId, kToolbarAvatarBubbleElementId),
+-           /*is_section_end=*/false)});
++           /*is_section_end=*/true)});
++
++  if (!features::IsHeliumCatEnabled()) {
++    elements.push_back(ToolbarController::ResponsiveElementInfo(
++        ToolbarController::ElementIdInfo(
++            kToolbarAvatarButtonElementId, IDS_OVERFLOW_MENU_ITEM_TEXT_PROFILE,
++            is_incognito ? (&kIncognitoRefreshMenuIcon)
++                         : (&kUserAccountAvatarRefreshIcon),
++            kToolbarAvatarButtonElementId, kToolbarAvatarBubbleElementId),
++        /*is_section_end=*/false));
++  }
++
+   return elements;
+ }
+ 


### PR DESCRIPTION
Fixes #440
Fixes (maybe) #657

before:

https://github.com/user-attachments/assets/785c3358-d0a5-4e69-8e39-1bfc274f15f4

after:

https://github.com/user-attachments/assets/084e1ae8-bc4b-4dd6-ad28-e484da02ddc8

