### PR TITLE
helium/ui/side-panel-webui: add change wallpaper button, fix visibility

### DIFF
--- a/patches/helium/ui/layout/context-menu.patch
+++ b/patches/helium/ui/layout/context-menu.patch
@@ -23,7 +23,7 @@
  #define IDC_ADD_NEW_TAB_TO_GROUP      34100
 --- a/chrome/app/generated_resources.grd
 +++ b/chrome/app/generated_resources.grd
-@@ -10441,6 +10441,45 @@ Keep your key file in a safe place. You
+@@ -10444,6 +10444,45 @@ Keep your key file in a safe place. You
          Create split view
        </message>
  

--- a/patches/helium/ui/side-panel-webui-customize.patch
+++ b/patches/helium/ui/side-panel-webui-customize.patch
@@ -1,3 +1,25 @@
+--- a/chrome/app/generated_resources.grd
++++ b/chrome/app/generated_resources.grd
+@@ -7958,6 +7958,9 @@ Keep your key file in a safe place. You
+       <message name="IDS_NTP_CUSTOMIZE_CHROME_CHANGE_THEME_LABEL" desc="The label for the action button for changing Chrome theme in the New Tab Page customize chrome side panel.">
+         Change theme
+       </message>
++      <message name="IDS_NTP_CUSTOMIZE_CHROME_CHANGE_WALLPAPER_LABEL" desc="The label for the action button for changing Chrome wallpaper in the New Tab Page customize chrome side panel.">
++        Change wallpaper
++      </message>
+       <message name="IDS_NTP_CUSTOMIZE_FOOTER_HEADER" desc="The toggle for the Footer title in the customization menu on the New Tab Page." meaning="The footer which shows at the bottom of the New Tab page.">
+         Footer
+       </message>
+--- a/chrome/browser/ui/webui/side_panel/customize_chrome/customize_chrome_ui.cc
++++ b/chrome/browser/ui/webui/side_panel/customize_chrome/customize_chrome_ui.cc
+@@ -110,6 +110,7 @@ CustomizeChromeUI::CustomizeChromeUI(con
+       {"extensionsHeader", IDS_NTP_CUSTOMIZE_MENU_EXTENSIONS_LABEL},
+       // Appearance strings.
+       {"changeTheme", IDS_NTP_CUSTOMIZE_CHROME_CHANGE_THEME_LABEL},
++      {"changeWallpaper", IDS_NTP_CUSTOMIZE_CHROME_CHANGE_WALLPAPER_LABEL},
+       {"chromeWebStore", IDS_EXTENSION_WEB_STORE_TITLE},
+       {"classicChrome", IDS_NTP_CUSTOMIZE_NO_BACKGROUND_LABEL},
+       {"colorsContainerLabel", IDS_NTP_THEMES_CONTAINER_LABEL},
 --- a/chrome/browser/resources/side_panel/customize_chrome/customize_toolbar/toolbar.html.ts
 +++ b/chrome/browser/resources/side_panel/customize_chrome/customize_toolbar/toolbar.html.ts
 @@ -8,31 +8,15 @@ import type {ToolbarElement} from './too
@@ -34,10 +56,17 @@
      ${
                this.actions_.map(
                    (action) => action.category === category.id ?
-@@ -76,6 +60,13 @@ export function getHtml(this: ToolbarEle
+@@ -76,13 +60,13 @@ export function getHtml(this: ToolbarEle
                    html`<hr class="sp-hr">` :
                    ''}
    `)}
+-</div>
+-<hr class="sp-cards-separator">
+-<div class="sp-card" id="tipCard">
+-  <svg id="tipIcon" src="icons/lightbulb_outline.svg">
+-    <use href="icons/lightbulb_outline.svg#lightbulbOutline"></use>
+-  </svg>
+-  $i18n{reorderTipLabel}
 +  <hr class="sp-hr">
 +  <cr-button id="resetToDefaultButton"
 +      @click="${this.onResetToDefaultClicked_}"
@@ -46,8 +75,8 @@
 +    $i18n{resetToDefaultButtonLabel}
 +  </cr-button>
  </div>
- <hr class="sp-cards-separator">
- <div class="sp-card" id="tipCard">
+ <!--_html_template_end_-->`;
+ }
 --- a/chrome/browser/resources/side_panel/customize_chrome/theme_snapshot.html.ts
 +++ b/chrome/browser/resources/side_panel/customize_chrome/theme_snapshot.html.ts
 @@ -13,15 +13,6 @@ export function getHtml(this: ThemeSnaps
@@ -132,17 +161,52 @@
      ${(this.modulesEnabled_ && this.isSourceTabFirstPartyNtp_()) ? html`
 --- a/chrome/browser/resources/side_panel/customize_chrome/appearance.css
 +++ b/chrome/browser/resources/side_panel/customize_chrome/appearance.css
-@@ -25,7 +25,8 @@
+@@ -13,9 +13,14 @@
+ 
+ #editButtonsContainer {
+   display: flex;
++  flex-direction: column;
++  align-items: center;
+   gap: 8px;
+-  margin: 0 16px 16px;
+-  width: calc(100% - 32px);
++  margin: 8px 0;
++}
++
++#editButtonsContainer .sp-hr {
++  margin-bottom: 6px;
  }
  
- #editThemeButton {
+ #thirdPartyManageLinkButton {
+@@ -24,8 +29,10 @@
+   width: 100%;
+ }
+ 
+-#editThemeButton {
 -  flex-grow: 1;
++#editThemeButton,
++#setClassicChromeButton {
 +  width: calc(100% - 32px);
-+  margin: 12px 16px 8px 16px;
++  margin: 0 16px;
  }
  
  #wallpaperSearchButton {
-@@ -80,6 +81,7 @@ customize-color-scheme-mode,
+@@ -52,8 +59,13 @@
+   width: 20px;
+ }
+ 
+-#setClassicChromeButton {
++#setClassicChromeIcon {
++  --cr-icon-color: currentColor;
+   --cr-icon-image: url(icons/reset.svg);
++  height: 12px;
++  width: 12px;
++  margin-inline-end: 0;
++  margin-inline-start: 0;
+ }
+ 
+ #uploadedImageButton {
+@@ -80,6 +92,7 @@ customize-color-scheme-mode,
  customize-color-scheme-mode {
    display: block;
    margin: 16px;
@@ -150,34 +214,39 @@
  }
  
  cr-theme-color-picker {
+@@ -91,10 +104,6 @@ cr-theme-color-picker {
+   margin-top: 16px;
+ }
+ 
+-.theme-button:not([hidden]) ~ #editButtonsContainer {
+-  margin: 20px 16px;
+-}
+-
+ .link-out-button {
+   --cr-icon-image: url('chrome://resources/images/open_in_new.svg');
+ }
 --- a/chrome/browser/resources/side_panel/customize_chrome/appearance.html.ts
 +++ b/chrome/browser/resources/side_panel/customize_chrome/appearance.html.ts
-@@ -11,8 +11,20 @@ export function getHtml(this: Appearance
+@@ -11,58 +11,11 @@ export function getHtml(this: Appearance
    return html`<!--_html_template_start_-->
  <customize-chrome-theme-snapshot id="themeSnapshot"
      @edit-theme-click="${this.onEditThemeClicked_}"
 -    ?hidden="${!this.showThemeSnapshot_}">
 +    ?hidden="${true}">
  </customize-chrome-theme-snapshot>
-+<customize-color-scheme-mode></customize-color-scheme-mode>
-+<cr-theme-color-picker id="chromeColors" ?hidden="${!this.showColorPicker_}">
-+</cr-theme-color-picker>
-+<hr class="sp-hr">
-+<div id="followThemeToggle" class="sp-card-content"
-+    ?hidden="${!this.showDeviceThemeToggle_}">
-+  <div id="followThemeToggleTitle">$i18n{followThemeToggle}</div>
-+  <cr-toggle id="followThemeToggleControl" title="$i18n{followThemeToggle}"
-+      ?checked="${!!this.theme_ && this.theme_.followDeviceTheme}"
-+      @change="${this.onFollowThemeToggleChange_}">
-+  </cr-toggle>
-+</div>
- <customize-chrome-hover-button id="thirdPartyThemeLinkButton"
-     class="link-out-button theme-button"
-     ?hidden="${!this.thirdPartyThemeId_}"
-@@ -26,56 +38,16 @@ export function getHtml(this: Appearance
-     label="$i18n{yourUploadedImage}"
-     label-description="$i18n{currentTheme}">
- </customize-chrome-hover-button>
+-<customize-chrome-hover-button id="thirdPartyThemeLinkButton"
+-    class="link-out-button theme-button"
+-    ?hidden="${!this.thirdPartyThemeId_}"
+-    @click="${this.onThirdPartyThemeLinkButtonClick_}"
+-    label="${this.thirdPartyThemeName_}"
+-    label-description="$i18n{currentTheme}">
+-</customize-chrome-hover-button>
+-<customize-chrome-hover-button id="uploadedImageButton" class="theme-button"
+-    ?hidden="${!this.showUploadedImageButton_}"
+-    @click="${this.onUploadedImageButtonClick_}"
+-    label="$i18n{yourUploadedImage}"
+-    label-description="$i18n{currentTheme}">
+-</customize-chrome-hover-button>
 -<customize-chrome-hover-button id="searchedImageButton" class="theme-button"
 -    ?hidden="${!this.showSearchedImageButton_}"
 -    @click="${this.onSearchedImageButtonClick_}"
@@ -211,28 +280,44 @@
 -  ` : ''}
 -</div>
 -<hr class="sp-hr" ?hidden="${!this.showEditTheme_}">
--<customize-color-scheme-mode></customize-color-scheme-mode>
--<cr-theme-color-picker id="chromeColors" ?hidden="${!this.showColorPicker_}">
--</cr-theme-color-picker>
+ <customize-color-scheme-mode></customize-color-scheme-mode>
+ <cr-theme-color-picker id="chromeColors" ?hidden="${!this.showColorPicker_}">
+ </cr-theme-color-picker>
 -<hr class="sp-hr" ?hidden="${!this.showBottomDivider_}">
--<div id="followThemeToggle" class="sp-card-content"
--    ?hidden="${!this.showDeviceThemeToggle_}">
--  <div id="followThemeToggleTitle">$i18n{followThemeToggle}</div>
--  <cr-toggle id="followThemeToggleControl" title="$i18n{followThemeToggle}"
--      ?checked="${!!this.theme_ && this.theme_.followDeviceTheme}"
--      @change="${this.onFollowThemeToggleChange_}">
--  </cr-toggle>
--</div>
- <customize-chrome-hover-button id="setClassicChromeButton"
-     ?hidden="${!this.showClassicChromeButton_}"
-     label="$i18n{resetToClassicChrome}"
-     @click="${this.onSetClassicChromeClicked_}">
+ <div id="followThemeToggle" class="sp-card-content"
+     ?hidden="${!this.showDeviceThemeToggle_}">
+   <div id="followThemeToggleTitle">$i18n{followThemeToggle}</div>
+@@ -71,11 +24,29 @@ ${this.showManagedButton_ ? html`
+       @change="${this.onFollowThemeToggleChange_}">
+   </cr-toggle>
+ </div>
+-<customize-chrome-hover-button id="setClassicChromeButton"
+-    ?hidden="${!this.showClassicChromeButton_}"
+-    label="$i18n{resetToClassicChrome}"
+-    @click="${this.onSetClassicChromeClicked_}">
++<customize-chrome-hover-button id="thirdPartyThemeLinkButton"
++    class="link-out-button theme-button"
++    ?hidden="${!this.thirdPartyThemeId_}"
++    @click="${this.onThirdPartyThemeLinkButtonClick_}"
++    label="${this.thirdPartyThemeName_}"
++    label-description="$i18n{currentTheme}">
  </customize-chrome-hover-button>
-+<cr-button id="editThemeButton" @click="${this.onEditThemeClicked_}">
-+  <div id="editThemeIcon" class="cr-icon edit-theme-icon" slot="prefix-icon"
-+      ?hidden="${this.wallpaperSearchButtonEnabled_}"></div>
-+  ${this.editThemeButtonText_}
-+</cr-button>
++<div id="editButtonsContainer" ?hidden="${!this.showEditTheme_}">
++  <hr class="sp-hr">
++  <cr-button id="editThemeButton"
++      ?hidden="${!this.showEditTheme_}"
++      @click="${this.onUploadedImageButtonClick_}">
++    <div id="editThemeIcon" class="cr-icon edit-theme-icon" slot="prefix-icon"
++        ?hidden="${this.wallpaperSearchButtonEnabled_}"></div>
++    $i18n{changeWallpaper}
++  </cr-button>
++  <cr-button id="setClassicChromeButton"
++      ?hidden="${!this.showClassicChromeButton_}"
++      @click="${this.onSetClassicChromeClicked_}">
++    <div id="setClassicChromeIcon" class="cr-icon" slot="prefix-icon"></div>
++    $i18n{resetToDefaultButtonLabel}
++  </cr-button>
++</div>
  ${this.showManagedDialog_ ? html`
    <managed-dialog @close="${this.onManagedDialogClosed_}"
        title="$i18n{managedColorsTitle}"
@@ -304,111 +389,6 @@
  }
  
  .sub-options .option {
---- a/chrome/browser/resources/side_panel/shared/sp_shared_style_lit.css
-+++ b/chrome/browser/resources/side_panel/shared/sp_shared_style_lit.css
-@@ -10,7 +10,7 @@
- 
- .sp-card {
-   background: var(--color-side-panel-card-background);
--  border-radius: 12px;
-+  border-radius: 9px;
-   display: block;
-   margin: 0 var(--sp-body-padding);
-   padding: var(--sp-card-block-padding) 0;
-@@ -21,6 +21,15 @@
-   padding: 0 var(--sp-card-inline-padding);
- }
- 
-+.sp-card sp-heading.separator {
-+  margin-bottom: 8px;
-+}
-+
-+.option {
-+  align-items: center;
-+  padding-inline-start: 0;
-+}
-+
- .sp-scroller {
-   display: block;
-   overflow-x: hidden;
-@@ -77,7 +86,7 @@
- .sp-cards-separator {
-   border: 0;
-   flex-shrink: 0;
--  height: 8px;
-+  height: 6px;
-   margin: 0;
-   width: 100%;
- }
-@@ -97,3 +106,7 @@ cr-dialog::part(dialog) {
-   border-radius: 12px;
-   box-shadow: var(--cr-elevation-3);
- }
-+
-+cr-toolbar-search-field {
-+  border-radius: 9px;
-+}
---- a/chrome/browser/resources/side_panel/shared/sp_shared_vars.css
-+++ b/chrome/browser/resources/side_panel/shared/sp_shared_vars.css
-@@ -8,11 +8,11 @@
-  * #css_wrapper_metadata_end */
- 
- html {
--  --sp-body-padding: 8px;
-+  --sp-body-padding: 4px;
-   --sp-card-block-padding: 8px;
-   --sp-card-inline-padding: 16px;
-   --sp-card-padding: var(--sp-card-block-padding) var(--sp-card-inline-padding);
--  --sp-card-gap: 12px;
-+  --sp-card-gap: 8px;
- 
-   /* Override default WebUI vars from cr_shared_vars. */
-   --cr-primary-text-color: var(--color-side-panel-card-primary-foreground);
---- a/chrome/browser/resources/side_panel/shared/sp_heading.css
-+++ b/chrome/browser/resources/side_panel/shared/sp_heading.css
-@@ -15,12 +15,8 @@
-   align-items: center;
-   display: flex;
-   flex-shrink: 0;
--  gap: 4px;
--  height: 36px;
--}
--
--:host([compact]) {
--  height: 36px;
-+  gap: 12px;
-+  height: 28px;
- }
- 
- #backButton,
---- a/chrome/browser/resources/side_panel/customize_chrome/categories.html.ts
-+++ b/chrome/browser/resources/side_panel/customize_chrome/categories.html.ts
-@@ -10,7 +10,7 @@ export function getHtml(this: Categories
-   // clang-format off
-   return html`<!--_html_template_start_-->
- <div class="sp-card">
--  <sp-heading id="heading" @back-button-click="${this.onBackClick_}"
-+  <sp-heading id="heading" class="separator" @back-button-click="${this.onBackClick_}"
-       back-button-aria-label="$i18n{backButton}"
-       back-button-title="$i18n{backButton}">
-     <h2 slot="heading">$i18n{categoriesHeader}</h2>
-@@ -72,16 +72,6 @@ export function getHtml(this: Categories
-         <div class="label">${item.label}</div>
-       </div>
-     `)}
--    <div class="tile" tabindex="0" role="button"
--        @click="${this.onChromeWebStoreClick_}" id="chromeWebStoreTile">
--      <div class="image-container">
--        <img id="chromeWebStore" src="icons/chrome_web_store.svg"></img>
--      </div>
--      <div class="label">
--        <div class="cr-icon icon-external"></div>
--        $i18n{chromeWebStore}
--      </div>
--    </div>
-   </cr-grid>
- </div>
- <!--_html_template_end_-->`;
 --- a/chrome/browser/resources/side_panel/customize_chrome/hover_button.css
 +++ b/chrome/browser/resources/side_panel/customize_chrome/hover_button.css
 @@ -20,6 +20,7 @@
@@ -425,11 +405,4 @@
 -<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none"><path d="m7.898 12.5 1.704-1.7-1.684-1.698-.566.566.699.715c-.324 0-.637-.055-.942-.168a2.168 2.168 0 0 1-.808-.516 2.355 2.355 0 0 1-.516-.773A2.359 2.359 0 0 1 5.602 8c0-.18.015-.352.046-.516.036-.168.086-.328.153-.484l-.586-.582a3.419 3.419 0 0 0-.305.758A3 3 0 0 0 4.8 8c0 .422.079.832.243 1.227.16.394.39.738.691 1.039.32.324.68.558 1.075.71.394.149.812.223 1.257.223l-.734.735Zm2.887-2.918c.133-.242.235-.496.305-.758A3 3 0 0 0 11.2 8c0-.422-.083-.832-.25-1.227a3.185 3.185 0 0 0-.7-1.039 2.916 2.916 0 0 0-1.082-.691 3.376 3.376 0 0 0-1.27-.211l.77-.766-.566-.566-1.704 1.7 1.704 1.698.566-.566-.734-.73c.343 0 .664.054.957.164.296.113.566.289.808.535.223.222.395.48.516.773.125.297.183.606.183.926 0 .18-.015.352-.046.516a2.585 2.585 0 0 1-.153.484ZM8 14.398a6.192 6.192 0 0 1-2.484-.5 6.366 6.366 0 0 1-2.04-1.375 6.366 6.366 0 0 1-1.374-2.039A6.192 6.192 0 0 1 1.602 8c0-.89.164-1.719.5-2.492.332-.774.789-1.45 1.375-2.031a6.366 6.366 0 0 1 2.039-1.375A6.192 6.192 0 0 1 8 1.602c.89 0 1.719.164 2.492.5.774.332 1.45.789 2.031 1.375a6.375 6.375 0 0 1 1.375 2.03c.336.774.5 1.602.5 2.493 0 .879-.164 1.707-.5 2.484a6.366 6.366 0 0 1-1.375 2.04 6.375 6.375 0 0 1-2.03 1.374c-.774.336-1.602.5-2.493.5ZM8 13.2c1.445 0 2.672-.504 3.684-1.515 1.011-1.012 1.515-2.239 1.515-3.684 0-1.445-.504-2.672-1.515-3.684C10.672 3.305 9.445 2.801 8 2.801c-1.445 0-2.672.504-3.684 1.515C3.305 5.328 2.801 6.555 2.801 8c0 1.445.504 2.672 1.515 3.684C5.328 12.695 6.555 13.199 8 13.199ZM8 8Zm0 0" fill="#5F6368"/></svg>
 \ No newline at end of file
 +<svg xmlns="http://www.w3.org/2000/svg" height="20px" viewBox="0 -960 960 960" width="20px" fill="#1f1f1f"><path d="M480-192q-120 0-204-84t-84-204q0-120 84-204t204-84q65 0 120.5 27t95.5 72v-99h72v240H528v-72h131q-29-44-76-70t-103-26q-90 0-153 63t-63 153q0 90 63 153t153 63q84 0 144-55.5T693-456h74q-9 112-91 188t-196 76Z"/></svg>
-\ No newline at end of file
---- a/chrome/browser/resources/side_panel/customize_chrome/icons/upload.svg
-+++ b/chrome/browser/resources/side_panel/customize_chrome/icons/upload.svg
-@@ -1 +1 @@
--<svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M9.666 5.44 6.213 8.88 4.333 7 11 .335l6.666 6.667-1.88 1.893-3.453-3.453v10.893H9.666V5.441ZM3 15H.333v4c0 1.467 1.2 2.667 2.667 2.667h16c1.466 0 2.666-1.2 2.666-2.666v-4H19v4H3v-4Z" fill="#5F6368"/></svg>
-\ No newline at end of file
-+<svg xmlns="http://www.w3.org/2000/svg" height="20px" viewBox="0 -960 960 960" width="20px" fill="#1f1f1f"><path d="M444-336v-342L339-573l-51-51 192-192 192 192-51 51-105-105v342h-72ZM263.72-192Q234-192 213-213.15T192-264v-72h72v72h432v-72h72v72q0 29.7-21.16 50.85Q725.68-192 695.96-192H263.72Z"/></svg>
 \ No newline at end of file

--- a/patches/helium/ui/side-panel-webui-general.patch
+++ b/patches/helium/ui/side-panel-webui-general.patch
@@ -1,0 +1,77 @@
+--- a/chrome/browser/resources/side_panel/shared/sp_shared_style_lit.css
++++ b/chrome/browser/resources/side_panel/shared/sp_shared_style_lit.css
+@@ -10,7 +10,7 @@
+ 
+ .sp-card {
+   background: var(--color-side-panel-card-background);
+-  border-radius: 12px;
++  border-radius: 9px;
+   display: block;
+   margin: 0 var(--sp-body-padding);
+   padding: var(--sp-card-block-padding) 0;
+@@ -21,6 +21,15 @@
+   padding: 0 var(--sp-card-inline-padding);
+ }
+ 
++.sp-card sp-heading.separator {
++  margin-bottom: 8px;
++}
++
++.option {
++  align-items: center;
++  padding-inline-start: 0;
++}
++
+ .sp-scroller {
+   display: block;
+   overflow-x: hidden;
+@@ -77,7 +86,7 @@
+ .sp-cards-separator {
+   border: 0;
+   flex-shrink: 0;
+-  height: 8px;
++  height: 6px;
+   margin: 0;
+   width: 100%;
+ }
+@@ -97,3 +106,7 @@ cr-dialog::part(dialog) {
+   border-radius: 12px;
+   box-shadow: var(--cr-elevation-3);
+ }
++
++cr-toolbar-search-field {
++  border-radius: 9px;
++}
+--- a/chrome/browser/resources/side_panel/shared/sp_shared_vars.css
++++ b/chrome/browser/resources/side_panel/shared/sp_shared_vars.css
+@@ -8,11 +8,11 @@
+  * #css_wrapper_metadata_end */
+ 
+ html {
+-  --sp-body-padding: 8px;
++  --sp-body-padding: 6px;
+   --sp-card-block-padding: 8px;
+   --sp-card-inline-padding: 16px;
+   --sp-card-padding: var(--sp-card-block-padding) var(--sp-card-inline-padding);
+-  --sp-card-gap: 12px;
++  --sp-card-gap: 8px;
+ 
+   /* Override default WebUI vars from cr_shared_vars. */
+   --cr-primary-text-color: var(--color-side-panel-card-primary-foreground);
+--- a/chrome/browser/resources/side_panel/shared/sp_heading.css
++++ b/chrome/browser/resources/side_panel/shared/sp_heading.css
+@@ -15,12 +15,8 @@
+   align-items: center;
+   display: flex;
+   flex-shrink: 0;
+-  gap: 4px;
+-  height: 36px;
+-}
+-
+-:host([compact]) {
+-  height: 36px;
++  gap: 12px;
++  height: 28px;
+ }
+ 
+ #backButton,

--- a/patches/helium/ui/ublock-show-in-settings.patch
+++ b/patches/helium/ui/ublock-show-in-settings.patch
@@ -87,7 +87,7 @@
    };
 --- a/chrome/app/generated_resources.grd
 +++ b/chrome/app/generated_resources.grd
-@@ -13802,6 +13802,9 @@ Check your passwords anytime in <ph name
+@@ -13805,6 +13805,9 @@ Check your passwords anytime in <ph name
          <message name="IDS_EXTENSIONS_INSTALL_LOCATION_SHARED_MODULE" desc="The text explaining the the installation of the extension was because of extensions that depend on this shared module">
            Installed because of dependent extension(s).
          </message>

--- a/patches/series
+++ b/patches/series
@@ -238,7 +238,8 @@ helium/ui/add-specific-error-for-disabled-extension-downloads.patch
 helium/ui/selected-keyword-view.patch
 helium/ui/bookmark-button-bg-fix.patch
 helium/ui/restyle-ntp-tiles.patch
-helium/ui/side-panel-webui.patch
+helium/ui/side-panel-webui-general.patch
+helium/ui/side-panel-webui-customize.patch
 helium/ui/helium-logo-icons.patch
 helium/ui/square-ntp-monograms.patch
 helium/ui/default-theme.patch


### PR DESCRIPTION
- replaced "change theme" button with direct "change wallpaper" button. eliminated the extra empty page that only makes sense in google chrome (due to wallpaper collections).
- replaced a weird "reset" button with cr-button.
- updated button container styling.
- fixed #635 by hiding the NTP theme controls based on showEditTheme_, as it should've been from the start.
- removed stale patches which no longer affect anything.
- split side-panel-webui into side-panel-webui-customize and side-panel-webui-general.

before:

https://github.com/user-attachments/assets/63422fde-d51b-49c3-bea0-d8867ccf75f6

after:

https://github.com/user-attachments/assets/e9dc8867-e390-4f85-9da1-57621939ce37
