### PR TITLE
helium/ui/cat: fix double margin between window controls & toolbar

### DIFF
--- a/patches/helium/ui/experiments/compact-action-toolbar.patch
+++ b/patches/helium/ui/experiments/compact-action-toolbar.patch
@@ -368,3 +368,26 @@
    return elements;
  }
  
+--- a/chrome/browser/ui/views/frame/layout/browser_view_tabbed_layout_impl.cc
++++ b/chrome/browser/ui/views/frame/layout/browser_view_tabbed_layout_impl.cc
+@@ -13,6 +13,7 @@
+ #include "base/trace_event/trace_event.h"
+ #include "build/build_config.h"
+ #include "chrome/browser/ui/layout_constants.h"
++#include "chrome/browser/ui/ui_features.h"
+ #include "chrome/browser/ui/views/bookmarks/bookmark_bar_view.h"
+ #include "chrome/browser/ui/views/frame/immersive_mode_controller.h"
+ #include "chrome/browser/ui/views/frame/layout/browser_view_layout_delegate.h"
+@@ -634,9 +635,11 @@ gfx::Rect BrowserViewTabbedLayoutImpl::C
+   if (IsParentedTo(views().toolbar, views().top_container)) {
+     gfx::Rect toolbar_bounds;
+     if (toolbar_visible) {
++      // Visually clamp two conflicting margins: window controls & toolbar
++      const int exclusion = features::IsHeliumCatEnabled() ? 10 : 0;
+       toolbar_bounds =
+           needs_exclusion
+-              ? GetBoundsWithExclusion(params, views().toolbar)
++              ? GetBoundsWithExclusion(params, views().toolbar, exclusion)
+               : gfx::Rect(params.visual_client_area.x(),
+                           params.visual_client_area.y(),
+                           params.visual_client_area.width(),


### PR DESCRIPTION
before:
<img width="196" height="74" alt="image" src="https://github.com/user-attachments/assets/601a9097-c03e-40fd-98ba-063887e5d8d3" />

after:
<img width="197" height="68" alt="image" src="https://github.com/user-attachments/assets/fa216858-5930-4a5f-a0ad-0cbb5ded652e" />

needs testing on linux (with various window controls) & on windows