### PR TITLE
helium/core: don't expose mv3-only features to ublock component

### DIFF
--- a/patches/helium/core/ublock-install-as-component.patch
+++ b/patches/helium/core/ublock-install-as-component.patch
@@ -1,6 +1,6 @@
 --- /dev/null
 +++ b/components/helium_services/extension_ids.h
-@@ -0,0 +1,18 @@
+@@ -0,0 +1,22 @@
 +// Copyright 2025 The Helium Authors
 +// You can use, redistribute, and/or modify this source code under
 +// the terms of the GPL-3.0 license that can be found in the LICENSE file.
@@ -15,6 +15,10 @@
 +
 +inline constexpr char kUBlockOriginComponentId[] =
 +    "blockjmkbacgjkknlgpkjjiijinjdanf";
++
++inline constexpr char kUblockOriginComponentIdHashed[] =
++    // SHA1(kUBlockOriginComponentId)
++    "70C2895ED505C532A80761F0928B821B103D0786";
 +
 +}  // namespace helium
 +

--- a/patches/helium/core/ublock-reconfigure-defaults.patch
+++ b/patches/helium/core/ublock-reconfigure-defaults.patch
@@ -8,12 +8,16 @@
  
  namespace extensions {
  struct InstallWarning;
-@@ -104,6 +105,10 @@ class Manifest final {
+@@ -104,6 +105,14 @@ class Manifest final {
             location == mojom::ManifestLocation::kExternalComponent;
    }
  
 +  static inline bool IsUBlockComponent(std::string_view extension_id) {
 +    return extension_id == helium::kUBlockOriginComponentId;
++  }
++
++  static inline bool IsUblockComponentHashed(const HashedExtensionId& id) {
++    return id.value() == helium::kUblockOriginComponentIdHashed;
 +  }
 +
    static inline bool IsValidLocation(mojom::ManifestLocation location) {
@@ -223,3 +227,13 @@
      if (!entry.is_string()) {
        NOTREACHED();
      }
+--- a/extensions/common/features/simple_feature.cc
++++ b/extensions/common/features/simple_feature.cc
+@@ -698,6 +698,7 @@ Feature::Availability SimpleFeature::Get
+   // Component extensions can access any feature.
+   // NOTE: Deliberately does not match EXTERNAL_COMPONENT.
+   if (component_extensions_auto_granted_ &&
++      !Manifest::IsUblockComponentHashed(hashed_id) &&
+       location == ManifestLocation::kComponent)
+     return CreateAvailability(AvailabilityResult::kIsAvailable);
+ 


### PR DESCRIPTION
fixes #677
