### PR TITLE
fix: make CWS nag removal locale-agnostic (#965)

### DIFF
--- a/patches/helium/core/fixups-chrome-webstore-script.patch
+++ b/patches/helium/core/fixups-chrome-webstore-script.patch
@@ -29,7 +29,7 @@
 +// the terms of the GPL-3.0 license that can be found in the LICENSE file.
 +
 +(() => {
-+  const PROMO_POPUP_SELECTOR = 'header > [aria-labelledby=promo-header]';
++  const PROMO_POPUP_SELECTOR = '[aria-labelledby=promo-header]';
 +
 +  // detect "switch to chrome" nag sections by their Chrome download
 +  // link, which is locale-agnostic unlike aria-label text.


### PR DESCRIPTION
## Summary

Fixes #965 — the "Switch to Chrome" nag on the Chrome Web Store was only removed for English locales. Non-English users (Chinese, Japanese, Korean, etc.) still saw the nag popup.

Sorry about #975, I pr'ed an untested code 
## Root cause

The existing `extstore_fixups` content script used hardcoded English `aria-label` selectors (`aria-label=Info`, `aria-label^='Switch to Chrome'`) that are translated in non-English locales, causing silent failure.

Additionally, the promo popup selector used a **direct-child combinator** (`header > [aria-labelledby=promo-header]`) but the dialog is nested inside multiple wrapper divs within the `<header>`, so the selector never matched.

## Fix

**1. Locale-agnostic nag section detection** — instead of matching translated aria-label text, detect nag sections by their Chrome download link (`google.com/chrome`), which is always present regardless of locale:

```js
const CHROME_DL_PATTERN = /^https?:\/\/(?:www\.)?google\.com\/(intl\/[^/]+\/)?chrome/;
```

**2. Fixed promo popup selector** — removed the direct-child combinator so `[aria-labelledby=promo-header]` matches regardless of nesting depth.

**3. MutationObserver** — watches the DOM for late-injected nag elements (CWS renders the promo dialog asynchronously and adds `aria-labelledby` after initial render).

## Testing

Built Helium from source on a Linux VM (c2-standard-60, 60 vCPUs) and tested on live Chrome Web Store pages.

### Screenshots (no nag visible in any locale)

**English (`?hl=en`)**
![English CWS - no nag](https://github.com/TheAbMehta/helium/releases/download/helium-cws-proof/proof-en.png)

**Chinese (`?hl=zh-CN`)**
![Chinese CWS - no nag](https://github.com/TheAbMehta/helium/releases/download/helium-cws-proof/proof-zh.png)

**Japanese (`?hl=ja`)**
![Japanese CWS - no nag](https://github.com/TheAbMehta/helium/releases/download/helium-cws-proof/proof-ja.png)

### Video recordings

- [English CWS recording (17s)](https://github.com/TheAbMehta/helium/releases/download/helium-cws-proof/helium-cws-english.mp4)
- [Chinese CWS recording (17s)](https://github.com/TheAbMehta/helium/releases/download/helium-cws-proof/helium-cws-chinese.mp4)

### Console log evidence

The content script's MutationObserver detects and removes the nag ~1s after page load:

```
11:29:20.001  Content script loaded at document_start
11:29:20.461  Dialog appears (aria-labelledby: null — not yet set by CWS)
11:29:21.074  promoPopup found: true → Removing promo popup
11:29:21.074  Found 0 dialog elements (nag fully removed)
```

## Disclosure

This PR was authored with the assistance of Claude (LLM) to help understand the codebase and structure the implementation and description.