### PR TITLE
helium/ui/top-container: remove old layout file patch

### DIFF
--- a/patches/helium/ui/top-container.patch
+++ b/patches/helium/ui/top-container.patch
@@ -1,13 +1,3 @@
---- a/chrome/browser/ui/views/frame/layout/browser_view_layout_delegate_impl.cc
-+++ b/chrome/browser/ui/views/frame/layout/browser_view_layout_delegate_impl.cc
-@@ -120,6 +120,7 @@ bool BrowserViewLayoutDelegateImpl::IsIn
- }
- 
- bool BrowserViewLayoutDelegateImpl::IsContentsSeparatorEnabled() const {
-+  return false;
-   // Web app windows manage their own separator.
-   // TODO(crbug.com/40102629): Make PWAs set the visibility of the ToolbarView
-   // based on whether it is visible instead of setting the height to 0px. This
 --- a/chrome/browser/ui/views/frame/top_container_background.cc
 +++ b/chrome/browser/ui/views/frame/top_container_background.cc
 @@ -8,6 +8,7 @@


### PR DESCRIPTION
the old layout is no longer used, so this patch is useless