### PR TITLE
helium/ui: remove patches for the old browser layout

### DIFF
--- a/patches/helium/ui/experiments/compact-action-toolbar.patch
+++ b/patches/helium/ui/experiments/compact-action-toolbar.patch
@@ -120,40 +120,6 @@
    UpdateTabSearchBubbleHost();
  
    // TODO(pbos): Investigate whether the side panels should be creatable when
---- a/chrome/browser/ui/views/frame/layout/browser_view_layout_impl_old.cc
-+++ b/chrome/browser/ui/views/frame/layout/browser_view_layout_impl_old.cc
-@@ -396,6 +396,15 @@ void BrowserViewLayoutImplOld::LayoutVer
- void BrowserViewLayoutImplOld::LayoutTabStripRegion(
-     gfx::Rect& available_bounds) {
-   TRACE_EVENT0("ui", "BrowserViewLayout::LayoutTabStripRegion");
-+
-+  // If the CAT feature is enabled and we're in a normal browser,
-+  // skip laying out the tab strip region. It's laid out in the toolbar.
-+  // The tab strip isn't drawn in other browser types, so the next
-+  // if statement will hide it.
-+  if (features::IsHeliumCatEnabled() && browser()->is_type_normal()) {
-+    return;
-+  }
-+
-   if (!delegate().ShouldDrawTabStrip()) {
-     SetViewVisibility(views().tab_strip_region_view, false);
-     views().tab_strip_region_view->SetBounds(0, 0, 0, 0);
-@@ -449,6 +458,15 @@ void BrowserViewLayoutImplOld::LayoutToo
-     toolbar_bounds.set_width(toolbar_bounds.width() -
-                              kMinVerticalTabStripWidth);
-     views().toolbar->SetBoundsRect(toolbar_bounds);
-+  } else if (features::IsHeliumCatEnabled() && delegate().ShouldDrawTabStrip()) {
-+    // If CAT is enabled and the tab strip should be drawn, then we're most
-+    // likely layered under window controls, so we accommodate space for
-+    // them like a tab strip would.
-+    gfx::Rect tab_strip_region_bounds(
-+        delegate().GetBoundsForTabStripRegionInBrowserView());
-+    int height = toolbar_visible ? views().toolbar->GetPreferredSize().height() : 0;
-+    views().toolbar->SetBounds(tab_strip_region_bounds.x(), available_bounds.y(),
-+                        tab_strip_region_bounds.width(), height);
-   } else {
-     int height =
-         toolbar_visible ? views().toolbar->GetPreferredSize().height() : 0;
 --- a/chrome/browser/ui/views/toolbar/toolbar_view.cc
 +++ b/chrome/browser/ui/views/toolbar/toolbar_view.cc
 @@ -58,6 +58,7 @@

--- a/patches/helium/ui/side-panel.patch
+++ b/patches/helium/ui/side-panel.patch
@@ -34,33 +34,3 @@
      SetProperty(views::kMarginsKey,
                  gfx::Insets().set_left(resize_handle_left_margin));
    } else {
---- a/chrome/browser/ui/views/frame/layout/browser_view_layout_impl_old.cc
-+++ b/chrome/browser/ui/views/frame/layout/browser_view_layout_impl_old.cc
-@@ -613,27 +613,6 @@ void BrowserViewLayoutImplOld::LayoutCon
-                           !layout_result.side_panel_right_aligned);
-     views().left_aligned_side_panel_separator->SetBoundsRect(
-         layout_result.separator_bounds);
--
--    SetViewVisibility(views().side_panel_rounded_corner,
--                      layout_result.side_panel_visible);
--    if (layout_result.side_panel_visible) {
--      // Adjust the rounded corner bounds based on the side panel bounds.
--      const int corner_size =
--          views().side_panel_rounded_corner->GetPreferredSize().width();
--
--      const int top_separator_height = views::Separator::kThickness;
--      if (layout_result.contents_container_after_side_panel) {
--        views().side_panel_rounded_corner->SetBounds(
--            layout_result.side_panel_bounds.right(),
--            layout_result.side_panel_bounds.y() - top_separator_height,
--            corner_size, corner_size);
--      } else {
--        views().side_panel_rounded_corner->SetBounds(
--            layout_result.side_panel_bounds.x() - corner_size,
--            layout_result.side_panel_bounds.y() - top_separator_height,
--            corner_size, corner_size);
--      }
--    }
-   }
- }
- 


### PR DESCRIPTION
it's no longer used (as of 144) and was removed in upstream's main. patching dead code makes no sense.