### PR TITLE
helium/onboarding: introduce get/install extension APIs

### DIFF
--- a/patches/helium/core/onboarding-page.patch
+++ b/patches/helium/core/onboarding-page.patch
@@ -151,7 +151,7 @@
    map.AddWebUIConfig(std::make_unique<SigninErrorUIConfig>());
 --- /dev/null
 +++ b/chrome/browser/ui/webui/onboarding/onboarding_page_ui.cc
-@@ -0,0 +1,44 @@
+@@ -0,0 +1,46 @@
 +// Copyright 2025 The Helium Authors
 +// You can use, redistribute, and/or modify this source code under
 +// the terms of the GPL-3.0 license that can be found in the LICENSE file.
@@ -182,7 +182,9 @@
 +  webui::SetupWebUIDataSource(source, kHeliumOnboardingGenerated,
 +                              IDR_HELIUM_ONBOARDING_INDEX_HTML);
 +
-+  source->UseStringsJs();
++  // TODO: remove this call once the following issue/s are resolved:
++  // https://github.com/sveltejs/svelte/issues/10826
++  // https://github.com/sveltejs/svelte/issues/14438
 +  source->DisableTrustedTypesCSP();
 +
 +  web_ui->AddMessageHandler(


### PR DESCRIPTION
```
type EnablementMap = Record<ExtensionId, boolean>
Event `extension-state-changed` -> EnablementMap
and method `getExtensions()` -> Promise<EnablementMap>
- indicates whether the extension is enabled or not.

Method `installExtension(id: string)` -> Promise<void>
- enables or installs an extension (with user prompt)
- if unsuccessful, throws { code: number, error: string }
  where `code` is extensions::webstore_install::Result

also:
- ran clang-format on most of the patch
- removed NTP background color stuff since it's not used
- cleaned up unneeded includes in both .h and .cc files
```