### PR TITLE
upstream-fixes/vertical: show discard indicator on discarded tabs

### DIFF
--- a/patches/helium/ui/tabs.patch
+++ b/patches/helium/ui/tabs.patch
@@ -159,16 +159,16 @@
                          group_color.value_or(tab_stroke_color));
 --- a/chrome/browser/ui/views/tabs/tab.cc
 +++ b/chrome/browser/ui/views/tabs/tab.cc
-@@ -133,6 +133,8 @@ constexpr int kTabAlertIndicatorCloseBut
- // the discard ring by this amount if there is enough space.
- constexpr int kIncreasedDiscardIndicatorRadiusDp = 2;
+@@ -129,6 +129,8 @@ constexpr int kPinnedTabExtraWidthToRend
+ constexpr int kTabAlertIndicatorCloseButtonPaddingAdjustmentTouchUI = 8;
+ constexpr int kTabAlertIndicatorCloseButtonPaddingAdjustment = 4;
  
 +constexpr int kIndicatorPadding = 2;
 +
  bool g_show_hover_card_on_mouse_hover = true;
  
  // Helper functions ------------------------------------------------------------
-@@ -433,19 +435,15 @@ void Tab::Layout(PassKey) {
+@@ -426,19 +428,15 @@ void Tab::Layout(PassKey) {
    }
    close_button_->SetVisible(showing_close_button_);
  
@@ -193,7 +193,7 @@
          contents_rect.y() + Center(contents_rect.height(), image_size.height()),
          image_size.width(), image_size.height());
      if (center_icon_) {
-@@ -456,6 +454,7 @@ void Tab::Layout(PassKey) {
+@@ -449,6 +447,7 @@ void Tab::Layout(PassKey) {
        MaybeAdjustLeftForPinnedTab(&bounds, bounds.width());
      }
      alert_indicator_button_->SetBoundsRect(bounds);
@@ -201,7 +201,7 @@
    }
    alert_indicator_button_->UpdateAlertIndicatorAnimation();
    alert_indicator_button_->SetVisible(showing_alert_indicator_);
-@@ -464,7 +463,9 @@ void Tab::Layout(PassKey) {
+@@ -457,7 +456,9 @@ void Tab::Layout(PassKey) {
    bool show_title = ShouldRenderAsNormalTab();
    if (show_title) {
      int title_left = start;
@@ -212,7 +212,7 @@
        // When computing the spacing from the favicon, don't count the actual
        // icon view width (which will include extra room for the alert
        // indicator), but rather the normal favicon width which is what it will
-@@ -475,9 +476,7 @@ void Tab::Layout(PassKey) {
+@@ -468,9 +469,7 @@ void Tab::Layout(PassKey) {
        title_left = std::max(title_left, after_favicon);
      }
      int title_right = contents_rect.right();
@@ -223,7 +223,7 @@
        // Allow the title to overlay the close button's empty border padding.
        title_right = close_x - after_title_padding;
      }
-@@ -1187,7 +1186,7 @@ void Tab::UpdateIconVisibility() {
+@@ -1176,7 +1175,7 @@ void Tab::UpdateIconVisibility() {
    const int close_button_width =
        GetLayoutConstant(LayoutConstant::kTabCloseButtonSize) +
        GetLayoutConstant(LayoutConstant::kTabAfterTitlePadding);
@@ -232,7 +232,7 @@
        available_width >= (touch_ui ? kTouchMinimumContentsWidthForCloseButtons
                                     : kMinimumContentsWidthForCloseButtons);
  
-@@ -1235,6 +1234,10 @@ void Tab::UpdateIconVisibility() {
+@@ -1224,6 +1223,10 @@ void Tab::UpdateIconVisibility() {
          large_enough_for_close_button;
      if (base::CommandLine::ForCurrentProcess()->HasSwitch("hide-tab-close-buttons"))
        showing_close_button_ = false;
@@ -243,7 +243,7 @@
      if (showing_close_button_) {
        available_width -= close_button_width;
      }
-@@ -1252,10 +1255,6 @@ void Tab::UpdateIconVisibility() {
+@@ -1241,10 +1244,6 @@ void Tab::UpdateIconVisibility() {
        }
      }
    }
@@ -254,7 +254,7 @@
  }
  
  bool Tab::ShouldRenderAsNormalTab() const {
-@@ -1276,15 +1275,29 @@ void Tab::UpdateTabIconNeedsAttentionBlo
+@@ -1265,15 +1264,29 @@ void Tab::UpdateTabIconNeedsAttentionBlo
  }
  
  int Tab::GetWidthOfLargestSelectableRegion() const {
@@ -552,7 +552,7 @@
  gfx::ImageSkia AlertIndicatorButton::GetImageToPaint() {
 --- a/chrome/browser/ui/views/tabs/browser_tab_strip_controller.cc
 +++ b/chrome/browser/ui/views/tabs/browser_tab_strip_controller.cc
-@@ -275,14 +275,6 @@ bool BrowserTabStripController::IsBrowse
+@@ -266,14 +266,6 @@ bool BrowserTabStripController::IsBrowse
  
  void BrowserTabStripController::SelectTab(int model_index,
                                            const ui::Event& event) {

--- a/patches/series
+++ b/patches/series
@@ -4,6 +4,7 @@ upstream-fixes/vertical/r1568929-animate-cross-collection-operations.patch
 upstream-fixes/vertical/r1570045-improve-dragging-between-groups-and-unpinned.patch
 upstream-fixes/vertical/r1570472-fix-crash-drag-pinned-tabs.patch
 upstream-fixes/vertical/r1570584-remove-redundant-parameter-from-tabdragcontroller.patch
+upstream-fixes/vertical/r1570647-vertical-tab-discard-indicator.patch
 upstream-fixes/vertical/r1570728-disable-tab-change-scroll-on-linux.patch
 upstream-fixes/vertical/r1571017-add-horizontal-animation-support-to-layout.patch
 upstream-fixes/vertical/r1571331-improve-tab-drag-performance-macos.patch
@@ -18,6 +19,7 @@ upstream-fixes/vertical/r1572660-correctly-position-dragged-split-views.patch
 upstream-fixes/vertical/r1572664-rename-tabslotshimview-to-verticaltabslotview.patch
 upstream-fixes/vertical/r1572994-check-tab-collection-node-before-dragging.patch
 upstream-fixes/vertical/r1573180-reset-tab-strip-model-flag.patch
+upstream-fixes/vertical/r1573301-always-enlarge-discard-indicator.patch
 upstream-fixes/vertical/r1573324-lazily-load-tabstrips-when-switching-modes.patch
 upstream-fixes/vertical/r1573883-fix-crash-dragging-from-inactive-tabstrip.patch
 upstream-fixes/vertical/r1574955-handle-dragging-pinned-vertical-tabs.patch
@@ -43,6 +45,7 @@ upstream-fixes/vertical/r1580497-ensure-dragged-tabs-are-contiguous.patch
 upstream-fixes/vertical/r1580788-use-bounds-of-dragged-tabs-for-target.patch
 upstream-fixes/vertical/keep-vertical-drag-alive-across-handoff.patch
 upstream-fixes/vertical/dont-reset-inexistent-tab-strip.patch
+upstream-fixes/vertical/remove-tab-discard-ring-promo.patch
 
 inox-patchset/fix-building-without-safebrowsing.patch
 inox-patchset/disable-autofill-download-manager.patch

--- a/patches/ungoogled-chromium/add-flag-for-tab-hover-cards.patch
+++ b/patches/ungoogled-chromium/add-flag-for-tab-hover-cards.patch
@@ -8,7 +8,7 @@
  #include "base/debug/alias.h"
  #include "base/functional/bind.h"
  #include "base/i18n/rtl.h"
-@@ -768,6 +769,13 @@ void Tab::HideHover(TabStyle::HideHoverS
+@@ -761,6 +762,13 @@ void Tab::HideHover(TabStyle::HideHoverS
    DeprecatedLayoutImmediately();
  }
  

--- a/patches/ungoogled-chromium/add-flag-to-hide-tab-close-buttons.patch
+++ b/patches/ungoogled-chromium/add-flag-to-hide-tab-close-buttons.patch
@@ -1,6 +1,6 @@
 --- a/chrome/browser/ui/views/tabs/tab.cc
 +++ b/chrome/browser/ui/views/tabs/tab.cc
-@@ -1200,7 +1200,11 @@ void Tab::UpdateIconVisibility() {
+@@ -1189,7 +1189,11 @@ void Tab::UpdateIconVisibility() {
      // Close button is shown on active tabs regardless of the size.
      showing_close_button_ = true;
  #endif  // BUILDFLAG(IS_CHROMEOS)
@@ -12,7 +12,7 @@
  
      showing_alert_indicator_ =
          has_alert_icon && alert_icon_width <= available_width;
-@@ -1229,6 +1233,8 @@ void Tab::UpdateIconVisibility() {
+@@ -1218,6 +1222,8 @@ void Tab::UpdateIconVisibility() {
          !controller_->IsLockedForOnTask() &&
  #endif
          large_enough_for_close_button;

--- a/patches/ungoogled-chromium/enable-paste-and-go-new-tab-button.patch
+++ b/patches/ungoogled-chromium/enable-paste-and-go-new-tab-button.patch
@@ -29,7 +29,7 @@
  #include "components/performance_manager/public/user_tuning/prefs.h"
  #include "components/prefs/pref_service.h"
  #include "components/saved_tab_groups/public/features.h"
-@@ -560,6 +563,18 @@ void BrowserTabStripController::CreateNe
+@@ -551,6 +554,18 @@ void BrowserTabStripController::CreateNe
    chrome::NewTab(browser_view_->browser(), context);
  }
  

--- a/patches/upstream-fixes/vertical/r1570647-vertical-tab-discard-indicator.patch
+++ b/patches/upstream-fixes/vertical/r1570647-vertical-tab-discard-indicator.patch
@@ -1,0 +1,252 @@
+From d848dfaecedc6a6d47988fa2f68932d934dd9275 Mon Sep 17 00:00:00 2001
+From: Charles Meng <charlesmeng@chromium.org>
+Date: Fri, 16 Jan 2026 14:21:11 -0800
+Subject: [PATCH] [Vertical Tabs] Allow vertical tab icon to show discard indicator
+
+Notify vertical tab icon to update data when a tab is replaced due to
+discard. Additionally listen to the should show discard indicator pref
+on the tab icon itself.
+
+Fixed: 475302379
+Change-Id: I2e39735d8a3cd38d66217b54677f0d5a4d7c08b1
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7486606
+Commit-Queue: Charles Meng <charlesmeng@chromium.org>
+Reviewed-by: Eshwar Stalin <estalin@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1570647}
+---
+
+--- a/chrome/browser/ui/views/tabs/browser_tab_strip_controller.cc
++++ b/chrome/browser/ui/views/tabs/browser_tab_strip_controller.cc
+@@ -160,15 +160,6 @@ BrowserTabStripController::BrowserTabStr
+     menu_model_factory_ = std::make_unique<TabMenuModelFactory>();
+   }
+   model_->SetTabStripUI(this);
+-
+-  should_show_discard_indicator_ = g_browser_process->local_state()->GetBoolean(
+-      performance_manager::user_tuning::prefs::kDiscardRingTreatmentEnabled);
+-  local_state_registrar_.Init(g_browser_process->local_state());
+-  local_state_registrar_.Add(
+-      performance_manager::user_tuning::prefs::kDiscardRingTreatmentEnabled,
+-      base::BindRepeating(
+-          &BrowserTabStripController::OnDiscardRingTreatmentEnabledChanged,
+-          base::Unretained(this)));
+ }
+ 
+ BrowserTabStripController::~BrowserTabStripController() {
+@@ -937,11 +928,6 @@ void BrowserTabStripController::AddTabs(
+ 
+   tabstrip_->AddTabsAt(std::move(tabs_data));
+ 
+-  for (const auto& [contents, index] : contents_list) {
+-    tabstrip_->tab_at(index)->SetShouldShowDiscardIndicator(
+-        should_show_discard_indicator_);
+-  }
+-
+   // Try to show tab search IPH if needed.
+   constexpr int kTabSearchIPHTriggerThreshold = 8;
+   if (tabstrip_->GetTabCount() >= kTabSearchIPHTriggerThreshold) {
+@@ -950,15 +936,6 @@ void BrowserTabStripController::AddTabs(
+   }
+ }
+ 
+-void BrowserTabStripController::OnDiscardRingTreatmentEnabledChanged() {
+-  should_show_discard_indicator_ = g_browser_process->local_state()->GetBoolean(
+-      performance_manager::user_tuning::prefs::kDiscardRingTreatmentEnabled);
+-  for (int tab_index = 0; tab_index < tabstrip_->GetTabCount(); ++tab_index) {
+-    tabstrip_->tab_at(tab_index)->SetShouldShowDiscardIndicator(
+-        should_show_discard_indicator_);
+-  }
+-}
+-
+ bool BrowserTabStripController::IsContextMenuCommandChecked(
+     TabStripModel::ContextMenuCommand command_id) {
+   return false;
+--- a/chrome/browser/ui/views/tabs/browser_tab_strip_controller.h
++++ b/chrome/browser/ui/views/tabs/browser_tab_strip_controller.h
+@@ -197,11 +197,7 @@ class BrowserTabStripController : public
+   // tabs.
+   std::unique_ptr<ImmersiveRevealedLock> immersive_reveal_lock_;
+ 
+-  PrefChangeRegistrar local_state_registrar_;
+-
+   std::unique_ptr<TabMenuModelFactory> menu_model_factory_;
+-
+-  bool should_show_discard_indicator_ = true;
+ };
+ 
+ #endif  // CHROME_BROWSER_UI_VIEWS_TABS_BROWSER_TAB_STRIP_CONTROLLER_H_
+--- a/chrome/browser/ui/views/tabs/tab.cc
++++ b/chrome/browser/ui/views/tabs/tab.cc
+@@ -1079,10 +1079,6 @@ std::u16string Tab::GetTooltipText(const
+   return result;
+ }
+ 
+-void Tab::SetShouldShowDiscardIndicator(bool enabled) {
+-  icon_->SetShouldShowDiscardIndicator(enabled);
+-}
+-
+ void Tab::UpdateInsets() {
+   SetBorder(views::CreateEmptyBorder(tab_style_views()->GetContentsInsets()));
+ }
+--- a/chrome/browser/ui/views/tabs/tab.h
++++ b/chrome/browser/ui/views/tabs/tab.h
+@@ -207,8 +207,6 @@ class Tab : public gfx::AnimationDelegat
+     return alert_indicator_button_;
+   }
+ 
+-  void SetShouldShowDiscardIndicator(bool enabled);
+-
+   void UpdateInsets();
+ 
+ #if BUILDFLAG(ENABLE_GLIC)
+--- a/chrome/browser/ui/views/tabs/tab_icon.cc
++++ b/chrome/browser/ui/views/tabs/tab_icon.cc
+@@ -25,6 +25,8 @@
+ #include "chrome/common/webui_url_constants.h"
+ #include "components/feature_engagement/public/feature_constants.h"
+ #include "components/grit/components_scaled_resources.h"
++#include "components/performance_manager/public/user_tuning/prefs.h"
++#include "components/prefs/pref_service.h"
+ #include "content/public/common/url_constants.h"
+ #include "ui/base/metadata/metadata_impl_macros.h"
+ #include "ui/base/resource/resource_bundle.h"
+@@ -112,6 +114,13 @@ TabIcon::TabIcon()
+   DCHECK(!GetShowingLoadingAnimation());
+ 
+   SetProperty(views::kElementIdentifierKey, kTabIconElementId);
++
++  local_state_registrar_.Init(g_browser_process->local_state());
++  local_state_registrar_.Add(
++      performance_manager::user_tuning::prefs::kDiscardRingTreatmentEnabled,
++      base::BindRepeating(&TabIcon::OnDiscardRingTreatmentEnabledChanged,
++                          base::Unretained(this)));
++  OnDiscardRingTreatmentEnabledChanged();
+ }
+ 
+ TabIcon::~TabIcon() = default;
+@@ -197,9 +206,13 @@ void TabIcon::EnlargeDiscardIndicatorRad
+   increased_discard_indicator_radius_ = radius;
+ }
+ 
+-void TabIcon::SetShouldShowDiscardIndicator(bool enabled) {
+-  should_show_discard_indicator_ = enabled;
+-  bool show_discard_indicator = is_discarded_ && should_show_discard_indicator_;
++void TabIcon::OnDiscardRingTreatmentEnabledChanged() {
++  discard_ring_treatment_enabled_ =
++      g_browser_process->local_state()->GetBoolean(
++          performance_manager::user_tuning::prefs::
++              kDiscardRingTreatmentEnabled);
++  bool show_discard_indicator =
++      is_discarded_ && discard_ring_treatment_enabled_;
+   if (was_discard_indicator_shown_ != show_discard_indicator) {
+     was_discard_indicator_shown_ = show_discard_indicator;
+ 
+@@ -454,7 +467,8 @@ void TabIcon::SetIcon(const ui::ImageMod
+ 
+ void TabIcon::SetDiscarded(bool discarded) {
+   is_discarded_ = discarded;
+-  bool show_discard_indicator = is_discarded_ && should_show_discard_indicator_;
++  bool show_discard_indicator =
++      is_discarded_ && discard_ring_treatment_enabled_;
+   if (was_discard_indicator_shown_ != show_discard_indicator) {
+     was_discard_indicator_shown_ = show_discard_indicator;
+     favicon_size_animation_.SetSlideDuration(
+--- a/chrome/browser/ui/views/tabs/tab_icon.h
++++ b/chrome/browser/ui/views/tabs/tab_icon.h
+@@ -10,6 +10,7 @@
+ #include "base/time/time.h"
+ #include "chrome/browser/ui/tabs/tab_network_state.h"
+ #include "components/performance_manager/public/features.h"
++#include "components/prefs/pref_change_registrar.h"
+ #include "ui/base/interaction/element_tracker.h"
+ #include "ui/base/metadata/metadata_header_macros.h"
+ #include "ui/base/models/image_model.h"
+@@ -83,7 +84,7 @@ class TabIcon : public views::View, publ
+   bool GetActiveStateForTesting() { return is_active_tab_; }
+ 
+   void EnlargeDiscardIndicatorRadius(int radius);
+-  void SetShouldShowDiscardIndicator(bool enabled);
++  void OnDiscardRingTreatmentEnabledChanged();
+ 
+  protected:
+   class CrashAnimation;
+@@ -195,7 +196,7 @@ class TabIcon : public views::View, publ
+   // due to a change in the discard status or a change to the pref, because
+   // we don't want to animate the discard ring in the latter case.
+   bool is_discarded_ = false;
+-  bool should_show_discard_indicator_ = true;
++  bool discard_ring_treatment_enabled_ = true;
+   bool was_discard_indicator_shown_ = false;
+ 
+   // Crash animation (in place of favicon). Lazily created since most of the
+@@ -211,6 +212,8 @@ class TabIcon : public views::View, publ
+   bool is_monochrome_favicon_ = false;
+ 
+   int increased_discard_indicator_radius_ = 0;
++
++  PrefChangeRegistrar local_state_registrar_;
+ };
+ 
+ #endif  // CHROME_BROWSER_UI_VIEWS_TABS_TAB_ICON_H_
+--- a/chrome/browser/ui/views/tabs/vertical/BUILD.gn
++++ b/chrome/browser/ui/views/tabs/vertical/BUILD.gn
+@@ -104,6 +104,7 @@ source_set("browser_tests") {
+     ":impl",
+     "//base",
+     "//chrome/browser",
++    "//chrome/browser/performance_manager/public/user_tuning",
+     "//chrome/browser/ui",
+     "//chrome/browser/ui:browser_element_identifiers",
+     "//chrome/browser/ui:ui_features",
+--- a/chrome/browser/ui/views/tabs/vertical/root_tab_collection_node.cc
++++ b/chrome/browser/ui/views/tabs/vertical/root_tab_collection_node.cc
+@@ -124,21 +124,21 @@ void RootTabCollectionNode::OnTabStripMo
+     return;
+   }
+ 
+-  std::set<TabCollectionNode*> selection_changes;
++  std::set<TabCollectionNode*> changed_tabs;
+ 
+   if (selection.active_tab_changed()) {
+     if (selection.old_tab) {
+       TabCollectionNode* old_tab_node =
+           GetNodeForHandle(selection.old_tab->GetHandle());
+       if (old_tab_node) {
+-        selection_changes.insert(old_tab_node);
++        changed_tabs.insert(old_tab_node);
+       }
+     }
+     if (selection.new_tab) {
+       TabCollectionNode* new_tab_node =
+           GetNodeForHandle(selection.new_tab->GetHandle());
+       if (new_tab_node) {
+-        selection_changes.insert(new_tab_node);
++        changed_tabs.insert(new_tab_node);
+       }
+     }
+   }
+@@ -158,13 +158,22 @@ void RootTabCollectionNode::OnTabStripMo
+          base::STLSetUnion<SelectionHandles>(old_selections, new_selections)) {
+       TabCollectionNode* tab_node = GetNodeForHandle(tab_handle);
+       if (tab_node) {
+-        selection_changes.insert(tab_node);
++        changed_tabs.insert(tab_node);
+       }
+     }
+     selected_tabs_ = selected_tabs;
+   }
+ 
+-  for (auto* tab_node : selection_changes) {
++  if (change.type() == TabStripModelChange::kReplaced) {
++    // Discarding a tab causes a replace change notification to be sent. Add any
++    // replaced tab to the list of tabs to update.
++    auto* replace = change.GetReplace();
++    TabCollectionNode* tab_node = GetNodeForHandle(
++        tab_strip_model->GetTabAtIndex(replace->index)->GetHandle());
++    changed_tabs.insert(tab_node);
++  }
++
++  for (auto* tab_node : changed_tabs) {
+     tab_node->NotifyDataChanged();
+   }
+ }

--- a/patches/upstream-fixes/vertical/r1571827-update-group-editor-bubble-anchoring.patch
+++ b/patches/upstream-fixes/vertical/r1571827-update-group-editor-bubble-anchoring.patch
@@ -25,7 +25,7 @@ Cr-Commit-Position: refs/heads/main@{#1571827}
  #include "components/tabs/public/split_tab_data.h"
  #include "components/tabs/public/tab_collection.h"
  #include "components/tabs/public/tab_collection_types.h"
-@@ -173,18 +174,23 @@ void RootTabCollectionNode::OnTabGroupCh
+@@ -182,18 +183,23 @@ void RootTabCollectionNode::OnTabGroupCh
    if (tab_strip_model_->closing_all()) {
      return;
    }

--- a/patches/upstream-fixes/vertical/r1573301-always-enlarge-discard-indicator.patch
+++ b/patches/upstream-fixes/vertical/r1573301-always-enlarge-discard-indicator.patch
@@ -1,0 +1,123 @@
+From fa336d92699c944b7f6128e41935b2281efbcc89 Mon Sep 17 00:00:00 2001
+From: Charles Meng <charlesmeng@chromium.org>
+Date: Thu, 22 Jan 2026 14:04:53 -0800
+Subject: [PATCH] [Vertical Tabs] Always enlarge the discard indicator for vertical tabs
+
+Update TabIcon so that it by default enlarges the discard indicator
+radius unless its parent view notifies it that there is not enough
+width to do so. This makes it so that the indicator radius is always
+enlarged in the case of vertical tabs.
+
+Comparison screenshots:
+https://screenshot.googleplex.com/hJ8bcEqJ6VwGYyj.png
+https://screenshot.googleplex.com/5PCEYzUgzjBRvHy.png
+
+Bug: 475302379
+Change-Id: Iaa899a268bfba42578dc2e962f8459645d3aa918
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7510237
+Reviewed-by: Eshwar Stalin <estalin@chromium.org>
+Commit-Queue: Charles Meng <charlesmeng@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1573301}
+---
+
+--- a/chrome/browser/ui/views/tabs/tab.cc
++++ b/chrome/browser/ui/views/tabs/tab.cc
+@@ -128,10 +128,6 @@ constexpr int kPinnedTabExtraWidthToRend
+ constexpr int kTabAlertIndicatorCloseButtonPaddingAdjustmentTouchUI = 8;
+ constexpr int kTabAlertIndicatorCloseButtonPaddingAdjustment = 4;
+ 
+-// When the DiscardRingImprovements feature is enabled, increase the radius of
+-// the discard ring by this amount if there is enough space.
+-constexpr int kIncreasedDiscardIndicatorRadiusDp = 2;
+-
+ bool g_show_hover_card_on_mouse_hover = true;
+ 
+ // Helper functions ------------------------------------------------------------
+@@ -383,11 +379,8 @@ void Tab::Layout(PassKey) {
+     } else {
+       MaybeAdjustLeftForPinnedTab(&favicon_bounds, gfx::kFaviconSize);
+     }
+-    icon_->EnlargeDiscardIndicatorRadius(
+-        width() - 2 * tab_style()->GetBottomCornerRadius() >=
+-                gfx::kFaviconSize + 2 * kIncreasedDiscardIndicatorRadiusDp
+-            ? kIncreasedDiscardIndicatorRadiusDp
+-            : 0);
++    icon_->ResizeDiscardIndicatorRadiusForWidth(
++        width() - 2 * tab_style()->GetBottomCornerRadius());
+ 
+     // Add space for insets outside the favicon bounds.
+     favicon_bounds.Inset(-icon_->GetInsets());
+--- a/chrome/browser/ui/views/tabs/tab_icon.cc
++++ b/chrome/browser/ui/views/tabs/tab_icon.cc
+@@ -102,9 +102,8 @@ TabIcon::TabIcon()
+   SetCanProcessEventsWithinSubtree(false);
+ 
+   // Add padding to avoid clipping the attention indicator and the increased
+-  // discard ring radius when kDiscardRingImprovements is enabled. Padding must
+-  // be symmetric on each side so that elements will anchor to the center of the
+-  // favicon.
++  // discard ring radius. Padding must be symmetric on each side so that
++  // elements will anchor to the center of the favicon.
+   SetBorder(views::CreateEmptyBorder(kAttentionIndicatorRadius));
+ 
+   const int preferred_width = gfx::kFaviconSize + GetInsets().width();
+@@ -201,9 +200,11 @@ void TabIcon::StepLoadingAnimation(const
+   }
+ }
+ 
+-void TabIcon::EnlargeDiscardIndicatorRadius(int radius) {
+-  CHECK(radius <= GetInsets().left());
+-  increased_discard_indicator_radius_ = radius;
++void TabIcon::ResizeDiscardIndicatorRadiusForWidth(int width) {
++  increased_discard_indicator_radius_ =
++      width >= gfx::kFaviconSize + 2 * kIncreasedDiscardIndicatorRadiusDp
++          ? kIncreasedDiscardIndicatorRadiusDp
++          : 0;
+ }
+ 
+ void TabIcon::OnDiscardRingTreatmentEnabledChanged() {
+@@ -317,11 +318,10 @@ void TabIcon::PaintDiscardRingAndIcon(gf
+   // Fades in the discard ring and smaller favicon
+   MaybePaintFavicon(canvas, icon, icon_bounds);
+ 
+-  // Increase the bounds of the discard ring beyond the icon bounds if
+-  // kDiscardRingImprovements is enabled. This is safe because in the
+-  // constructor, we have already added insets so that the larger discard ring
+-  // can expand into them and won't be clipped, and the icon bounds will be
+-  // inside those insets.
++  // Increase the bounds of the discard ring beyond the icon bounds if there is
++  // enough space in the tab. This is safe because in the constructor, we have
++  // already added insets so that the larger discard ring can expand into them
++  // and won't be clipped, and the icon bounds will be inside those insets.
+   gfx::Rect discard_ring_bounds = icon_bounds;
+   discard_ring_bounds.Outset(increased_discard_indicator_radius_);
+ 
+--- a/chrome/browser/ui/views/tabs/tab_icon.h
++++ b/chrome/browser/ui/views/tabs/tab_icon.h
+@@ -83,7 +83,11 @@ class TabIcon : public views::View, publ
+   gfx::ImageSkia GetThemedIconForTesting() { return themed_favicon_; }
+   bool GetActiveStateForTesting() { return is_active_tab_; }
+ 
+-  void EnlargeDiscardIndicatorRadius(int radius);
++  // Called by the parent view when the width available to draw the tab icon
++  // changes, to determine whether to increase the discard indicator radius.
++  // Not used by vertical tabs since there always is enough width to draw the
++  // increased discard indicator radius.
++  void ResizeDiscardIndicatorRadiusForWidth(int width);
+   void OnDiscardRingTreatmentEnabledChanged();
+ 
+  protected:
+@@ -211,7 +215,12 @@ class TabIcon : public views::View, publ
+ 
+   bool is_monochrome_favicon_ = false;
+ 
+-  int increased_discard_indicator_radius_ = 0;
++  // If there is enough space, increased the size of the discard ring beyond the
++  // default favicon size, by this amount.
++  static constexpr int kIncreasedDiscardIndicatorRadiusDp = 2;
++
++  // The amount to increase the size of the discard ring by.
++  int increased_discard_indicator_radius_ = kIncreasedDiscardIndicatorRadiusDp;
+ 
+   PrefChangeRegistrar local_state_registrar_;
+ };

--- a/patches/upstream-fixes/vertical/r1573324-lazily-load-tabstrips-when-switching-modes.patch
+++ b/patches/upstream-fixes/vertical/r1573324-lazily-load-tabstrips-when-switching-modes.patch
@@ -361,10 +361,10 @@ Cr-Commit-Position: refs/heads/main@{#1573324}
      menu_model_factory_ = std::make_unique<TabMenuModelFactory>();
    }
 -  model_->SetTabStripUI(this);
+ }
  
-   should_show_discard_indicator_ = g_browser_process->local_state()->GetBoolean(
-       performance_manager::user_tuning::prefs::kDiscardRingTreatmentEnabled);
-@@ -184,6 +183,7 @@ BrowserTabStripController::~BrowserTabSt
+ BrowserTabStripController::~BrowserTabStripController() {
+@@ -175,6 +174,7 @@ BrowserTabStripController::~BrowserTabSt
  
  void BrowserTabStripController::InitFromModel(TabStrip* tabstrip) {
    tabstrip_ = tabstrip;
@@ -372,7 +372,7 @@ Cr-Commit-Position: refs/heads/main@{#1573324}
  
    // Walk the model, calling our insertion observer method for each item within
    // it.
-@@ -192,7 +192,37 @@ void BrowserTabStripController::InitFrom
+@@ -183,7 +183,37 @@ void BrowserTabStripController::InitFrom
      tabs_to_add.emplace_back(model_->GetTabAtIndex(i), i);
    }
    AddTabs(tabs_to_add);

--- a/patches/upstream-fixes/vertical/remove-tab-discard-ring-promo.patch
+++ b/patches/upstream-fixes/vertical/remove-tab-discard-ring-promo.patch
@@ -1,0 +1,33 @@
+--- a/chrome/browser/ui/views/tabs/tab_icon.cc
++++ b/chrome/browser/ui/views/tabs/tab_icon.cc
+@@ -13,17 +13,12 @@
+ #include "chrome/browser/browser_process.h"
+ #include "chrome/browser/favicon/favicon_utils.h"
+ #include "chrome/browser/themes/theme_properties.h"
+-#include "chrome/browser/ui/browser.h"
+ #include "chrome/browser/ui/browser_element_identifiers.h"
+-#include "chrome/browser/ui/browser_finder.h"
+-#include "chrome/browser/ui/browser_window.h"
+ #include "chrome/browser/ui/color/chrome_color_id.h"
+ #include "chrome/browser/ui/layout_constants.h"
+ #include "chrome/browser/ui/tabs/tab_renderer_data.h"
+-#include "chrome/browser/ui/user_education/browser_user_education_interface.h"
+ #include "chrome/browser/ui/views/dotted_icon.h"
+ #include "chrome/common/webui_url_constants.h"
+-#include "components/feature_engagement/public/feature_constants.h"
+ #include "components/grit/components_scaled_resources.h"
+ #include "components/performance_manager/public/user_tuning/prefs.h"
+ #include "components/prefs/pref_service.h"
+@@ -478,12 +473,6 @@ void TabIcon::SetDiscarded(bool discarde
+           gfx::Animation::RichAnimationDuration(base::Seconds(1)));
+       tab_discard_animation_.Start();
+       favicon_size_animation_.Hide();
+-
+-      // Potentially show an IPH if a tab was discarded.
+-      Browser* browser = chrome::FindBrowserWithUiElementContext(
+-          views::ElementTrackerViews::GetInstance()->GetContextForView(this));
+-      BrowserUserEducationInterface::From(browser)->MaybeShowFeaturePromo(
+-          feature_engagement::kIPHDiscardRingFeature);
+     } else {
+       tab_discard_animation_.Stop();
+       favicon_size_animation_.Show();


### PR DESCRIPTION
and remove discard promo because it was called before a valid UI context (tab strip) was created, which was causing a crash. helium doesn't have user education promos, so it was a no-op anyway.

fixes #926
