### PR TITLE
upstream-fixes: disable scroll to change tabs on linux

### DIFF
--- a/patches/series
+++ b/patches/series
@@ -4,6 +4,7 @@ upstream-fixes/vertical/r1568929-animate-cross-collection-operations.patch
 upstream-fixes/vertical/r1570045-improve-dragging-between-groups-and-unpinned.patch
 upstream-fixes/vertical/r1570472-fix-crash-drag-pinned-tabs.patch
 upstream-fixes/vertical/r1570584-remove-redundant-parameter-from-tabdragcontroller.patch
+upstream-fixes/vertical/r1570728-disable-tab-change-scroll-on-linux.patch
 upstream-fixes/vertical/r1571017-add-horizontal-animation-support-to-layout.patch
 upstream-fixes/vertical/r1571331-improve-tab-drag-performance-macos.patch
 upstream-fixes/vertical/r1571338-handle-tab-drags-over-split-vertical-tabs.patch

--- a/patches/ungoogled-chromium/add-flag-to-scroll-tabs.patch
+++ b/patches/ungoogled-chromium/add-flag-to-scroll-tabs.patch
@@ -40,13 +40,13 @@
    // It's possible to destroy the browser while a drop is active.  In this case,
 @@ -331,7 +346,7 @@ bool BrowserRootView::OnMouseWheel(const
  
-   // Scroll-event-changes-tab is incompatible with scrolling tabstrip, so
+   // Scroll-event-changes-tab is incompatible with vertical tabstrip, so
    // disable it if the latter feature is enabled.
--  if (browser_defaults::kScrollEventChangesTab) {
-+  if (scroll_event_changes_tab_) {
+-  if (browser_defaults::kScrollEventChangesTab &&
++  if (scroll_event_changes_tab_ &&
+       !browser_view_->ShouldDrawVerticalTabStrip()) {
      // Switch to the left/right tab if the wheel-scroll happens over the
      // tabstrip, or the empty space beside the tabstrip.
-     views::View* hit_view = GetEventHandlerForPoint(event.location());
 --- a/chrome/browser/ui/views/frame/browser_root_view.h
 +++ b/chrome/browser/ui/views/frame/browser_root_view.h
 @@ -158,6 +158,8 @@ class BrowserRootView : public views::in

--- a/patches/upstream-fixes/vertical/r1570728-disable-tab-change-scroll-on-linux.patch
+++ b/patches/upstream-fixes/vertical/r1570728-disable-tab-change-scroll-on-linux.patch
@@ -1,0 +1,28 @@
+From 5a01450659fa329157d6996f10d4a2ad2ad2decd Mon Sep 17 00:00:00 2001
+From: Alison Gale <agale@chromium.org>
+Date: Fri, 16 Jan 2026 18:35:05 -0800
+Subject: [PATCH] [Vertical Tabs] Disable scroll to change tabs on Linux
+
+Bug: 474165324
+Change-Id: I71eff12cf6f50c238cfbf72d5f0c7789037f5ba0
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7486711
+Commit-Queue: Alison Gale <agale@chromium.org>
+Reviewed-by: Vince Lugli <lugli@google.com>
+Cr-Commit-Position: refs/heads/main@{#1570728}
+---
+
+--- a/chrome/browser/ui/views/frame/browser_root_view.cc
++++ b/chrome/browser/ui/views/frame/browser_root_view.cc
+@@ -329,9 +329,10 @@ bool BrowserRootView::OnMouseWheel(const
+   // TODO(dfried): See if it's possible to move this logic deeper into the view
+   // hierarchy - ideally to HorizontalTabStripRegionView.
+ 
+-  // Scroll-event-changes-tab is incompatible with scrolling tabstrip, so
++  // Scroll-event-changes-tab is incompatible with vertical tabstrip, so
+   // disable it if the latter feature is enabled.
+-  if (browser_defaults::kScrollEventChangesTab) {
++  if (browser_defaults::kScrollEventChangesTab &&
++      !browser_view_->ShouldDrawVerticalTabStrip()) {
+     // Switch to the left/right tab if the wheel-scroll happens over the
+     // tabstrip, or the empty space beside the tabstrip.
+     views::View* hit_view = GetEventHandlerForPoint(event.location());


### PR DESCRIPTION
imo we should remove `ungoogled-chromium/add-flag-to-scroll-tabs.patch` entirely (along with many others) but that's just my minimalist opinion