### PR TITLE
helium/bangs: remove strict match check in MaybeStripKeyword

### DIFF
--- a/patches/helium/core/add-native-bangs.patch
+++ b/patches/helium/core/add-native-bangs.patch
@@ -885,22 +885,7 @@
    EmitEnteredKeywordModeHistogram(entry_method, turl, !user_text_.empty());
  }
  
-@@ -1601,7 +1627,13 @@ void OmniboxEditModel::InternalSetUserTe
- 
- std::u16string OmniboxEditModel::MaybeStripKeyword(
-     const std::u16string& text) const {
--  return is_keyword_selected()
-+  std::u16string trimmed_text;
-+  base::TrimWhitespace(text, base::TRIM_LEADING, &trimmed_text);
-+
-+  std::u16string actual_keyword = base::ToLowerASCII(
-+    AutocompleteInput::SplitKeywordFromInput(trimmed_text, false, nullptr));
-+
-+  return is_keyword_selected() && actual_keyword == keyword_
-              ? AutocompleteInput::SplitReplacementStringFromInput(text, false)
-              : text;
- }
-@@ -2795,6 +2827,21 @@ bool OmniboxEditModel::AllowKeywordSpace
+@@ -2795,6 +2821,21 @@ bool OmniboxEditModel::AllowKeywordSpace
    return GetPrefService()->GetBoolean(omnibox::kKeywordSpaceTriggeringEnabled);
  }
  
@@ -922,7 +907,7 @@
  bool OmniboxEditModel::ShouldAcceptKeywordAfterInsertingSpaceAtEnd(
      const std::u16string& new_text) {
    // Check if the user has disabled space triggering.
-@@ -2818,16 +2865,20 @@ bool OmniboxEditModel::ShouldAcceptKeywo
+@@ -2818,16 +2859,20 @@ bool OmniboxEditModel::ShouldAcceptKeywo
      return false;
    }
  


### PR DESCRIPTION
i can't remember what this was added for, and bangs seem to be working fine even without it. so let's just yank it out since it seems to be causing problems.

Fixes #146
Fixes #784
