### PR TITLE
helium/ui/pdf-viewer: adaptive sidenav width

### DIFF
--- a/patches/helium/ui/pdf-viewer.patch
+++ b/patches/helium/ui/pdf-viewer.patch
@@ -83,15 +83,26 @@
  #fit {
 --- a/chrome/browser/resources/pdf/pdf_viewer.css
 +++ b/chrome/browser/resources/pdf/pdf_viewer.css
-@@ -13,7 +13,7 @@
+@@ -13,7 +13,8 @@
   * #css_wrapper_metadata_end */
  
  :host {
 -  --viewer-pdf-sidenav-width: 300px;
-+  --viewer-pdf-sidenav-width: 180px;
++  --viewer-pdf-sidenav-width: 350px;
++  --viewer-pdf-sidenav-min-width: 180px;
    display: flex;
    flex-direction: column;
    height: 100%;
+@@ -53,7 +54,8 @@ viewer-toolbar {
+   overflow: hidden;
+   transition: transform 250ms cubic-bezier(.6, 0, 0, 1), visibility 250ms;
+   visibility: visible;
+-  width: var(--viewer-pdf-sidenav-width);
++  max-width: var(--viewer-pdf-sidenav-width);
++  min-width: var(--viewer-pdf-sidenav-min-width);
+ }
+ 
+ #sidenav-container.floating {
 --- a/chrome/browser/resources/pdf/elements/viewer_thumbnail_bar.css
 +++ b/chrome/browser/resources/pdf/elements/viewer_thumbnail_bar.css
 @@ -14,11 +14,11 @@
@@ -108,3 +119,25 @@
 -  padding-top: 24px;
 +  padding-top: 18px;
  }
+--- a/chrome/browser/resources/pdf/elements/viewer_pdf_sidenav.css
++++ b/chrome/browser/resources/pdf/elements/viewer_pdf_sidenav.css
+@@ -17,9 +17,9 @@
+   background-color: var(--viewer-side-background-color);
+   display: flex;
+   height: 100%;
+-  min-width: var(--viewer-pdf-sidenav-width);
+   overflow: hidden;
+-  width: var(--viewer-pdf-sidenav-width);
++  max-width: var(--viewer-pdf-sidenav-width);
++  min-width: var(--viewer-pdf-sidenav-min-width);
+ }
+ 
+ #icons {
+@@ -33,6 +33,7 @@
+   color: white;
+   flex: 1;
+   overflow-x: hidden;
++  min-width: var(--viewer-pdf-sidenav-min-width);
+ }
+ 
+ #icons:not([hidden]) + #content {


### PR DESCRIPTION
fixes awkwardly narrow navigation view

before:
<img width="424" height="434" alt="image" src="https://github.com/user-attachments/assets/2def0276-e8ee-4741-87ad-1f644cd6fcd1" />
after:
<img width="420" height="447" alt="image" src="https://github.com/user-attachments/assets/ba6b8955-cc5a-4c2a-8f11-8c411557cbf7" />

before:
<img width="405" height="957" alt="image" src="https://github.com/user-attachments/assets/dccb82da-c121-476f-b1f5-8e0a617433e9" />
after:
<img width="424" height="709" alt="image" src="https://github.com/user-attachments/assets/124666dd-d860-4396-b3b0-453f2df6f707" />
