### PR TITLE
helium/core: add component to remove webstore nags

### DIFF
--- a/patches/helium/core/fixups-chrome-webstore-script.patch
+++ b/patches/helium/core/fixups-chrome-webstore-script.patch
@@ -1,0 +1,89 @@
+--- a/components/extstore_fixups/BUILD.gn
++++ b/components/extstore_fixups/BUILD.gn
+@@ -16,6 +16,7 @@ generate_grd("extstore_fixups_grd") {
+     input_files_base_dir = rebase_path(".", "//")
+     input_files = [
+         "manifest.json",
++        "chrome-webstore.js",
+     ]
+ }
+ 
+--- a/components/extstore_fixups/manifest.json
++++ b/components/extstore_fixups/manifest.json
+@@ -9,5 +9,10 @@
+   "version": "0.0.0",
+   "manifest_version": 3,
+   "content_scripts": [
++    {
++      "matches": [ "https://chromewebstore.google.com/*" ],
++      "run_at": "document_start",
++      "js": [ "chrome-webstore.js" ]
++    }
+   ]
+ }
+--- /dev/null
++++ b/components/extstore_fixups/chrome-webstore.js
+@@ -0,0 +1,63 @@
++// Copyright 2025 The Helium Authors
++// You can use, redistribute, and/or modify this source code under
++// the terms of the GPL-3.0 license that can be found in the LICENSE file.
++
++(() => {
++  const PROMO_POPUP_SELECTOR = 'header > [aria-labelledby=promo-header]';
++  const SWITCH_NAG_SELECTOR = 'main section [aria-label=Info]';
++  const SWITCH_BTN_SELECTOR = 'button[aria-label^=\'Switch to Chrome\']';
++  const removeChromeNags = () => {
++    const promoPopup = document.querySelector(PROMO_POPUP_SELECTOR);
++    if (promoPopup) {
++      promoPopup.remove();
++    }
++
++    const switchNag = document.querySelector(SWITCH_NAG_SELECTOR);
++    if (switchNag && switchNag.querySelector(SWITCH_BTN_SELECTOR)) {
++      switchNag.remove();
++    }
++  };
++
++  const replaceDownloadButtonText = (el) => {
++    if (el.nodeType === Node.TEXT_NODE) {
++      if (!el.nodeValue?.includes('Chrome')) {
++        return false;
++      }
++
++      el.nodeValue = el.nodeValue.replace('Chrome', 'Helium');
++      return true;
++    } else if (el.childNodes) {
++      for (const node of el.childNodes) {
++        if (replaceDownloadButtonText(node)) {
++          return true;
++        }
++      }
++    }
++
++    return false;
++  };
++
++  const changeDownloadButtonText = () => {
++    const mainTitles = document.querySelectorAll('main section h1');
++
++    for (const mainTitleEl of mainTitles) {
++      const downloadButton =
++          mainTitleEl?.parentElement?.parentElement?.querySelector('button');
++      if (!downloadButton || !downloadButton.textContent?.includes('Chrome')) {
++        continue;
++      }
++
++      if (replaceDownloadButtonText(downloadButton)) {
++        break;
++      }
++    }
++  };
++
++  const handleChanges = () => {
++    removeChromeNags();
++    changeDownloadButtonText();
++  };
++
++  const observer = new MutationObserver(handleChanges);
++  observer.observe(document, {childList: true, subtree: true});
++})();

--- a/patches/helium/core/fixups-component-setup.patch
+++ b/patches/helium/core/fixups-component-setup.patch
@@ -1,0 +1,198 @@
+--- /dev/null
++++ b/components/extstore_fixups/BUILD.gn
+@@ -0,0 +1,37 @@
++# Copyright 2025 The Helium Authors
++# You can use, redistribute, and/or modify this source code under
++# the terms of the GPL-3.0 license that can be found in the LICENSE file.
++
++import("//ui/webui/resources/tools/generate_grd.gni")
++import("//tools/grit/grit_rule.gni")
++
++generated_grd = "$target_gen_dir/resources.grd"
++
++generate_grd("extstore_fixups_grd") {
++    out_grd = generated_grd
++
++    grd_prefix = "extstore_fixups"
++    resource_path_prefix = "extstore_fixups"
++
++    input_files_base_dir = rebase_path(".", "//")
++    input_files = [
++        "manifest.json",
++    ]
++}
++
++grit("extstore_fixups") {
++    source = generated_grd
++
++    # Required because the .grd is generated.
++    enable_input_discovery_for_gn_analyze = false
++    output_dir = "$target_gen_dir/resources"
++
++    outputs = [
++        "grit/extstore_fixups_resources.h",
++        "grit/extstore_fixups_resources_map.cc",
++        "grit/extstore_fixups_resources_map.h",
++        "extstore_fixups_resources.pak"
++    ]
++
++    deps = [":extstore_fixups_grd"]
++}
+--- /dev/null
++++ b/components/extstore_fixups/manifest.json
+@@ -0,0 +1,13 @@
++// Copyright 2025 The Helium Authors
++// You can use, redistribute, and/or modify this source code under
++// the terms of the GPL-3.0 license that can be found in the LICENSE file.
++
++{
++  "name": "extstore-fixups",
++  // chrome-extension://jfnekidfgkhnfagaabpddmioknbjglgp
++  "key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDGyNfoa6gmayvnBUHaYz2fNyPT7CIj6e5VccAZcIbpM/w9bhshiU0zxe0Ci+oLzHy3E/mObNM1IrXhHAQZno7H3frUxTH+m2eIGiwcqLfJkaQFkXvSoInpsG2N3Q74W6YN3mKk7rBAE8PQT1Nyh5H8AmIaWRvLz1+vcowpPNjU/QIDAQAB",
++  "version": "0.0.0",
++  "manifest_version": 3,
++  "content_scripts": [
++  ]
++}
+--- /dev/null
++++ b/components/extstore_fixups/extension_ids.h
+@@ -0,0 +1,15 @@
++// Copyright 2025 The Helium Authors
++// You can use, redistribute, and/or modify this source code under
++// the terms of the GPL-3.0 license that can be found in the LICENSE file.
++
++#ifndef COMPONENTS_EXTSTORE_FIXUPS_EXTENSION_IDS_H_
++#define COMPONENTS_EXTSTORE_FIXUPS_EXTENSION_IDS_H_
++
++namespace helium {
++
++inline constexpr char kExtstoreFixupsExtensionId[] =
++    "jfnekidfgkhnfagaabpddmioknbjglgp";
++
++}  // namespace helium
++
++#endif /* COMPONENTS_EXTSTORE_FIXUPS_EXTENSION_IDS_H_ */
+--- a/tools/gritsettings/resource_ids.spec
++++ b/tools/gritsettings/resource_ids.spec
+@@ -205,7 +205,7 @@
+     "META": {"sizes": {"includes": [20]}},
+     "includes": [2820],
+   },
+-  "<(SHARED_INTERMEDIATE_DIR)/chrome/browser/resources/ash/inline_login/resources.grd": {
++  "<(SHARED_INTERMEDIATE_DIR)/components/extstore_fixups/resources.grd": {
+     "META": {"sizes": {"includes": [20]}},
+     "includes": [2840],
+   },
+--- a/chrome/chrome_paks.gni
++++ b/chrome/chrome_paks.gni
+@@ -141,6 +141,7 @@ template("chrome_extra_paks") {
+       "$root_gen_dir/components/translate_internals_resources.pak",
+       "$root_gen_dir/components/user_actions_ui_resources.pak",
+       "$root_gen_dir/components/version_ui_resources.pak",
++      "$root_gen_dir/components/extstore_fixups/resources/extstore_fixups_resources.pak",
+       "$root_gen_dir/content/attribution_internals_resources.pak",
+       "$root_gen_dir/content/content_resources.pak",
+       "$root_gen_dir/content/histograms_resources.pak",
+@@ -169,6 +170,7 @@ template("chrome_extra_paks") {
+       "//components/autofill/core/browser:autofill_alternative_state_name_map_resources",
+       "//components/metrics:server_urls_grd",
+       "//components/resources",
++      "//components/extstore_fixups",
+       "//content:content_resources",
+       "//content/browser/resources",
+       "//mojo/public/js:resources",
+--- a/chrome/browser/extensions/BUILD.gn
++++ b/chrome/browser/extensions/BUILD.gn
+@@ -585,6 +585,7 @@ source_set("extensions") {
+     "//components/update_client:common_impl",
+     "//components/user_prefs",
+     "//components/vector_icons",
++    "//components/extstore_fixups",
+     "//content/public/browser",
+     "//extensions/browser",
+     "//extensions/browser/api/storage:settings_namespace",
+--- a/chrome/browser/extensions/chrome_component_extension_resource_manager.cc
++++ b/chrome/browser/extensions/chrome_component_extension_resource_manager.cc
+@@ -19,6 +19,7 @@
+ #include "chrome/grit/chrome_unscaled_resources.h"
+ #include "chrome/grit/component_extension_resources_map.h"
+ #include "chrome/grit/theme_resources.h"
++#include "components/extstore_fixups/resources/grit/extstore_fixups_resources_map.h"
+ #include "content/public/browser/browser_thread.h"
+ #include "extensions/buildflags/buildflags.h"
+ #include "extensions/common/constants.h"
+@@ -97,6 +98,7 @@ ChromeComponentExtensionResourceManager:
+   AddComponentResourceEntries(kComponentExtensionResources);
+   AddComponentResourceEntries(kExtraComponentExtensionResources);
+   AddComponentResourceEntries(kUblockResources);
++  AddComponentResourceEntries(kExtstoreFixupsResources);
+ 
+ #if BUILDFLAG(IS_CHROMEOS)
+   // Add Files app JS modules resources.
+--- a/chrome/browser/extensions/component_loader.h
++++ b/chrome/browser/extensions/component_loader.h
+@@ -216,6 +216,7 @@ class ComponentLoader : public KeyedServ
+                                  const std::string& description_string);
+   void AddWebStoreApp();
+   void AddUBlock();
++  void AddExtstoreFixups();
+ 
+ #if BUILDFLAG(IS_CHROMEOS)
+   void AddChromeApp();
+--- a/chrome/browser/extensions/component_loader.cc
++++ b/chrome/browser/extensions/component_loader.cc
+@@ -38,6 +38,7 @@
+ #include "chrome/grit/generated_resources.h"
+ #include "components/crx_file/id_util.h"
+ #include "components/version_info/version_info.h"
++#include "components/extstore_fixups/resources/grit/extstore_fixups_resources.h"
+ #include "content/public/browser/browser_thread.h"
+ #include "content/public/common/content_switches.h"
+ #include "extensions/browser/extension_file_task_runner.h"
+@@ -446,6 +447,11 @@ void ComponentLoader::AddUBlock() {
+   }
+ }
+ 
++void ComponentLoader::AddExtstoreFixups() {
++  Add(IDR_EXTSTORE_FIXUPS_MANIFEST_JSON,
++      base::FilePath(FILE_PATH_LITERAL("extstore_fixups")));
++}
++
+ #if BUILDFLAG(IS_CHROMEOS)
+ void ComponentLoader::AddChromeApp() {
+   AddWithNameAndDescription(
+@@ -524,6 +530,7 @@ void ComponentLoader::AddDefaultComponen
+   if (!skip_session_components) {
+     AddWebStoreApp();
+     AddUBlock();
++    AddExtstoreFixups();
+ #if BUILDFLAG(IS_CHROMEOS)
+     AddChromeApp();
+ #endif  // BUILDFLAG(IS_CHROMEOS)
+--- a/chrome/browser/extensions/component_extensions_allowlist/allowlist.cc
++++ b/chrome/browser/extensions/component_extensions_allowlist/allowlist.cc
+@@ -16,6 +16,8 @@
+ #include "chrome/common/extensions/extension_constants.h"
+ #include "chrome/grit/browser_resources.h"
+ #include "components/helium_services/extension_ids.h"
++#include "components/extstore_fixups/extension_ids.h"
++#include "components/extstore_fixups/resources/grit/extstore_fixups_resources.h"
+ #include "extensions/buildflags/buildflags.h"
+ #include "extensions/common/constants.h"
+ #include "printing/buildflags/buildflags.h"
+@@ -37,6 +39,7 @@ bool IsComponentExtensionAllowlisted(con
+       extension_misc::kInAppPaymentsSupportAppId,
+       extension_misc::kPdfExtensionId,
+       helium::kUBlockOriginComponentId,
++      helium::kExtstoreFixupsExtensionId,
+ #if BUILDFLAG(IS_CHROMEOS)
+       extension_misc::kAssessmentAssistantExtensionId,
+       extension_misc::kAccessibilityCommonExtensionId,
+@@ -93,6 +96,7 @@ bool IsComponentExtensionAllowlisted(int
+     case IDR_READING_MODE_GDOCS_HELPER_MANIFEST:
+     case IDR_WEBSTORE_MANIFEST:
+     case IDR_UBLOCK_MANIFEST_JSON:
++    case IDR_EXTSTORE_FIXUPS_MANIFEST_JSON:
+ 
+ #if BUILDFLAG(IS_CHROMEOS)
+     // Separate ChromeOS list, as it is quite large.

--- a/patches/series
+++ b/patches/series
@@ -182,6 +182,8 @@ helium/core/browser-window-context-menu.patch
 helium/core/disable-ntp-footer.patch
 helium/core/tab-cycling-mru.patch
 helium/core/component-updates.patch
+helium/core/fixups-component-setup.patch
+helium/core/fixups-chrome-webstore-script.patch
 
 helium/settings/settings-page-icons.patch
 helium/settings/move-search-suggest.patch


### PR DESCRIPTION
this component can be also used later for compatibility fixes with alternative extension stores like opera/edge store

fixes #551

before:
<img width="1630" height="468" alt="Screenshot 2026-01-18 at 18 46 23" src="https://github.com/user-attachments/assets/81219e40-43d2-423d-ae36-ebef62aaf2b9" />


after:
<img width="1328" height="315" alt="Screenshot 2026-01-18 at 20 19 16" src="https://github.com/user-attachments/assets/5d5e26c8-0d59-483c-af25-424111da345c" />
