### PR TITLE
helium/onboarding: remove HasPrefPath() exception

### DIFF
--- a/patches/helium/core/add-native-bangs.patch
+++ b/patches/helium/core/add-native-bangs.patch
@@ -700,7 +700,7 @@
      // Sanity check for https://crbug.com/781703.
 --- a/components/helium_services/helium_services_helpers.cc
 +++ b/components/helium_services/helium_services_helpers.cc
-@@ -67,6 +67,11 @@ bool ShouldAccessExtensionService(const
+@@ -63,6 +63,11 @@ bool ShouldAccessExtensionService(const
              prefs.GetBoolean(prefs::kHeliumExtProxyEnabled);
  }
  

--- a/patches/helium/core/add-updater-preference.patch
+++ b/patches/helium/core/add-updater-preference.patch
@@ -41,7 +41,7 @@
  std::optional<GURL> GetValidUserOverridenURL(std::string_view user_url_) {
      if (user_url_.empty()) {
          return std::nullopt;
-@@ -77,6 +83,11 @@ bool ShouldFetchBangs(const PrefService&
+@@ -73,6 +79,11 @@ bool ShouldFetchBangs(const PrefService&
              prefs.GetBoolean(prefs::kHeliumBangsEnabled);
  }
  
@@ -53,7 +53,7 @@
  GURL GetExtensionUpdateURL(const PrefService& prefs) {
      if (!ShouldAccessExtensionService(prefs)) {
          return GetDummyURL();
-@@ -102,6 +113,20 @@ GURL GetSpellcheckURL(const PrefService&
+@@ -98,6 +109,20 @@ GURL GetSpellcheckURL(const PrefService&
      return GetServicesBaseURL(prefs).Resolve("/dict/");
  }
  

--- a/patches/helium/core/component-updates.patch
+++ b/patches/helium/core/component-updates.patch
@@ -22,7 +22,7 @@
  #include "components/prefs/pref_service.h"
  #include "net/base/url_util.h"
  #include "url/gurl.h"
-@@ -88,6 +89,12 @@ bool ShouldAccessUpdateService(const Pre
+@@ -84,6 +85,12 @@ bool ShouldAccessUpdateService(const Pre
              prefs.GetBoolean(prefs::kHeliumUpdateFetchingEnabled);
  }
  
@@ -35,7 +35,7 @@
  bool ShouldAccessUBlockAssets(const PrefService& prefs) {
      return ShouldAccessServices(prefs) &&
              prefs.GetBoolean(prefs::kHeliumUBlockAssetsEnabled);
-@@ -132,6 +139,14 @@ GURL GetBrowserUpdateURL(const PrefServi
+@@ -128,6 +135,14 @@ GURL GetBrowserUpdateURL(const PrefServi
  #endif
  }
  

--- a/patches/helium/core/onboarding-page.patch
+++ b/patches/helium/core/onboarding-page.patch
@@ -597,17 +597,13 @@
 +#endif  // CHROME_BROWSER_UI_WEBUI_ONBOARDING_ONBOARDING_HANDLER_H_
 --- a/components/helium_services/helium_services_helpers.cc
 +++ b/components/helium_services/helium_services_helpers.cc
-@@ -53,12 +53,18 @@ GURL GetDummyURL() {
+@@ -53,12 +53,14 @@ GURL GetDummyURL() {
  }
  
  bool ShouldAccessServices(const PrefService& prefs) {
 -    return prefs.GetBoolean(prefs::kHeliumServicesEnabled);
-+    // onboarding was completed without touching kHeliumServicesEnabled,
-+    // OR the user has explicitly enabled kHeliumServicesEnabled somewhere
-+    // (either via onboarding, or user settings)
 +    return prefs.GetBoolean(prefs::kHeliumServicesEnabled) &&
-+           (prefs.GetBoolean(prefs::kHeliumServicesConsented)
-+           || prefs.HasPrefPath(prefs::kHeliumServicesEnabled));
++           prefs.GetBoolean(prefs::kHeliumServicesConsented);
  }
  
  void ConfigurePrefChangeRegistrarFor(std::string_view pref_name,

--- a/patches/helium/core/proxy-extension-downloads.patch
+++ b/patches/helium/core/proxy-extension-downloads.patch
@@ -249,8 +249,8 @@
  #include "components/helium_services/pref_names.h"
  #include "components/prefs/pref_service.h"
  #include "net/base/url_util.h"
-@@ -61,6 +62,28 @@ bool ShouldAccessServices(const PrefServ
-            || prefs.HasPrefPath(prefs::kHeliumServicesEnabled));
+@@ -57,6 +58,28 @@ bool ShouldAccessServices(const PrefServ
+            prefs.GetBoolean(prefs::kHeliumServicesConsented);
  }
  
 +bool ShouldAccessExtensionService(const PrefService& prefs) {

--- a/patches/helium/core/reenable-spellcheck-downloads.patch
+++ b/patches/helium/core/reenable-spellcheck-downloads.patch
@@ -45,7 +45,7 @@
  
 --- a/components/helium_services/helium_services_helpers.cc
 +++ b/components/helium_services/helium_services_helpers.cc
-@@ -67,6 +67,11 @@ bool ShouldAccessExtensionService(const
+@@ -63,6 +63,11 @@ bool ShouldAccessExtensionService(const
              prefs.GetBoolean(prefs::kHeliumExtProxyEnabled);
  }
  
@@ -57,7 +57,7 @@
  bool ShouldFetchBangs(const PrefService& prefs) {
      return ShouldAccessServices(prefs) &&
              prefs.GetBoolean(prefs::kHeliumBangsEnabled);
-@@ -89,6 +94,14 @@ GURL GetWebstoreSnippetURL(const PrefSer
+@@ -85,6 +90,14 @@ GURL GetWebstoreSnippetURL(const PrefSer
          base::StringPrintf("/ext/cws_snippet?id=%s", id));
  }
  

--- a/patches/helium/core/ublock-helium-services.patch
+++ b/patches/helium/core/ublock-helium-services.patch
@@ -1,6 +1,6 @@
 --- a/components/helium_services/helium_services_helpers.cc
 +++ b/components/helium_services/helium_services_helpers.cc
-@@ -88,6 +88,11 @@ bool ShouldAccessUpdateService(const Pre
+@@ -84,6 +84,11 @@ bool ShouldAccessUpdateService(const Pre
              prefs.GetBoolean(prefs::kHeliumUpdateFetchingEnabled);
  }
  
@@ -12,7 +12,7 @@
  GURL GetExtensionUpdateURL(const PrefService& prefs) {
      if (!ShouldAccessExtensionService(prefs)) {
          return GetDummyURL();
-@@ -127,6 +132,14 @@ GURL GetBrowserUpdateURL(const PrefServi
+@@ -123,6 +128,14 @@ GURL GetBrowserUpdateURL(const PrefServi
  #endif
  }
  


### PR DESCRIPTION
this check was mostly intended to not break services access for pre-onboarding users. onboarding was introduced a long time ago (way before pre-0.0.1), so this is not a real concern anymore.

it was still possible to make ShouldAccessServices() return `true` by toggling services.enabled off and on in onboarding; this change should make it so that it's not possible anymore (meaning the user has to navigate to the next step before services are truly enabled).

For your pull request to not get closed without review, please confirm that: