### PR TITLE
upstream-fixes/vertical: fix vertical tabs layer z order

### DIFF
--- a/patches/helium/ui/layout/vertical.patch
+++ b/patches/helium/ui/layout/vertical.patch
@@ -225,7 +225,7 @@
  #include "chrome/browser/ui/tabs/vertical_tab_strip_state_controller.h"
  #include "chrome/browser/ui/views/frame/browser_view.h"
  #include "chrome/browser/ui/views/frame/top_container_background.h"
-@@ -51,7 +52,9 @@
+@@ -52,7 +53,9 @@
  #include "ui/views/view_utils.h"
  
  namespace {
@@ -236,7 +236,7 @@
  }  // namespace
  
  VerticalTabStripRegionView::VerticalTabStripRegionView(
-@@ -85,15 +88,13 @@ VerticalTabStripRegionView::VerticalTabS
+@@ -91,15 +94,13 @@ VerticalTabStripRegionView::VerticalTabS
        views::FlexSpecification(views::MinimumFlexSizeRule::kPreferred,
                                 views::MaximumFlexSizeRule::kUnbounded));
  
@@ -253,7 +253,7 @@
    resize_animation_.SetTweenType(gfx::Tween::Type::EASE_IN_OUT_EMPHASIZED);
    resize_animation_.Reset(!state_controller_->IsCollapsed());
  
-@@ -142,8 +143,11 @@ void VerticalTabStripRegionView::Layout(
+@@ -148,8 +149,11 @@ void VerticalTabStripRegionView::Layout(
  
    // Manually position the resize area as it overlaps views handled by the flex
    // layout.
@@ -267,7 +267,7 @@
  }
  
  views::View* VerticalTabStripRegionView::GetDefaultFocusableChild() {
-@@ -326,7 +330,10 @@ void VerticalTabStripRegionView::OnResiz
+@@ -332,7 +336,10 @@ void VerticalTabStripRegionView::OnResiz
    if (!starting_width_on_resize_.has_value()) {
      starting_width_on_resize_ = width();
    }
@@ -279,7 +279,7 @@
    if (done_resizing) {
      starting_width_on_resize_ = std::nullopt;
    }
-@@ -336,6 +343,19 @@ void VerticalTabStripRegionView::OnResiz
+@@ -342,6 +349,19 @@ void VerticalTabStripRegionView::OnResiz
      new_state.collapsed = false;
      new_state.uncollapsed_width =
          std::clamp(proposed_width, kUncollapsedMinWidth, kUncollapsedMaxWidth);
@@ -299,7 +299,7 @@
      if (done_resizing) {
        // We only want to save the uncollapsed width to the state controller if
        // the user has lifted their mouse, otherwise dragging the resize area to
-@@ -404,6 +424,15 @@ void VerticalTabStripRegionView::SetExcl
+@@ -410,6 +430,15 @@ void VerticalTabStripRegionView::SetExcl
    top_button_container_->SetExclusionWidthForLayout(exclusion_width);
  }
  
@@ -315,7 +315,7 @@
  VerticalPinnedTabContainerView*
  VerticalTabStripRegionView::GetPinnedTabsContainer() {
    return tab_strip_view_->GetPinnedTabsContainer();
-@@ -425,10 +454,11 @@ views::View* VerticalTabStripRegionView:
+@@ -431,10 +460,11 @@ views::View* VerticalTabStripRegionView:
        views::FlexSpecification(views::MinimumFlexSizeRule::kScaleToZero,
                                 views::MaximumFlexSizeRule::kPreferred));
    tab_strip_view_->SetProperty(views::kMarginsKey,
@@ -331,7 +331,7 @@
    return tab_strip_view_;
  }
  
-@@ -438,6 +468,23 @@ void VerticalTabStripRegionView::ClearTa
+@@ -444,6 +474,23 @@ void VerticalTabStripRegionView::ClearTa
    RemoveChildViewT(std::exchange(tab_strip_view_, nullptr));
  }
  
@@ -355,7 +355,7 @@
  void VerticalTabStripRegionView::OnCollapsedStateChanged(
      tabs::VerticalTabStripStateController* state_controller) {
    if (target_collapse_state_.collapsed != state_controller->IsCollapsed()) {
-@@ -453,16 +500,15 @@ void VerticalTabStripRegionView::OnColla
+@@ -459,16 +506,15 @@ void VerticalTabStripRegionView::OnColla
        state_controller_->IsCollapsed()
            ? LayoutConstant::kVerticalTabStripCollapsedPadding
            : LayoutConstant::kVerticalTabStripUncollapsedPadding);
@@ -375,16 +375,17 @@
  
    if (tab_strip_view_) {
      tab_strip_view_->SetCollapsedState(state_controller->IsCollapsed());
-@@ -503,9 +549,6 @@ void VerticalTabStripRegionView::ResizeT
+@@ -509,10 +555,6 @@ void VerticalTabStripRegionView::ResizeT
  }
  
  void VerticalTabStripRegionView::UpdateBackgroundColors() {
 -  top_button_separator_->SetColorId(IsFrameActive()
 -                                        ? kColorTabDividerFrameActive
 -                                        : kColorTabDividerFrameInactive);
+-
+   SchedulePaint();
  }
  
- bool VerticalTabStripRegionView::IsFrameActive() const {
 --- a/chrome/browser/ui/views/tabs/vertical/vertical_tab_strip_top_container.cc
 +++ b/chrome/browser/ui/views/tabs/vertical/vertical_tab_strip_top_container.cc
 @@ -18,7 +18,8 @@

--- a/patches/series
+++ b/patches/series
@@ -13,6 +13,7 @@ upstream-fixes/vertical/r1571827-update-group-editor-bubble-anchoring.patch
 upstream-fixes/vertical/r1571897-paint-dragged-tabs-to-layer.patch
 upstream-fixes/vertical/r1571978-support-dragging-multiple-vertical-tabs.patch
 upstream-fixes/vertical/r1572056-fix-hit-test-context-menu.patch
+upstream-fixes/vertical/r1572266-fix-vertical-tab-strip-z-order.patch
 upstream-fixes/vertical/r1572660-correctly-position-dragged-split-views.patch
 upstream-fixes/vertical/r1572664-rename-tabslotshimview-to-verticaltabslotview.patch
 upstream-fixes/vertical/r1572994-check-tab-collection-node-before-dragging.patch

--- a/patches/upstream-fixes/vertical/r1572266-fix-vertical-tab-strip-z-order.patch
+++ b/patches/upstream-fixes/vertical/r1572266-fix-vertical-tab-strip-z-order.patch
@@ -1,0 +1,55 @@
+From fba80fe8421c23bdc0e1403d4694a2b008c5aa51 Mon Sep 17 00:00:00 2001
+From: Dana Fried <dfried@chromium.org>
+Date: Wed, 21 Jan 2026 06:14:27 -0800
+Subject: [PATCH] [Vertical Tabs] Paint tabstrip to layer
+
+This prevents the animating side panel from painting over the tabstrip,
+since Z-order works like:
+
+layer highest Z
+...
+layer lowest Z
+non-layer highest Z
+...
+non-layer lowest Z
+
+Bug: 473424028
+Change-Id: I09e4f2c60c5dd45583c15523316a940b85ecab35
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7494682
+Commit-Queue: Dana Fried <dfried@chromium.org>
+Auto-Submit: Dana Fried <dfried@chromium.org>
+Reviewed-by: Eshwar Stalin <estalin@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1572266}
+---
+
+--- a/chrome/browser/ui/views/frame/vertical_tab_strip_region_view.cc
++++ b/chrome/browser/ui/views/frame/vertical_tab_strip_region_view.cc
+@@ -37,6 +37,7 @@
+ #include "components/tabs/public/tab_interface.h"
+ #include "ui/base/metadata/metadata_impl_macros.h"
+ #include "ui/color/color_id.h"
++#include "ui/compositor/layer.h"
+ #include "ui/gfx/animation/animation.h"
+ #include "ui/views/background.h"
+ #include "ui/views/controls/resize_area.h"
+@@ -61,6 +62,11 @@ VerticalTabStripRegionView::VerticalTabS
+     : tab_strip_model_(browser->GetTabStripModel()),
+       state_controller_(state_controller),
+       resize_animation_(this) {
++  // For z-ordering purposes this needs to be on a layer.
++  SetPaintToLayer();
++  // Because corners may be transparent, this must be set to false.
++  layer()->SetFillsBoundsOpaquely(false);
++
+   flex_layout_ = SetLayoutManager(std::make_unique<views::FlexLayout>());
+   flex_layout_->SetOrientation(views::LayoutOrientation::kVertical)
+       .SetCollapseMargins(true)
+@@ -471,6 +477,8 @@ void VerticalTabStripRegionView::UpdateB
+   top_button_separator_->SetColorId(IsFrameActive()
+                                         ? kColorTabDividerFrameActive
+                                         : kColorTabDividerFrameInactive);
++
++  SchedulePaint();
+ }
+ 
+ bool VerticalTabStripRegionView::IsFrameActive() const {

--- a/patches/upstream-fixes/vertical/r1573324-lazily-load-tabstrips-when-switching-modes.patch
+++ b/patches/upstream-fixes/vertical/r1573324-lazily-load-tabstrips-when-switching-modes.patch
@@ -176,7 +176,7 @@ Cr-Commit-Position: refs/heads/main@{#1573324}
    virtual void DisableTabStripEditingForTesting() const = 0;
 --- a/chrome/browser/ui/views/frame/vertical_tab_strip_region_view.cc
 +++ b/chrome/browser/ui/views/frame/vertical_tab_strip_region_view.cc
-@@ -58,7 +58,8 @@ VerticalTabStripRegionView::VerticalTabS
+@@ -59,7 +59,8 @@ VerticalTabStripRegionView::VerticalTabS
      actions::ActionItem* root_action_item,
      BrowserWindowInterface* browser,
      BrowserView* browser_view)
@@ -185,8 +185,8 @@ Cr-Commit-Position: refs/heads/main@{#1573324}
 +      tab_strip_model_(browser_view->browser()->GetTabStripModel()),
        state_controller_(state_controller),
        resize_animation_(this) {
-   flex_layout_ = SetLayoutManager(std::make_unique<views::FlexLayout>());
-@@ -105,21 +106,22 @@ VerticalTabStripRegionView::VerticalTabS
+   // For z-ordering purposes this needs to be on a layer.
+@@ -111,21 +112,22 @@ VerticalTabStripRegionView::VerticalTabS
  
    GetViewAccessibility().SetRole(ax::mojom::Role::kTabList);
  
@@ -217,7 +217,7 @@ Cr-Commit-Position: refs/heads/main@{#1573324}
  }
  
  void VerticalTabStripRegionView::AddedToWidget() {
-@@ -142,6 +144,56 @@ views::View* VerticalTabStripRegionView:
+@@ -148,6 +150,56 @@ views::View* VerticalTabStripRegionView:
    return top_button_container_;
  }
  
@@ -274,7 +274,7 @@ Cr-Commit-Position: refs/heads/main@{#1573324}
  bool VerticalTabStripRegionView::IsTabStripEditable() const {
    // TODO(crbug.com/467710547): This needs to consider the drag context. Wait
    // until that is implemented before updating this function.
-@@ -341,29 +393,6 @@ bool VerticalTabStripRegionView::IsPosit
+@@ -347,29 +399,6 @@ bool VerticalTabStripRegionView::IsPosit
    return true;
  }
  
@@ -304,7 +304,7 @@ Cr-Commit-Position: refs/heads/main@{#1573324}
  void VerticalTabStripRegionView::SetToolbarHeightForLayout(
      const int toolbar_height) {
    top_button_container_->SetToolbarHeightForLayout(toolbar_height);
-@@ -403,6 +432,12 @@ views::View* VerticalTabStripRegionView:
+@@ -409,6 +438,12 @@ views::View* VerticalTabStripRegionView:
    return tab_strip_view_;
  }
  

--- a/patches/upstream-fixes/vertical/r1573883-fix-crash-dragging-from-inactive-tabstrip.patch
+++ b/patches/upstream-fixes/vertical/r1573883-fix-crash-dragging-from-inactive-tabstrip.patch
@@ -19,7 +19,7 @@ Cr-Commit-Position: refs/heads/main@{#1573883}
 
 --- a/chrome/browser/ui/views/frame/vertical_tab_strip_region_view.cc
 +++ b/chrome/browser/ui/views/frame/vertical_tab_strip_region_view.cc
-@@ -514,6 +514,10 @@ bool VerticalTabStripRegionView::IsFrame
+@@ -522,6 +522,10 @@ bool VerticalTabStripRegionView::IsFrame
  
  TabDragTarget* VerticalTabStripRegionView::GetTabDragTarget(
      const gfx::Point& point_in_screen) {

--- a/patches/upstream-fixes/vertical/r1574955-handle-dragging-pinned-vertical-tabs.patch
+++ b/patches/upstream-fixes/vertical/r1574955-handle-dragging-pinned-vertical-tabs.patch
@@ -30,7 +30,7 @@ Cr-Commit-Position: refs/heads/main@{#1574955}
  #include "chrome/browser/ui/views/tabs/vertical/vertical_tab_drag_handler.h"
  #include "chrome/browser/ui/views/tabs/vertical/vertical_tab_strip_bottom_container.h"
  #include "chrome/browser/ui/views/tabs/vertical/vertical_tab_strip_controller.h"
-@@ -119,7 +120,7 @@ VerticalTabStripRegionView::~VerticalTab
+@@ -125,7 +126,7 @@ VerticalTabStripRegionView::~VerticalTab
    tab_strip_controller_.reset();
  
    if (drag_handler_) {
@@ -39,7 +39,7 @@ Cr-Commit-Position: refs/heads/main@{#1574955}
      drag_handler_ = nullptr;
    }
  }
-@@ -189,7 +190,9 @@ void VerticalTabStripRegionView::ResetTa
+@@ -195,7 +196,9 @@ void VerticalTabStripRegionView::ResetTa
    tab_strip_controller_.reset();
  
    CHECK(drag_handler_);
@@ -50,7 +50,7 @@ Cr-Commit-Position: refs/heads/main@{#1574955}
  
    root_node_.reset();
  }
-@@ -303,7 +306,7 @@ views::View* VerticalTabStripRegionView:
+@@ -309,7 +312,7 @@ views::View* VerticalTabStripRegionView:
  }
  
  TabDragContext* VerticalTabStripRegionView::GetDragContext() {
@@ -59,7 +59,7 @@ Cr-Commit-Position: refs/heads/main@{#1574955}
  }
  
  std::optional<BrowserRootView::DropIndex>
-@@ -517,13 +520,17 @@ TabDragTarget* VerticalTabStripRegionVie
+@@ -525,13 +528,17 @@ TabDragTarget* VerticalTabStripRegionVie
    if (!drag_handler_) {
      return nullptr;
    }

--- a/patches/upstream-fixes/vertical/r1576224-implement-tabstripregionview-overrides.patch
+++ b/patches/upstream-fixes/vertical/r1576224-implement-tabstripregionview-overrides.patch
@@ -25,7 +25,7 @@ Cr-Commit-Position: refs/heads/main@{#1576224}
 
 --- a/chrome/browser/ui/views/frame/vertical_tab_strip_region_view.cc
 +++ b/chrome/browser/ui/views/frame/vertical_tab_strip_region_view.cc
-@@ -198,35 +198,31 @@ void VerticalTabStripRegionView::ResetTa
+@@ -204,35 +204,31 @@ void VerticalTabStripRegionView::ResetTa
  }
  
  bool VerticalTabStripRegionView::IsTabStripEditable() const {

--- a/patches/upstream-fixes/vertical/r1578230-move-ntb.patch
+++ b/patches/upstream-fixes/vertical/r1578230-move-ntb.patch
@@ -24,7 +24,7 @@ Cr-Commit-Position: refs/heads/main@{#1578230}
 
 --- a/chrome/browser/ui/views/frame/vertical_tab_strip_region_view.cc
 +++ b/chrome/browser/ui/views/frame/vertical_tab_strip_region_view.cc
-@@ -76,12 +76,17 @@ VerticalTabStripRegionView::VerticalTabS
+@@ -82,12 +82,17 @@ VerticalTabStripRegionView::VerticalTabS
        AddChildView(std::make_unique<VerticalTabStripTopContainer>(
            state_controller_, root_action_item));
  
@@ -44,7 +44,7 @@ Cr-Commit-Position: refs/heads/main@{#1578230}
    gemini_button_ = AddChildView(std::make_unique<views::View>());
  
    resize_area_ = AddChildView(std::make_unique<views::ResizeArea>(this));
-@@ -422,7 +427,7 @@ views::View* VerticalTabStripRegionView:
+@@ -428,7 +433,7 @@ views::View* VerticalTabStripRegionView:
    tab_strip_view_->SetProperty(
        views::kFlexBehaviorKey,
        views::FlexSpecification(views::MinimumFlexSizeRule::kScaleToZero,

--- a/patches/upstream-fixes/vertical/r1578463-eliminate-stopanimating-api.patch
+++ b/patches/upstream-fixes/vertical/r1578463-eliminate-stopanimating-api.patch
@@ -55,7 +55,7 @@ Cr-Commit-Position: refs/heads/main@{#1578463}
    virtual const TabRendererData& GetTabRendererData(int tab_index) = 0;
 --- a/chrome/browser/ui/views/frame/vertical_tab_strip_region_view.cc
 +++ b/chrome/browser/ui/views/frame/vertical_tab_strip_region_view.cc
-@@ -222,14 +222,6 @@ bool VerticalTabStripRegionView::IsTabSt
+@@ -228,14 +228,6 @@ bool VerticalTabStripRegionView::IsTabSt
    return !drag_controller || drag_controller->IsMovingLastTab();
  }
  

--- a/patches/upstream-fixes/vertical/r1579815-fix-context-after-ntb-move.patch
+++ b/patches/upstream-fixes/vertical/r1579815-fix-context-after-ntb-move.patch
@@ -17,7 +17,7 @@ Cr-Commit-Position: refs/heads/main@{#1579815}
 
 --- a/chrome/browser/ui/views/frame/vertical_tab_strip_region_view.cc
 +++ b/chrome/browser/ui/views/frame/vertical_tab_strip_region_view.cc
-@@ -383,6 +383,10 @@ bool VerticalTabStripRegionView::IsPosit
+@@ -389,6 +389,10 @@ bool VerticalTabStripRegionView::IsPosit
        if (child == tab_strip_view_) {
          return tab_strip_view_->IsPositionInWindowCaption(point_in_child);
        }


### PR DESCRIPTION
prevents side panel from painting over the tab strip

before:

https://github.com/user-attachments/assets/4eec3507-8874-42a1-940c-377e99f3a60d

after:

https://github.com/user-attachments/assets/3c5b7cac-ed32-49e4-935b-fcef7c8788cb

