### PR TITLE
helium/ui: fix caption button bounds on macos

### DIFF
--- a/patches/helium/ui/fix-caption-button-bounds.patch
+++ b/patches/helium/ui/fix-caption-button-bounds.patch
@@ -1,14 +1,3 @@
---- a/chrome/browser/ui/views/frame/layout/browser_view_layout_delegate_impl.cc
-+++ b/chrome/browser/ui/views/frame/layout/browser_view_layout_delegate_impl.cc
-@@ -236,7 +236,7 @@ BrowserViewLayoutDelegateImpl::GetBounds
-                    layout.trailing_exclusion.vertical_padding);
-   bounds_f.set_height(
-       std::max(max_bound, static_cast<float>(tabstrip_minimum_size.height())));
--  const int tab_margin = TabStyle::Get()->GetBottomCornerRadius();
-+  const int tab_margin = TabStyle::Get()->GetBottomCornerRadius() / 2;
-   bounds_f.Inset(gfx::InsetsF::TLBR(
-       0.0f,
-       layout.leading_exclusion.content.width() +
 --- a/components/remote_cocoa/app_shim/browser_native_widget_window_mac.mm
 +++ b/components/remote_cocoa/app_shim/browser_native_widget_window_mac.mm
 @@ -63,13 +63,10 @@ const double kThinControllerHeight = 0.5
@@ -40,17 +29,23 @@
    // Don't mess with the window radius before macOS 26, as concentricity was not
 --- a/chrome/browser/ui/views/frame/browser_frame_view_mac.mm
 +++ b/chrome/browser/ui/views/frame/browser_frame_view_mac.mm
-@@ -465,10 +465,10 @@ BrowserFrameViewMac::GetCaptionButtonBou
-   // not precise.
+@@ -461,14 +461,13 @@ BrowserFrameViewMac::BoundsAndMargins
+ BrowserFrameViewMac::GetCaptionButtonBounds() const {
+   BoundsAndMargins result;
+ 
+-  // These are empirically determined; feel free to change them if they're
+-  // not precise.
++  // Bounds determined via manual measurements
    if (@available(macOS 26, *)) {
-     result.bounds = gfx::RectF(12, 10, 62, 18);
+-    result.bounds = gfx::RectF(12, 10, 62, 18);
 -    result.margins = gfx::OutsetsF::VH(10, 12);
-+    result.margins = gfx::OutsetsF::VH(0, 6);
++    result.bounds = gfx::RectF(10, 10, 60, 14);
++    result.margins = gfx::OutsetsF::VH(0, 14);
    } else {
 -    result.bounds = gfx::RectF(20, 11, 54, 16);
 -    result.margins = gfx::OutsetsF::VH(11, 20);
-+    result.bounds = gfx::RectF(20, 11, 40, 16);
-+    result.margins = gfx::OutsetsF::VH(0, 14);
++    result.bounds = gfx::RectF(11, 11, 52, 12);
++    result.margins = gfx::OutsetsF::VH(0, 15);
    }
  
    // Mirror for when caption buttons are on the "wrong" side.


### PR DESCRIPTION
now biblically accurate on sequoia & tahoe:

<img width="594" height="528" alt="comp" src="https://github.com/user-attachments/assets/39130f36-2774-424a-a701-68c76f0b4820" />
