### PR TITLE
helium/bangs: only replace user_text if the result is longer

### DIFF
--- a/patches/helium/core/add-native-bangs.patch
+++ b/patches/helium/core/add-native-bangs.patch
@@ -867,7 +867,7 @@
 +
 +  if (turl && turl->bang_id() > 0 && !user_text_.starts_with(u'!')) {
 +    AutocompleteMatch match = CurrentMatch();
-+    if (!match.fill_into_edit.empty()) {
++    if (match.fill_into_edit.length() > user_text_.length()) {
 +      user_text_ = match.fill_into_edit;
 +    }
 +  }


### PR DESCRIPTION
The intent of this `if` is to allow the user to select a suggested query from bang history, but it previously always overwrote |user_text_| even if it was longer (which is not possible if the user is selecting a suggestion, as it will always be longer than currently-typed text).

Because |fill_into_edit| is trimmed, it also removed the trailing space that is desired if the user was inputting a completely new query.

Make it so that |user_text_| is only replaced if it will result in an expansion.

Fixes #726
