### PR TITLE
[LLM SPAM] fix: suppress Chrome Web Store nag in Chinese locale

### DIFF
--- a/patches/helium/core/ublock-cws-nag-filters.patch
+++ b/patches/helium/core/ublock-cws-nag-filters.patch
@@ -1,0 +1,33 @@
+diff --git a/third_party/ublock/assets/ublock/helium.txt b/third_party/ublock/assets/ublock/helium.txt
+new file mode 100644
+--- /dev/null
++++ b/third_party/ublock/assets/ublock/helium.txt
+@@ -0,0 +1,10 @@
++! Title: Helium filters
++! Description: Filters specific to the Helium browser
++! Last modified: 2025-02-21
++! Homepage: https://github.com/imputnet/helium
++
++! Chrome Web Store nag suppression (all locales)
++chromewebstore.google.com##[role="dialog"][aria-labelledby="promo-header"]
++chromewebstore.google.com##[aria-label="Info"]:has-text(/Switch to Chrome|Chrome に切り替え|切換至 Chrome|切换到 Chrome|Chrome로 전환|Passer à Chrome|Zu Chrome wechseln|Cambiar a Chrome|Passa a Chrome|Mudar para o Chrome/)
++chromewebstore.google.com##[aria-label="資訊"]:has-text(Chrome)
++chromewebstore.google.com##[aria-label="信息"]:has-text(Chrome)
+diff --git a/third_party/ublock/assets/assets.json b/third_party/ublock/assets/assets.json
+--- a/third_party/ublock/assets/assets.json
++++ b/third_party/ublock/assets/assets.json
+@@ -141,6 +141,14 @@
+ 		],
+ 		"supportURL": "https://github.com/uBlockOrigin/uAssets"
+ 	},
++	"ublock-helium": {
++		"content": "filters",
++		"group": "default",
++		"title": "Helium filters",
++		"contentURL": "assets/ublock/helium.txt",
++		"supportURL": "https://github.com/imputnet/helium"
++	},
++
+ 	"ublock-experimental": {
+ 		"content": "filters",
+ 		"group": "default",

--- a/patches/series
+++ b/patches/series
@@ -164,6 +164,7 @@ helium/core/ublock-install-as-component.patch
 helium/core/ublock-reconfigure-defaults.patch
 helium/core/ublock-migrate-prefs.patch
 helium/core/ublock-helium-services.patch
+helium/core/ublock-cws-nag-filters.patch
 helium/core/clean-omnibox-suggestions.patch
 helium/core/increase-incognito-storage-quota.patch
 helium/core/mitigate-fingerprinting-canvas.patch


### PR DESCRIPTION
## Summary

Fixes #965

The Chrome Web Store installation nag ("切換至 Chrome 即可安裝擴充功能和主題") is shown on Chinese locale pages because the existing nag suppression only covers English strings.

## Changes

- Added a new `helium.txt` uBlock filter list bundled at `third_party/ublock/assets/ublock/helium.txt`
- Registered the filter list in `assets.json` as `ublock-helium` with `"group": "default"` so it's enabled by default
- Added the patch to the series file after `ublock-helium-services.patch`

## Filter rules

The filter list suppresses the CWS nag across all locales:

- `[role="dialog"][aria-labelledby="promo-header"]` — catches the nag dialog structurally
- `:has-text()` rules with regex matching for English, Chinese (Simplified & Traditional), Japanese, Korean, French, German, Spanish, Italian, and Portuguese translations of "Switch to Chrome"
- Separate `aria-label` selectors for Chinese locale variants (`資訊` for Traditional Chinese, `信息` for Simplified Chinese)

## Testing

The patch applies cleanly against the post-`ublock-setup-sources.patch` state of `assets.json`. The filter list is registered as a default-enabled bundled list, following the same pattern as other uBlock filter lists in the project.