### PR TITLE
upstream-fixes/vertical: autoscroll to activated tabs

### DIFF
--- a/patches/helium/ui/layout/vertical.patch
+++ b/patches/helium/ui/layout/vertical.patch
@@ -315,23 +315,24 @@
  VerticalPinnedTabContainerView*
  VerticalTabStripRegionView::GetPinnedTabsContainer() {
    return tab_strip_view_->GetPinnedTabsContainer();
-@@ -431,10 +460,11 @@ views::View* VerticalTabStripRegionView:
+@@ -431,11 +460,12 @@ views::View* VerticalTabStripRegionView:
        views::FlexSpecification(views::MinimumFlexSizeRule::kScaleToZero,
                                 views::MaximumFlexSizeRule::kPreferred));
    tab_strip_view_->SetProperty(views::kMarginsKey,
 -                               gfx::Insets::VH(kRegionVerticalPadding, 0));
++      gfx::Insets::TLBR(kRegionVerticalPadding, 0,
++          kBottomContainerGap, 0));
+   tab_strip_view_->InitializeTabStrip(*tab_strip_model_);
 -  std::optional<size_t> separator_index = GetIndexOf(top_button_separator_);
 -  CHECK(separator_index.has_value());
 -  ReorderChildView(tab_strip_view_, separator_index.value() + 1);
-+      gfx::Insets::TLBR(kRegionVerticalPadding, 0,
-+          kBottomContainerGap, 0));
 +  std::optional<size_t> top_container_index = GetIndexOf(top_button_container_);
 +  CHECK(top_container_index.has_value());
 +  ReorderChildView(tab_strip_view_, top_container_index.value() + 1);
    return tab_strip_view_;
  }
  
-@@ -444,6 +474,23 @@ void VerticalTabStripRegionView::ClearTa
+@@ -445,6 +475,23 @@ void VerticalTabStripRegionView::ClearTa
    RemoveChildViewT(std::exchange(tab_strip_view_, nullptr));
  }
  
@@ -355,7 +356,7 @@
  void VerticalTabStripRegionView::OnCollapsedStateChanged(
      tabs::VerticalTabStripStateController* state_controller) {
    if (target_collapse_state_.collapsed != state_controller->IsCollapsed()) {
-@@ -459,16 +506,15 @@ void VerticalTabStripRegionView::OnColla
+@@ -460,16 +507,15 @@ void VerticalTabStripRegionView::OnColla
        state_controller_->IsCollapsed()
            ? LayoutConstant::kVerticalTabStripCollapsedPadding
            : LayoutConstant::kVerticalTabStripUncollapsedPadding);
@@ -375,7 +376,7 @@
  
    if (tab_strip_view_) {
      tab_strip_view_->SetCollapsedState(state_controller->IsCollapsed());
-@@ -509,10 +555,6 @@ void VerticalTabStripRegionView::ResizeT
+@@ -510,10 +556,6 @@ void VerticalTabStripRegionView::ResizeT
  }
  
  void VerticalTabStripRegionView::UpdateBackgroundColors() {

--- a/patches/series
+++ b/patches/series
@@ -23,6 +23,8 @@ upstream-fixes/vertical/r1573883-fix-crash-dragging-from-inactive-tabstrip.patch
 upstream-fixes/vertical/r1574955-handle-dragging-pinned-vertical-tabs.patch
 upstream-fixes/vertical/r1576165-correctly-position-tabs-dragged-at-bottom-of-container.patch
 upstream-fixes/vertical/r1576224-implement-tabstripregionview-overrides.patch
+upstream-fixes/vertical/r1576368-add-scrollview-api.patch
+upstream-fixes/vertical/r1576442-scroll-to-activated-tabs.patch
 upstream-fixes/vertical/r1576761-move-drag-offset-data-to-dragsessiondata.patch
 upstream-fixes/vertical/r1576938-fix-drag-targeting-crash.patch
 upstream-fixes/vertical/r1577348-support-dragging-tabgroup-headers.patch

--- a/patches/upstream-fixes/vertical/r1576368-add-scrollview-api.patch
+++ b/patches/upstream-fixes/vertical/r1576368-add-scrollview-api.patch
@@ -1,0 +1,110 @@
+From c85037d93ebf287dd174f7917e2aeb71f49a4314 Mon Sep 17 00:00:00 2001
+From: thomas lukaszewicz <tluk@chromium.org>
+Date: Wed, 28 Jan 2026 21:15:23 -0800
+Subject: [PATCH] Add ScrollView::RequestSuccessfulPresentationTimeForNextFrame()
+
+This CL adds a new API that enables clients to respond to changes in
+scroll view content bounds.
+
+This is intended to be used in combination with ScrollView scroll
+APIs (e.g. ScrollToOffset(), ScrollByOffset()) where it is necessary
+for the content bounds to have been updated for offsets to be
+computed correctly.
+
+The associated callback must wait for the compositor to generate
+the next frame. This is necessary as layer scroll calculations
+require the compositor to update layer information.
+
+Bug: 459824840
+Change-Id: If9cfb74e8982cc63440cc257b35f9fe3039eb7ae
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7528853
+Commit-Queue: Tom Lukaszewicz <tluk@chromium.org>
+Reviewed-by: Keren Zhu <kerenzhu@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1576368}
+---
+
+--- a/ui/views/controls/scroll_view.cc
++++ b/ui/views/controls/scroll_view.cc
+@@ -927,6 +927,22 @@ void ScrollView::Layout(PassKey) {
+     post_layout_callback_.Run(this);
+     CHECK_EQ(layout_needed, needs_layout());
+   }
++
++  if (next_successful_frame_post_layout_callback_) {
++    // Layout should only occur to Widget parented Views.
++    views::Widget* const widget = GetWidget();
++    CHECK(widget);
++    widget->GetCompositor()->RequestSuccessfulPresentationTimeForNextFrame(
++        base::BindOnce(
++            [](base::WeakPtr<ScrollView> self, base::OnceClosure callback,
++               const viz::FrameTimingDetails& frame_timing_details) {
++              if (self) {
++                std::move(callback).Run();
++              }
++            },
++            weak_ptr_factory_.GetWeakPtr(),
++            std::move(next_successful_frame_post_layout_callback_)));
++  }
+ }
+ 
+ bool ScrollView::OnKeyPressed(const ui::KeyEvent& event) {
+@@ -1469,6 +1485,11 @@ void ScrollView::RegisterPostLayoutCallb
+   post_layout_callback_ = post_layout_callback;
+ }
+ 
++void ScrollView::RegisterNextSuccessfulFramePostLayoutCallback(
++    base::OnceClosure callback) {
++  next_successful_frame_post_layout_callback_ = std::move(callback);
++}
++
+ View* ScrollView::GetContentsViewportForTest() const {
+   return contents_viewport_;
+ }
+--- a/ui/views/controls/scroll_view.h
++++ b/ui/views/controls/scroll_view.h
+@@ -11,6 +11,7 @@
+ 
+ #include "base/callback_list.h"
+ #include "base/memory/raw_ptr.h"
++#include "base/memory/weak_ptr.h"
+ #include "ui/color/color_variant.h"
+ #include "ui/compositor/layer_type.h"
+ #include "ui/views/controls/focus_ring.h"
+@@ -257,9 +258,19 @@ class VIEWS_EXPORT ScrollView : public V
+   // and to update the scrollbars to reflect the new position.
+   // The callback should not trigger any new layouts on the scroll view,
+   // otherwise it will lead to a CHECK failure.
++  // DEPRECATED: Use `RegisterNextSuccessfulFramePostLayoutCallback()` instead.
+   void RegisterPostLayoutCallback(
+       base::RepeatingCallback<void(ScrollView*)> post_layout_callback);
+ 
++  // Registers a callback that will be invoked after the compositor has
++  // submitted the next successful frame following the next layout pass. Waiting
++  // for the next frame post layout is necessary as a given layout pass will not
++  // be reflected on a content view's layer until a frame has been produced.
++  // Failing to wait for frame production will result in incorrect scroll
++  // behavior of APIs such as `ScrollToOffset()` and `ScrollByOffset()`.
++  void RegisterNextSuccessfulFramePostLayoutCallback(
++      base::OnceClosure callback);
++
+   bool is_scrolling() const {
+     return horiz_sb_->is_scrolling() || vert_sb_->is_scrolling();
+   }
+@@ -434,6 +445,8 @@ class VIEWS_EXPORT ScrollView : public V
+   // Post-layout callback.
+   base::RepeatingCallback<void(ScrollView*)> post_layout_callback_;
+ 
++  base::OnceClosure next_successful_frame_post_layout_callback_;
++
+   GradientDirection gradient_direction_ = GradientDirection::kNone;
+ 
+   // Track if the leading gradient is shown
+@@ -441,6 +454,8 @@ class VIEWS_EXPORT ScrollView : public V
+ 
+   // Track if the trailing gradient is shown
+   bool is_trailing_gradient_visible_ = false;
++
++  base::WeakPtrFactory<ScrollView> weak_ptr_factory_{this};
+ };
+ 
+ // When building with GCC this ensures that an instantiation of the

--- a/patches/upstream-fixes/vertical/r1576442-scroll-to-activated-tabs.patch
+++ b/patches/upstream-fixes/vertical/r1576442-scroll-to-activated-tabs.patch
@@ -1,0 +1,323 @@
+From 215ae0715affb24f938d45d4f5935bb29ecd9c38 Mon Sep 17 00:00:00 2001
+From: thomas lukaszewicz <tluk@chromium.org>
+Date: Thu, 29 Jan 2026 02:02:10 -0800
+Subject: [PATCH] [Vertical Tabs] Add support for scrolling to activated tabs
+
+This CL adds support for scrolling into view activated tabs across
+both pinned and unpinned collections.
+
+This CL handles cases where tabs may be present in nested collections
+(such as tab groups or split tabs).
+
+A static method was added to the animating layout manager that allows
+querying for view target bounds, independent of any animations that
+may currently be in progress.
+
+See video below
+http://screencast/cast/NDc0Nzk2OTUzMzMxMzAyNHwxNTA4OTI3Zi1mNw
+
+Bug: 459824840, 475613765
+Change-Id: I69fa14c6c515db50583bc0b470e043077843c888
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7530416
+Reviewed-by: Eshwar Stalin <estalin@chromium.org>
+Commit-Queue: Tom Lukaszewicz <tluk@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1576442}
+---
+
+--- a/chrome/browser/ui/views/frame/vertical_tab_strip_region_view.cc
++++ b/chrome/browser/ui/views/frame/vertical_tab_strip_region_view.cc
+@@ -431,6 +431,7 @@ views::View* VerticalTabStripRegionView:
+                                views::MaximumFlexSizeRule::kUnbounded));
+   tab_strip_view_->SetProperty(views::kMarginsKey,
+                                gfx::Insets::VH(kRegionVerticalPadding, 0));
++  tab_strip_view_->InitializeTabStrip(*tab_strip_model_);
+   std::optional<size_t> separator_index = GetIndexOf(top_button_separator_);
+   CHECK(separator_index.has_value());
+   ReorderChildView(tab_strip_view_, separator_index.value() + 1);
+--- a/chrome/browser/ui/views/tabs/vertical/BUILD.gn
++++ b/chrome/browser/ui/views/tabs/vertical/BUILD.gn
+@@ -16,6 +16,7 @@ source_set("vertical") {
+     "vertical_split_tab_view.h",
+     "vertical_tab_strip_bottom_container.h",
+     "vertical_tab_strip_top_container.h",
++    "vertical_tab_strip_utils.h",
+     "vertical_tab_strip_view.h",
+     "vertical_unpinned_tab_container_view.h",
+   ]
+@@ -52,6 +53,7 @@ source_set("impl") {
+     "vertical_tab_group_view.h",
+     "vertical_tab_strip_bottom_container.cc",
+     "vertical_tab_strip_top_container.cc",
++    "vertical_tab_strip_utils.cc",
+     "vertical_tab_strip_view.cc",
+     "vertical_tab_view.cc",
+     "vertical_tab_view.h",
+--- /dev/null
++++ b/chrome/browser/ui/views/tabs/vertical/vertical_tab_strip_utils.cc
+@@ -0,0 +1,37 @@
++// Copyright 2026 The Chromium Authors
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#include "chrome/browser/ui/views/tabs/vertical/vertical_tab_strip_utils.h"
++
++#include "chrome/browser/ui/views/tabs/vertical/tab_collection_animating_layout_manager.h"
++#include "chrome/browser/ui/views/tabs/vertical/vertical_pinned_tab_container_view.h"
++#include "chrome/browser/ui/views/tabs/vertical/vertical_tab_group_view.h"
++#include "chrome/browser/ui/views/tabs/vertical/vertical_unpinned_tab_container_view.h"
++#include "ui/views/view.h"
++#include "ui/views/view_utils.h"
++
++gfx::Rect GetVerticalTabStripViewTargetBounds(const views::View* view) {
++  CHECK(view);
++
++  const views::View* const parent = view->parent();
++  const auto has_animating_layout_manager = [](const views::View* container) {
++    // New clients of `TabCollectionAnimatingLayoutManager` should be added to
++    // this list as usage expands.
++    return views::IsViewClass<VerticalPinnedTabContainerView>(container) ||
++           views::IsViewClass<VerticalUnpinnedTabContainerView>(container) ||
++           views::IsViewClass<VerticalTabGroupView>(container);
++  };
++  if (!parent || !has_animating_layout_manager(parent)) {
++    return view->bounds();
++  }
++
++  const auto* const layout_manager =
++      static_cast<const TabCollectionAnimatingLayoutManager*>(
++          parent->GetLayoutManager());
++  CHECK(layout_manager);
++
++  const views::ChildLayout* const view_layout =
++      layout_manager->target_layout().GetLayoutFor(view);
++  return view_layout ? view_layout->bounds : view->bounds();
++}
+--- /dev/null
++++ b/chrome/browser/ui/views/tabs/vertical/vertical_tab_strip_utils.h
+@@ -0,0 +1,20 @@
++// Copyright 2026 The Chromium Authors
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#ifndef CHROME_BROWSER_UI_VIEWS_TABS_VERTICAL_VERTICAL_TAB_STRIP_UTILS_H_
++#define CHROME_BROWSER_UI_VIEWS_TABS_VERTICAL_VERTICAL_TAB_STRIP_UTILS_H_
++
++#include "ui/gfx/geometry/rect.h"
++
++namespace views {
++class View;
++}
++
++// Returns the target bounds for the provided `view` in the vertical tab strip
++// hierarchy. For views managed by `TabCollectionAnimatingLayoutManager` this
++// may differ from current `View::bounds()` due to animated transitions. For
++// other views the current bounds will be returned.
++gfx::Rect GetVerticalTabStripViewTargetBounds(const views::View* view);
++
++#endif  // CHROME_BROWSER_UI_VIEWS_TABS_VERTICAL_VERTICAL_TAB_STRIP_UTILS_H_
+--- a/chrome/browser/ui/views/tabs/vertical/vertical_tab_strip_view.cc
++++ b/chrome/browser/ui/views/tabs/vertical/vertical_tab_strip_view.cc
+@@ -9,8 +9,10 @@
+ #include "chrome/browser/ui/browser_element_identifiers.h"
+ #include "chrome/browser/ui/color/chrome_color_id.h"
+ #include "chrome/browser/ui/layout_constants.h"
++#include "chrome/browser/ui/tabs/tab_strip_model.h"
+ #include "chrome/browser/ui/views/tabs/vertical/tab_collection_node.h"
+ #include "chrome/browser/ui/views/tabs/vertical/vertical_pinned_tab_container_view.h"
++#include "chrome/browser/ui/views/tabs/vertical/vertical_tab_strip_utils.h"
+ #include "chrome/browser/ui/views/tabs/vertical/vertical_unpinned_tab_container_view.h"
+ #include "ui/base/metadata/metadata_impl_macros.h"
+ #include "ui/color/color_id.h"
+@@ -22,6 +24,7 @@
+ #include "ui/views/layout/proposed_layout.h"
+ #include "ui/views/view.h"
+ #include "ui/views/view_class_properties.h"
++#include "ui/views/view_tracker.h"
+ #include "ui/views/view_utils.h"
+ 
+ namespace {
+@@ -38,7 +41,8 @@ void SetScrollViewProperties(views::Scro
+ }
+ }  // namespace
+ 
+-VerticalTabStripView::VerticalTabStripView(TabCollectionNode* collection_node) {
++VerticalTabStripView::VerticalTabStripView(TabCollectionNode* collection_node)
++    : collection_node_(collection_node) {
+   SetLayoutManager(std::make_unique<views::DelegatingLayoutManager>(this));
+   SetProperty(views::kElementIdentifierKey, kTabStripElementId);
+ 
+@@ -59,6 +63,10 @@ VerticalTabStripView::VerticalTabStripVi
+ 
+   collection_node->set_remove_child_from_node(base::BindRepeating(
+       &VerticalTabStripView::RemoveScrollViewContents, base::Unretained(this)));
++
++  node_destroyed_subscription_ =
++      collection_node_->RegisterWillDestroyCallback(base::BindOnce(
++          &VerticalTabStripView::ResetCollectionNode, base::Unretained(this)));
+ }
+ 
+ VerticalTabStripView::~VerticalTabStripView() = default;
+@@ -138,6 +146,33 @@ views::ProposedLayout VerticalTabStripVi
+   return layouts;
+ }
+ 
++void VerticalTabStripView::OnTabStripModelChanged(
++    TabStripModel* tab_strip_model,
++    const TabStripModelChange& change,
++    const TabStripSelectionChange& selection) {
++  if (collection_node_ && selection.active_tab_changed() && selection.new_tab) {
++    TabCollectionNode* activated_node =
++        collection_node_->GetNodeForHandle(selection.new_tab->GetHandle());
++    CHECK(activated_node);
++
++    if (pinned_tabs_container_view_->Contains(activated_node->view())) {
++      pinned_tabs_scroll_view_->RegisterNextSuccessfulFramePostLayoutCallback(
++          base::BindOnce(
++              &VerticalTabStripView::DidPresentFramePostActivation,
++              base::Unretained(this), pinned_tabs_scroll_view_,
++              std::make_unique<views::ViewTracker>(activated_node->view())));
++    } else {
++      // Views must either be in the pinned or unpinned view trees.
++      DCHECK(unpinned_tabs_container_view_->Contains(activated_node->view()));
++      unpinned_tabs_scroll_view_->RegisterNextSuccessfulFramePostLayoutCallback(
++          base::BindOnce(
++              &VerticalTabStripView::DidPresentFramePostActivation,
++              base::Unretained(this), unpinned_tabs_scroll_view_,
++              std::make_unique<views::ViewTracker>(activated_node->view())));
++    }
++  }
++}
++
+ VerticalPinnedTabContainerView* VerticalTabStripView::GetPinnedTabsContainer() {
+   return pinned_tabs_container_view_;
+ }
+@@ -194,6 +229,12 @@ bool VerticalTabStripView::IsPositionInW
+   return true;
+ }
+ 
++void VerticalTabStripView::InitializeTabStrip(TabStripModel& tab_strip_model) {
++  // TODO(crbug.com/452120900): TabStripModelObserver auto-unregisters in its
++  // destructor.
++  tab_strip_model.AddObserver(this);
++}
++
+ views::View* VerticalTabStripView::AddScrollViewContents(
+     std::unique_ptr<views::View> view) {
+   if (auto* container =
+@@ -226,5 +267,46 @@ void VerticalTabStripView::RemoveScrollV
+   NOTREACHED();
+ }
+ 
++void VerticalTabStripView::ResetCollectionNode() {
++  collection_node_ = nullptr;
++}
++
++void VerticalTabStripView::DidPresentFramePostActivation(
++    views::ScrollView* scroll_view,
++    std::unique_ptr<views::ViewTracker> view_tracker) {
++  views::View* const activated_view = view_tracker->view();
++
++  // Guard against views being removed from the tree between frames.
++  if (!activated_view || !Contains(activated_view)) {
++    return;
++  }
++
++  // Get view bounds in its contents coordinates.
++  gfx::Rect activated_view_bounds =
++      GetVerticalTabStripViewTargetBounds(activated_view);
++
++  // Proceed up the hierarchy until the content view is reached, iteratively
++  // adjusting target view bounds.
++  for (views::View* v = activated_view->parent(); v != scroll_view->contents();
++       v = v->parent()) {
++    activated_view_bounds =
++        views::View::ConvertRectToTarget(v, v->parent(), activated_view_bounds);
++  }
++
++  // Get the visible bounds of the content view.
++  const gfx::Rect visible_contents_rect = scroll_view->GetVisibleRect();
++
++  // Determine the adjustment required to fit the activated view into the
++  // visible content view bounds.
++  gfx::Rect adjusted_activated_view_bounds = activated_view_bounds;
++  adjusted_activated_view_bounds.AdjustToFit(visible_contents_rect);
++
++  // Calculate the required scroll offset for the visible content bounds (the
++  // reverse of the activated view adjustment).
++  int diff = activated_view_bounds.y() - adjusted_activated_view_bounds.y();
++
++  scroll_view->ScrollByOffset({0, static_cast<float>(diff)});
++}
++
+ BEGIN_METADATA(VerticalTabStripView)
+ END_METADATA
+--- a/chrome/browser/ui/views/tabs/vertical/vertical_tab_strip_view.h
++++ b/chrome/browser/ui/views/tabs/vertical/vertical_tab_strip_view.h
+@@ -6,11 +6,13 @@
+ #define CHROME_BROWSER_UI_VIEWS_TABS_VERTICAL_VERTICAL_TAB_STRIP_VIEW_H_
+ 
+ #include "base/memory/raw_ptr.h"
++#include "chrome/browser/ui/tabs/tab_strip_model_observer.h"
+ #include "ui/base/metadata/metadata_header_macros.h"
+ #include "ui/views/layout/delegating_layout_manager.h"
+ #include "ui/views/view.h"
+ 
+ class TabCollectionNode;
++class TabStripModel;
+ class VerticalPinnedTabContainerView;
+ class VerticalUnpinnedTabContainerView;
+ 
+@@ -18,11 +20,13 @@ namespace views {
+ class ScrollView;
+ class Separator;
+ class View;
++class ViewTracker;
+ }  // namespace views
+ 
+ // Container that holds the pinned and unpinned tabs in the vertical tab strip.
+ class VerticalTabStripView final : public views::View,
+-                                   public views::LayoutDelegate {
++                                   public views::LayoutDelegate,
++                                   public TabStripModelObserver {
+   METADATA_HEADER(VerticalTabStripView, views::View)
+ 
+  public:
+@@ -39,14 +43,30 @@ class VerticalTabStripView final : publi
+ 
+   bool IsPositionInWindowCaption(const gfx::Point& point);
+ 
++  void InitializeTabStrip(TabStripModel& tab_strip_model);
++
+   // LayoutDelegate:
+   views::ProposedLayout CalculateProposedLayout(
+       const views::SizeBounds& size_bounds) const override;
+ 
++  // TabStripModelObserver:
++  void OnTabStripModelChanged(
++      TabStripModel* tab_strip_model,
++      const TabStripModelChange& change,
++      const TabStripSelectionChange& selection) override;
++
+  private:
+   views::View* AddScrollViewContents(std::unique_ptr<views::View> view);
+   void RemoveScrollViewContents(views::View* view);
++  void ResetCollectionNode();
++
++  // Called when the compositor has successfully presented the next frame
++  // after an activation of `tracked_view` in `scroll_view`.
++  void DidPresentFramePostActivation(
++      views::ScrollView* scroll_view,
++      std::unique_ptr<views::ViewTracker> tracked_view);
+ 
++  raw_ptr<TabCollectionNode> collection_node_;
+   raw_ptr<views::ScrollView> pinned_tabs_scroll_view_ = nullptr;
+   raw_ptr<VerticalPinnedTabContainerView> pinned_tabs_container_view_ = nullptr;
+   raw_ptr<views::Separator> tabs_separator_ = nullptr;
+@@ -54,6 +74,7 @@ class VerticalTabStripView final : publi
+   raw_ptr<VerticalUnpinnedTabContainerView> unpinned_tabs_container_view_ =
+       nullptr;
+   bool is_collapsed_ = false;
++  base::CallbackListSubscription node_destroyed_subscription_;
+ };
+ 
+ #endif  // CHROME_BROWSER_UI_VIEWS_TABS_VERTICAL_VERTICAL_TAB_STRIP_VIEW_H_

--- a/patches/upstream-fixes/vertical/r1578138-custom-scrollbars.patch
+++ b/patches/upstream-fixes/vertical/r1578138-custom-scrollbars.patch
@@ -24,16 +24,16 @@ Cr-Commit-Position: refs/heads/main@{#1578138}
      "vertical_tab_strip_bottom_container.h",
 +    "vertical_tab_strip_scroll_bar.h",
      "vertical_tab_strip_top_container.h",
+     "vertical_tab_strip_utils.h",
      "vertical_tab_strip_view.h",
-     "vertical_unpinned_tab_container_view.h",
-@@ -51,6 +52,7 @@ source_set("impl") {
+@@ -52,6 +53,7 @@ source_set("impl") {
      "vertical_tab_group_view.cc",
      "vertical_tab_group_view.h",
      "vertical_tab_strip_bottom_container.cc",
 +    "vertical_tab_strip_scroll_bar.cc",
      "vertical_tab_strip_top_container.cc",
+     "vertical_tab_strip_utils.cc",
      "vertical_tab_strip_view.cc",
-     "vertical_tab_view.cc",
 --- /dev/null
 +++ b/chrome/browser/ui/views/tabs/vertical/vertical_tab_strip_scroll_bar.cc
 @@ -0,0 +1,157 @@
@@ -267,15 +267,15 @@ Cr-Commit-Position: refs/heads/main@{#1578138}
 +#endif  // CHROME_BROWSER_UI_VIEWS_TABS_VERTICAL_VERTICAL_TAB_STRIP_SCROLL_BAR_H_
 --- a/chrome/browser/ui/views/tabs/vertical/vertical_tab_strip_view.cc
 +++ b/chrome/browser/ui/views/tabs/vertical/vertical_tab_strip_view.cc
-@@ -11,6 +11,7 @@
- #include "chrome/browser/ui/layout_constants.h"
+@@ -13,6 +13,7 @@
  #include "chrome/browser/ui/views/tabs/vertical/tab_collection_node.h"
  #include "chrome/browser/ui/views/tabs/vertical/vertical_pinned_tab_container_view.h"
+ #include "chrome/browser/ui/views/tabs/vertical/vertical_tab_strip_utils.h"
 +#include "chrome/browser/ui/views/tabs/vertical/vertical_tab_strip_scroll_bar.h"
  #include "chrome/browser/ui/views/tabs/vertical/vertical_unpinned_tab_container_view.h"
  #include "ui/base/metadata/metadata_impl_macros.h"
  #include "ui/color/color_id.h"
-@@ -35,6 +36,8 @@ void SetScrollViewProperties(views::Scro
+@@ -38,6 +39,8 @@ void SetScrollViewProperties(views::Scro
        views::ScrollView::ScrollBarMode::kDisabled);
    scroll_view->SetOverflowGradientMask(
        views::ScrollView::GradientDirection::kVertical);

--- a/patches/upstream-fixes/vertical/r1578230-move-ntb.patch
+++ b/patches/upstream-fixes/vertical/r1578230-move-ntb.patch
@@ -52,7 +52,7 @@ Cr-Commit-Position: refs/heads/main@{#1578230}
 +                               views::MaximumFlexSizeRule::kPreferred));
    tab_strip_view_->SetProperty(views::kMarginsKey,
                                 gfx::Insets::VH(kRegionVerticalPadding, 0));
-   std::optional<size_t> separator_index = GetIndexOf(top_button_separator_);
+   tab_strip_view_->InitializeTabStrip(*tab_strip_model_);
 --- a/chrome/browser/ui/views/tabs/vertical/vertical_tab_strip_bottom_container.cc
 +++ b/chrome/browser/ui/views/tabs/vertical/vertical_tab_strip_bottom_container.cc
 @@ -114,6 +114,9 @@ void VerticalTabStripBottomContainer::Up
@@ -67,7 +67,7 @@ Cr-Commit-Position: refs/heads/main@{#1578230}
      // If collapsed, the tab group button and the new tab button share the same
 --- a/chrome/browser/ui/views/tabs/vertical/vertical_tab_strip_view.cc
 +++ b/chrome/browser/ui/views/tabs/vertical/vertical_tab_strip_view.cc
-@@ -26,9 +26,6 @@
+@@ -29,9 +29,6 @@
  #include "ui/views/view_utils.h"
  
  namespace {
@@ -77,7 +77,7 @@ Cr-Commit-Position: refs/heads/main@{#1578230}
  void SetScrollViewProperties(views::ScrollView* scroll_view) {
    scroll_view->SetUseContentsPreferredSize(true);
    scroll_view->SetBackgroundColor(std::nullopt);
-@@ -69,49 +66,75 @@ VerticalTabStripView::~VerticalTabStripV
+@@ -77,49 +74,75 @@ VerticalTabStripView::~VerticalTabStripV
  views::ProposedLayout VerticalTabStripView::CalculateProposedLayout(
      const views::SizeBounds& size_bounds) const {
    views::ProposedLayout layouts;
@@ -176,7 +176,7 @@ Cr-Commit-Position: refs/heads/main@{#1578230}
      int separator_width =
          size_bounds.width().value() - 2 * region_horizontal_padding;
      gfx::Rect tabs_separator_bounds(
-@@ -120,7 +143,7 @@ views::ProposedLayout VerticalTabStripVi
+@@ -128,7 +151,7 @@ views::ProposedLayout VerticalTabStripVi
      layouts.child_layouts.emplace_back(tabs_separator_.get(), true,
                                         tabs_separator_bounds);
  
@@ -185,7 +185,7 @@ Cr-Commit-Position: refs/heads/main@{#1578230}
    } else {
      layouts.child_layouts.emplace_back(tabs_separator_.get(), false,
                                         gfx::Rect());
-@@ -131,13 +154,17 @@ views::ProposedLayout VerticalTabStripVi
+@@ -139,13 +162,17 @@ views::ProposedLayout VerticalTabStripVi
    // strip is collapsed, tab groups need to draw the group colored line in this
    // space.
    gfx::Rect unpinned_container_bounds(0, y, size_bounds.width().value(),


### PR DESCRIPTION
closes #916

before:

https://github.com/user-attachments/assets/5d988aa3-7140-4c63-96ce-66b5d62cd9fe


after:

https://github.com/user-attachments/assets/5336989c-a132-4cff-b03d-c8159ff34009

