### PR TITLE
helium/core/search: break default search engine favicons

### DIFF
--- a/patches/helium/core/search/break-favicons.patch
+++ b/patches/helium/core/search/break-favicons.patch
@@ -1,0 +1,56 @@
+--- a/third_party/search_engines_data/resources/definitions/prepopulated_engines.json
++++ b/third_party/search_engines_data/resources/definitions/prepopulated_engines.json
+@@ -52,7 +52,7 @@
+     "bing": {
+       "name": "Microsoft Bing",
+       "keyword": "bing.com",
+-      "favicon_url": "https://www.bing.com/sa/simg/bing_p_rr_teal_min.ico",
++      "favicon_url": "",
+       "base_builtin_resource_id": "SEARCH_ENGINE_BING",
+       "logo_url": "https://cdn.sapphire.microsoftapp.net/icons/bing_144.png",
+       "search_url": "https://www.bing.com/search?q={searchTerms}",
+@@ -120,7 +120,7 @@
+     "duckduckgo": {
+       "name": "DuckDuckGo",
+       "keyword": "duckduckgo.com",
+-      "favicon_url": "https://duckduckgo.com/favicon.ico",
++      "favicon_url": "",
+       "base_builtin_resource_id": "SEARCH_ENGINE_DUCKDUCKGO",
+       "logo_url": "https://staticcdn.duckduckgo.com/android/DuckDuckGoLogo.png",
+       "search_url": "https://duckduckgo.com/?q={searchTerms}",
+@@ -139,7 +139,7 @@
+     "ecosia": {
+       "name": "Ecosia",
+       "keyword": "ecosia.org",
+-      "favicon_url": "https://cdn.ecosia.org/assets/images/ico/favicon.ico",
++      "favicon_url": "",
+       "base_builtin_resource_id": "SEARCH_ENGINE_ECOSIA",
+       "logo_url": "https://cdn.ecosia.org/static/icons/japan-choice-screen-logo.png",
+       "search_url": "https://www.ecosia.org/search?q={searchTerms}",
+@@ -173,7 +173,7 @@
+     "break_stuff_google": {
+       "name": "Google",
+       "keyword": "google.com",
+-      "favicon_url": "https://www.google.com/images/branding/product/ico/googleg_alldp.ico",
++      "favicon_url": "",
+       "base_builtin_resource_id": "SEARCH_ENGINE_GOOGLE",
+       "search_url": "https://www.google.com/search?q={searchTerms}",
+       "suggest_url": "https://www.google.com/complete/search?client=chrome&q={searchTerms}",
+@@ -197,7 +197,7 @@
+       "search_url": "https://kagi.com/search?q={searchTerms}",
+       "suggest_url": "https://kagisuggest.com/api/autosuggest?q={searchTerms}",
+       "new_tab_url": "https://kagi.com/",
+-      "favicon_url": "https://kagi.com/favicon.ico",
++      "favicon_url": "",
+       "base_builtin_resource_id": "SEARCH_ENGINE_KAGI",
+       "type": "SEARCH_ENGINE_KAGI",
+       "id": 115
+@@ -339,7 +339,7 @@
+     "qwant": {
+       "name": "Qwant",
+       "keyword": "qwant.com",
+-      "favicon_url": "https://www.qwant.com/favicon.ico",
++      "favicon_url": "",
+       "base_builtin_resource_id": "SEARCH_ENGINE_QWANT",
+       "search_url": "https://www.qwant.com/?q={searchTerms}",
+       "suggest_url": "https://api.qwant.com/api/suggest/?q={searchTerms}",

--- a/patches/series
+++ b/patches/series
@@ -116,6 +116,7 @@ helium/core/search/engine-defaults.patch
 helium/core/search/fix-search-engine-icons.patch
 helium/core/search/force-eu-search-features.patch
 helium/core/search/remove-description-snippet-deps.patch
+helium/core/search/break-favicons.patch
 
 helium/settings/setup-behavior-settings-page.patch
 helium/core/keyboard-shortcuts.patch


### PR DESCRIPTION
prevents unnecessary favicon requests when opening the search engines page in settings. we use our own offline assets on that page, so this has no visual impact.

fixes I-320