### PR TITLE
Add center bookmarks bar option

### DIFF
--- a/patches/helium/ui/layout/center-bookmarks-in-bar.patch
+++ b/patches/helium/ui/layout/center-bookmarks-in-bar.patch
@@ -1,0 +1,195 @@
+--- a/components/bookmarks/common/bookmark_pref_names.h
++++ b/components/bookmarks/common/bookmark_pref_names.h
+@@ -37,5 +37,10 @@ inline constexpr char kShowTabGroupsInBookmarkBar[] =
+     "bookmark_bar.show_tab_groups";
+ 
++// Boolean which specifies whether bookmarks should be centered on the
++// bookmark bar.
++inline constexpr char kCenterBookmarksInBookmarkBar[] =
++    "bookmark_bar.center_bookmarks";
++
+ // Boolean which specifies whether the Managed Bookmarks folder is visible on
+ // the bookmark bar.
+ inline constexpr char kShowManagedBookmarksInBookmarkBar[] =
+--- a/components/bookmarks/browser/bookmark_utils.cc
++++ b/components/bookmarks/browser/bookmark_utils.cc
+@@ -459,6 +459,9 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
+   registry->RegisterBooleanPref(
+       prefs::kShowTabGroupsInBookmarkBar, true,
+       user_prefs::PrefRegistrySyncable::SYNCABLE_PREF);
++  registry->RegisterBooleanPref(
++      prefs::kCenterBookmarksInBookmarkBar, false,
++      user_prefs::PrefRegistrySyncable::SYNCABLE_PREF);
+   registry->RegisterBooleanPref(
+       prefs::kShowManagedBookmarksInBookmarkBar, true,
+       user_prefs::PrefRegistrySyncable::SYNCABLE_PREF);
+--- a/components/sync_preferences/common_syncable_prefs_database.cc
++++ b/components/sync_preferences/common_syncable_prefs_database.cc
+@@ -117,6 +117,7 @@ enum {
+   kAutofillPaymentCardBenefits = 69,
+   // kCloseTabs = 70, (no longer synced)
+   kShowTabGroupsInBookmarkBar = 71,
++  kCenterBookmarksInBookmarkBar = 113,
+   kFacilitatedPaymentsPix = 72,
+   kSyncableTabGroups = 73,
+   kAutoPinNewTabGroups = 74,
+@@ -220,6 +221,9 @@ constexpr auto kCommonSyncablePrefsAllowlist =
+         {bookmarks::prefs::kShowTabGroupsInBookmarkBar,
+          {syncable_prefs_ids::kShowTabGroupsInBookmarkBar, syncer::PREFERENCES,
+           PrefSensitivity::kNone, MergeBehavior::kNone}},
++        {bookmarks::prefs::kCenterBookmarksInBookmarkBar,
++         {syncable_prefs_ids::kCenterBookmarksInBookmarkBar,
++          syncer::PREFERENCES, PrefSensitivity::kNone, MergeBehavior::kNone}},
+         {bookmarks::prefs::kShowBookmarkBar,
+          {syncable_prefs_ids::kShowBookmarkBar, syncer::PREFERENCES,
+           PrefSensitivity::kNone, MergeBehavior::kNone}},
+--- a/chrome/browser/extensions/api/settings_private/prefs_util.cc
++++ b/chrome/browser/extensions/api/settings_private/prefs_util.cc
+@@ -231,6 +231,8 @@ const PrefsUtil::TypedPrefMap& PrefsUtil::GetAllowlistedKeys() {
+       settings_api::PrefType::kBoolean;
+   (*s_allowlist)[bookmarks::prefs::kShowTabGroupsInBookmarkBar] =
+       settings_api::PrefType::kBoolean;
++  (*s_allowlist)[bookmarks::prefs::kCenterBookmarksInBookmarkBar] =
++      settings_api::PrefType::kBoolean;
+   (*s_allowlist)[::prefs::kSidePanelHorizontalAlignment] =
+       settings_api::PrefType::kBoolean;
+   (*s_allowlist)[::prefs::kTabSearchRightAligned] =
+--- a/chrome/app/settings_strings.grdp
++++ b/chrome/app/settings_strings.grdp
+@@ -291,6 +291,9 @@
+   <message name="IDS_SETTINGS_SHOW_TAB_GROUPS_IN_BOOKMARKS_BAR" desc="Label for the checkbox which enables or disables showing saved tab groups in bookmarks bar.">
+     Show tab groups in bookmarks bar
+   </message>
++  <message name="IDS_SETTINGS_CENTER_BOOKMARKS_IN_BOOKMARKS_BAR" desc="Label for the checkbox which enables or disables centering bookmarks in the bookmarks bar.">
++    Center bookmarks bar
++  </message>
+   <message name="IDS_SETTINGS_AUTO_PIN_NEW_TAB_GROUPS" desc="Label for the checkbox which enables or disables auto pin new tab groups.">
+     Automatically pin new tab groups created on any device to the bookmarks bar
+   </message>
+--- a/tools/metrics/histograms/metadata/sync/enums.xml
++++ b/tools/metrics/histograms/metadata/sync/enums.xml
+@@ -402,6 +402,7 @@
+   <int value="110" label="AutofillAiSyncedOptInStatus"/>
+   <int value="111" label="iOSPromoReminder"/>
+   <int value="112" label="AutofillAiReauthBeforeViewingSensitiveData"/>
++  <int value="113" label="CenterBookmarksInBookmarkBar"/>
+ <!-- LINT.ThenChange(/components/sync_preferences/common_syncable_prefs_database.cc:CommonSyncablePref)-->
+ 
+ <!-- LINT.IfChange(ChromeSyncablePref) -->
+--- a/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
++++ b/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
+@@ -531,7 +531,9 @@ void AddAppearanceStrings(content::WebUIDataSource* html_source,
+       {"allowSplitViewDragAndDrop",
+        IDS_SETTINGS_ALLOW_SPLIT_VIEW_DRAG_AND_DROP},
+       {"showTabGroupsInBookmarksBar",
+        IDS_SETTINGS_SHOW_TAB_GROUPS_IN_BOOKMARKS_BAR},
++      {"centerBookmarksInBookmarksBar",
++       IDS_SETTINGS_CENTER_BOOKMARKS_IN_BOOKMARKS_BAR},
+       {"autoPinNewTabGroups", IDS_SETTINGS_AUTO_PIN_NEW_TAB_GROUPS_HELIUM},
+       {"hoverCardTitle", IDS_SETTINGS_HOVER_CARD_TITLE},
+       {"showHoverCardImages", IDS_SETTINGS_SHOW_HOVER_CARD_IMAGES},
+--- a/chrome/browser/resources/settings/appearance_page/appearance_page.html
++++ b/chrome/browser/resources/settings/appearance_page/appearance_page.html
+@@ -171,6 +171,11 @@
+             label="$i18n{showTabGroupsInBookmarksBar}">
+         </settings-toggle-button>
+ 
++        <settings-toggle-button class="hr" id="centerBookmarksInBookmarksBar"
++            pref="{{prefs.bookmark_bar.center_bookmarks}}"
++            label="$i18n{centerBookmarksInBookmarksBar}">
++        </settings-toggle-button>
++
+         <div class="cr-row">
+           <div class="flex cr-padded-text" aria-hidden="true">
+             $i18n{sidePanelPosition}
+--- a/chrome/browser/ui/views/bookmarks/bookmark_bar_view.h
++++ b/chrome/browser/ui/views/bookmarks/bookmark_bar_view.h
+@@ -400,6 +400,9 @@ class BookmarkBarView : public views::AccessiblePaneView,
+   // Updates the visibility of the tab groups based on the pref value.
+   void OnTabGroupsVisibilityPrefChanged();
+ 
++  // Updates bookmark button alignment based on the pref value.
++  void OnCenterBookmarksPrefChanged();
++
+   void OnShowManagedBookmarksPrefChanged();
+ 
+   void LayoutAndPaint() {
+--- a/chrome/browser/ui/views/bookmarks/bookmark_bar_view.cc
++++ b/chrome/browser/ui/views/bookmarks/bookmark_bar_view.cc
+@@ -861,6 +861,8 @@ void BookmarkBarView::Layout(PassKey) {
+     }
+   }
+ 
++  const int bookmark_buttons_start_x = x;
++
+   if (bookmark_bar_children_count) {
+     bool can_render_button_bounds = x < max_x;
+     size_t button_count = bookmark_buttons_.size();
+@@ -892,6 +894,44 @@ void BookmarkBarView::Layout(PassKey) {
+       (bookmark_bar_children_count > bookmark_buttons_.size() ||
+        (!bookmark_buttons_.empty() &&
+         !bookmark_buttons_.back().first->GetVisible()));
++
++  const bool center_bookmarks = browser_->profile()->GetPrefs()->GetBoolean(
++      bookmarks::prefs::kCenterBookmarksInBookmarkBar);
++  if (center_bookmarks && !show_bookmarks_overflow &&
++      !bookmark_buttons_.empty()) {
++    auto first_visible_bookmark = std::ranges::find_if(
++        bookmark_buttons_, [](const BookmarkButtonAndNode& button_and_node) {
++          return button_and_node.first->GetVisible();
++        });
++    if (first_visible_bookmark != bookmark_buttons_.end()) {
++      auto last_visible_bookmark = std::ranges::find_if(
++          bookmark_buttons_.rbegin(), bookmark_buttons_.rend(),
++          [](const BookmarkButtonAndNode& button_and_node) {
++            return button_and_node.first->GetVisible();
++          });
++
++      const int visible_bookmarks_width =
++          last_visible_bookmark->first->bounds().right() -
++          first_visible_bookmark->first->x();
++      const int centered_bookmarks_start_x =
++          bookmark_buttons_start_x +
++          std::max(0, (max_x - bookmark_buttons_start_x -
++                       visible_bookmarks_width) /
++                          2);
++      const int x_offset =
++          centered_bookmarks_start_x - first_visible_bookmark->first->x();
++
++      if (x_offset != 0) {
++        for (const auto& button_and_node : bookmark_buttons_) {
++          views::View* bookmark_button = button_and_node.first;
++          if (!bookmark_button->GetVisible()) {
++            continue;
++          }
++          bookmark_button->SetX(bookmark_button->x() + x_offset);
++        }
++      }
++    }
++  }
+ 
+   // Set the visibility of the tab group separator if there are groups and
+   // bookmarks.
+@@ -1621,6 +1682,11 @@ void BookmarkBarView::Init() {
+       base::BindRepeating(&BookmarkBarView::OnTabGroupsVisibilityPrefChanged,
+                           base::Unretained(this)));
+ 
++  profile_pref_registrar_.Add(
++      bookmarks::prefs::kCenterBookmarksInBookmarkBar,
++      base::BindRepeating(&BookmarkBarView::OnCenterBookmarksPrefChanged,
++                          base::Unretained(this)));
++
+   profile_pref_registrar_.Add(
+       bookmarks::prefs::kShowManagedBookmarksInBookmarkBar,
+       base::BindRepeating(&BookmarkBarView::OnShowManagedBookmarksPrefChanged,
+@@ -2247,6 +2313,10 @@ void BookmarkBarView::OnTabGroupsVisibilityPrefChanged() {
+   LayoutAndPaint();
+ }
+ 
++void BookmarkBarView::OnCenterBookmarksPrefChanged() {
++  LayoutAndPaint();
++}
++
+ void BookmarkBarView::OnShowManagedBookmarksPrefChanged() {
+   if (UpdateOtherAndManagedButtonsVisibility()) {
+     LayoutAndPaint();

--- a/patches/series
+++ b/patches/series
@@ -308,6 +308,7 @@ helium/ui/remove-zoom-action.patch
 
 helium/ui/layout/core.patch
 helium/ui/layout/settings.patch
+helium/ui/layout/center-bookmarks-in-bar.patch
 helium/ui/layout/context-menu.patch
 helium/ui/layout/compact.patch
 helium/ui/layout/vertical.patch


### PR DESCRIPTION
For your pull request to not get closed without review, please confirm that:

- [ ] An issue exists where the maintainers agreed that this should be implemented (an approved feature request, or confirmed bug).
- [x] I tested that my contribution works locally, and does not break anything, otherwise I have marked my PR as draft.
- [x] If my contribution is non-trivial, I did not use AI to write most of it.
- [x] I understand that I will be permanently banned from interacting with this organization if I lied by checking any of these checkboxes.

Tested on (check one or more):
- [ ] Windows
- [x] macOS
- [ ] Linux

---

• Add an Appearance setting to center bookmarks in the bookmarks bar without affecting tab groups.

  - Introduces a new toggle: Center bookmarks bar (Settings > Appearance/Behavior).
  - Adds new pref: bookmark_bar.center_bookmarks with default false.
  - Updates bookmark bar layout so only bookmark buttons are centered when enabled.
  - Keeps saved tab groups left-aligned as before.
  - Wires pref through settings allowlist, localized strings, and syncable prefs metadata.
    
Default Setting:    
<img width="1752" height="107" alt="image" src="https://github.com/user-attachments/assets/a6a9908f-d072-456d-82c7-4528bdc01047" />

Center bookmarks on:
<img width="1755" height="113" alt="image" src="https://github.com/user-attachments/assets/2409d3cd-f693-4d20-b0a8-72ed76dab524" />

Setting - Center bookmarks bar:
<img width="723" height="412" alt="image" src="https://github.com/user-attachments/assets/74453fc1-0e09-42ff-b92f-34d12abd0f65" />


