### PR TITLE
helium/core/exclude-flags: exclude new layout kill switches

### DIFF
--- a/patches/helium/core/exclude-irrelevant-flags.patch
+++ b/patches/helium/core/exclude-irrelevant-flags.patch
@@ -1,6 +1,6 @@
 --- a/chrome/browser/about_flags.cc
 +++ b/chrome/browser/about_flags.cc
-@@ -13778,11 +13778,381 @@ const FeatureEntry kFeatureEntries[] = {
+@@ -13778,11 +13778,387 @@ const FeatureEntry kFeatureEntries[] = {
      // AboutFlagsHistogramTest unit test to verify this process).
  };
  
@@ -295,6 +295,12 @@
 +  "chrome-web-store-navigation-throttle",
 +  "supervised-user-block-interstitial-v3",
 +
++  // New layout kill switches
++  // (old layout is disabled in 144 and removed in 146)
++  "app-browser-use-new-layout",
++  "popup-browser-use-new-layout",
++  "tabbed-browser-use-new-layout",
++
 +  // Autofill
 +  "reintroduce-hybrid-passkey-entry-point",
 +  "fill-on-account-select",
@@ -383,7 +389,7 @@
    FlagsStateSingleton(const FlagsStateSingleton&) = delete;
    FlagsStateSingleton& operator=(const FlagsStateSingleton&) = delete;
    ~FlagsStateSingleton() override = default;
-@@ -13801,7 +14171,7 @@ class FlagsStateSingleton : public flags
+@@ -13801,7 +14177,7 @@ class FlagsStateSingleton : public flags
  
    void RestoreDefaultState() {
      flags_state_ =
@@ -392,7 +398,7 @@
    }
  
   private:
-@@ -14128,7 +14498,7 @@ base::span<const FeatureEntry> GetFeatur
+@@ -14128,7 +14504,7 @@ base::span<const FeatureEntry> GetFeatur
        !entries_for_testing->empty()) {
      return *entries_for_testing;
    }


### PR DESCRIPTION
related: #776 

we don't patch the old layout, so disabling the new one could have unpredicted consequences