### PR TITLE
helium/extstore-fixups: expect Google prefix for chrome

### DIFF
--- a/patches/helium/core/fixups-chrome-webstore-script.patch
+++ b/patches/helium/core/fixups-chrome-webstore-script.patch
@@ -50,7 +50,7 @@
 +        return false;
 +      }
 +
-+      el.nodeValue = el.nodeValue.replace('Chrome', 'Helium');
++      el.nodeValue = el.nodeValue.replace(/\b(Google\s)?Chrome\b/, 'Helium');
 +      return true;
 +    } else if (el.childNodes) {
 +      for (const node of el.childNodes) {


### PR DESCRIPTION
"Chrome" is translated as "Google Chrome" in some locales, so we need to replace the whole thing with Helium if that happens
