### PR TITLE
helium/core/search: use default search icon in omnibox

### DIFF
--- a/patches/helium/core/search/omnibox-default-search-icon.patch
+++ b/patches/helium/core/search/omnibox-default-search-icon.patch
@@ -1,0 +1,13 @@
+--- a/chrome/browser/ui/omnibox/omnibox_view.cc
++++ b/chrome/browser/ui/omnibox/omnibox_view.cc
+@@ -135,10 +135,6 @@ ui::ImageModel OmniboxView::GetIcon(int
+         return ui::ImageModel::FromImage(icon);
+       }
+     }
+-    favicon = turl ? controller()->client()->GetFaviconForKeywordSearchProvider(
+-                         turl, std::move(on_icon_fetched))
+-                   : controller()->client()->GetFaviconForDefaultSearchProvider(
+-                         std::move(on_icon_fetched));
+ 
+   } else if (match.type != AutocompleteMatchType::HISTORY_CLUSTER) {
+     // The starter pack suggestions are a unique case. These suggestions

--- a/patches/series
+++ b/patches/series
@@ -117,6 +117,7 @@ helium/core/search/fix-search-engine-icons.patch
 helium/core/search/force-eu-search-features.patch
 helium/core/search/remove-description-snippet-deps.patch
 helium/core/search/break-favicons.patch
+helium/core/search/omnibox-default-search-icon.patch
 
 helium/settings/setup-behavior-settings-page.patch
 helium/core/keyboard-shortcuts.patch


### PR DESCRIPTION
reduces visual noise and prevents ugly search engine favicons from breaking the visual uniformity and contrast. there's enough indication to tell what search engine you're using without the favicon.

before:
<img width="385" height="164" alt="image" src="https://github.com/user-attachments/assets/62b22b08-4b8c-4ac5-8905-1995b3161b9a" />

after:
<img width="368" height="137" alt="image" src="https://github.com/user-attachments/assets/0a5306fe-7202-417f-ba1f-98020eddaf78" />

(i love kagi, but dear god, that is one awful favicon)

fixes I-277