### PR TITLE
helium/ui/side-panel: remove the frame around side panels

### DIFF
--- a/patches/helium/ui/side-panel.patch
+++ b/patches/helium/ui/side-panel.patch
@@ -1,23 +1,451 @@
+--- a/chrome/browser/ui/views/side_panel/side_panel.h
++++ b/chrome/browser/ui/views/side_panel/side_panel.h
+@@ -15,6 +15,7 @@
+ #include "components/prefs/pref_change_registrar.h"
+ #include "ui/base/metadata/metadata_header_macros.h"
+ #include "ui/gfx/animation/slide_animation.h"
++#include "ui/gfx/geometry/insets.h"
+ #include "ui/gfx/geometry/rounded_corners_f.h"
+ #include "ui/views/accessible_pane_view.h"
+ #include "ui/views/animation/animation_delegate_views.h"
+@@ -123,7 +124,6 @@ class SidePanel : public views::Accessib
+   views::View* resize_area_for_testing() { return resize_area_; }
+ 
+  private:
+-  class BorderView;
+   class VisibleBoundsViewClipper;
+ 
+   // This method is the shared implementation of Open/Close.
+@@ -136,6 +136,8 @@ class SidePanel : public views::Accessib
+   bool ShouldShowAnimation() const;
+   void AnnounceResize();
+ 
++  gfx::Insets GetBorderInsets() const;
++  void UpdateBorderInsets();
+   void UpdateHorizontalAlignment();
+ 
+   // views::View:
+@@ -152,7 +154,6 @@ class SidePanel : public views::Accessib
+   void OnAnimationTypeEnded(
+       SidePanelAnimationCoordinator::AnimationType type) override;
+ 
+-  raw_ptr<BorderView> border_view_ = nullptr;
+   const raw_ptr<BrowserView> browser_view_;
+   const SidePanelEntry::PanelType type_;
+   raw_ptr<View> resize_area_ = nullptr;
 --- a/chrome/browser/ui/views/side_panel/side_panel.cc
 +++ b/chrome/browser/ui/views/side_panel/side_panel.cc
-@@ -60,12 +60,12 @@ namespace {
- // This thickness includes the solid-color background and the inner round-rect
- // border-color stroke. It does not include the outer-color separator.
- int GetBorderThickness() {
+@@ -42,12 +42,10 @@
+ #include "ui/gfx/geometry/insets_conversions.h"
+ #include "ui/gfx/geometry/rect.h"
+ #include "ui/gfx/geometry/rect_conversions.h"
+-#include "ui/gfx/geometry/rect_f.h"
+ #include "ui/gfx/geometry/rounded_corners_f.h"
+ #include "ui/gfx/geometry/skia_conversions.h"
+ #include "ui/gfx/scoped_canvas.h"
+ #include "ui/views/accessibility/view_accessibility.h"
+-#include "ui/views/border.h"
+ #include "ui/views/controls/separator.h"
+ #include "ui/views/layout/fill_layout.h"
+ #include "ui/views/layout/flex_layout.h"
+@@ -57,25 +55,17 @@
+ 
+ namespace {
+ 
+-// This thickness includes the solid-color background and the inner round-rect
+-// border-color stroke. It does not include the outer-color separator.
+-int GetBorderThickness() {
 -  return 8 + views::Separator::kThickness;
-+  return 6;
+-}
+-
+-// This is how many units of the toolbar are essentially expected to be
+-// background.
+-constexpr int kOverlapFromToolbar = 4;
+-
+-// We want the border to visually look like GetBorderThickness() units on all
+-// sides except the top. On the top side, background is drawn on top of the
+-// top-content separator and some units of background inside the toolbar (or
+-// bookmarks bar) itself. Subtract both of those to not get visually-excessive
+-// padding.
+-gfx::Insets GetBorderInsets() {
+-  int border_thickness = GetBorderThickness();
+-  return gfx::Insets::TLBR(-kOverlapFromToolbar, border_thickness,
+-                           border_thickness, border_thickness);
++constexpr int kResizeAreaWidth = 6;
++
++gfx::Insets GetBorderInsetsForAlignment(
++    SidePanel::HorizontalAlignment alignment) {
++  const bool is_right_aligned =
++      alignment == SidePanel::HorizontalAlignment::kRight;
++  const bool inset_on_left =
++      base::i18n::IsRTL() ? !is_right_aligned : is_right_aligned;
++  const int left = inset_on_left ? kResizeAreaWidth : 0;
++  const int right = inset_on_left ? 0 : kResizeAreaWidth;
++  return gfx::Insets::TLBR(0, left, 0, right);
  }
  
- // This is how many units of the toolbar are essentially expected to be
- // background.
--constexpr int kOverlapFromToolbar = 4;
-+constexpr int kOverlapFromToolbar = 3;
+ SidePanel::HorizontalAlignment GetHorizontalAlignment(
+@@ -92,130 +82,6 @@ SidePanel::HorizontalAlignment GetHorizo
+              : SidePanel::HorizontalAlignment::kLeft;
+ }
  
- // We want the border to visually look like GetBorderThickness() units on all
- // sides except the top. On the top side, background is drawn on top of the
+-// This border paints the toolbar color around the side panel content and draws
+-// a roundrect viewport around the side panel content. The border can have
+-// rounded corners of its own.
+-class SidePanelBorder : public views::Border {
+- public:
+-  explicit SidePanelBorder(BrowserView* browser_view)
+-      : browser_view_(browser_view) {
+-    SetColor(kColorSidePanelContentAreaSeparator);
+-  }
+-
+-  SidePanelBorder(const SidePanelBorder&) = delete;
+-  SidePanelBorder& operator=(const SidePanelBorder&) = delete;
+-
+-  void SetHeaderHeight(int height) { header_height_ = height; }
+-  void SetBorderRadii(const gfx::RoundedCornersF& radii) {
+-    border_radii_ = radii;
+-  }
+-
+-  void SetOutlineVisibility(bool visible) { outline_visible_ = visible; }
+-
+-  // views::Border:
+-  void Paint(const views::View& view, gfx::Canvas* canvas) override {
+-    // Undo DSF so that we can be sure to draw an integral number of pixels for
+-    // the border. Integral scale factors should be unaffected by this, but for
+-    // fractional scale factors this ensures sharp lines.
+-    gfx::ScopedCanvas scoped_unscale(canvas);
+-    float dsf = canvas->UndoDeviceScaleFactor();
+-
+-    const gfx::RectF scaled_view_bounds_f = gfx::ConvertRectToPixels(
+-        view.GetLocalBounds(), view.layer()->device_scale_factor());
+-
+-    gfx::RectF scaled_contents_bounds_f = scaled_view_bounds_f;
+-    const float corner_radius =
+-        dsf * view.GetLayoutProvider()->GetDistanceMetric(
+-                  ChromeDistanceMetric::
+-                      DISTANCE_CONTENT_HEIGHT_SIDE_PANEL_CONTENT_RADIUS);
+-    const gfx::InsetsF insets_in_pixels(
+-        gfx::ConvertInsetsToPixels(GetInsets(), dsf));
+-    scaled_contents_bounds_f.Inset(insets_in_pixels);
+-
+-    // Use ToEnclosedRect to make sure that the clip bounds never end up larger
+-    // than the child view.
+-    gfx::Rect clip_bounds = ToEnclosedRect(scaled_contents_bounds_f);
+-    SkRRect rect = SkRRect::MakeRectXY(gfx::RectToSkRect(clip_bounds),
+-                                       corner_radius, corner_radius);
+-
+-    // Clip out the content area from the background about to be painted.
+-    canvas->sk_canvas()->clipRRect(rect, SkClipOp::kDifference,
+-                                   /*do_anti_alias=*/true);
+-
+-    {
+-      // Redo the device scale factor. The theme background and clip for the
+-      // outer corners are drawn in DIPs. Note that the clip area above is in
+-      // pixels because `UndoDeviceScaleFactor()` was called before this.
+-      gfx::ScopedCanvas scoped_rescale(canvas);
+-      canvas->Scale(dsf, dsf);
+-
+-      const SkVector border_radii[4] = {
+-          {border_radii_.upper_left(), border_radii_.upper_left()},
+-          {border_radii_.upper_right(), border_radii_.upper_right()},
+-          {border_radii_.lower_right(), border_radii_.lower_right()},
+-          {border_radii_.lower_left(), border_radii_.lower_left()}};
+-
+-      const SkPath rounded_border_path = SkPath::RRect(SkRRect::MakeRectRadii(
+-          gfx::RectToSkRect(view.GetLocalBounds()), border_radii));
+-
+-      // Add another clip to the canvas that rounds the outer corners of the
+-      // border. This is done in DIPs because for some device scale factors, the
+-      // conversion to pixels can cause the clip to be off by a pixel, resulting
+-      // in a pixel gap between the side panel border and web contents.
+-      canvas->ClipPath(rounded_border_path, /*do_anti_alias=*/true);
+-
+-      // Draw the top-container background.
+-      ThemedBackground::PaintBackground(canvas, &view, browser_view_);
+-    }
+-
+-    // Paint the inner border around SidePanel content. Since half the stroke
+-    // gets painted in the clipped area, make this twice as thick, and scale
+-    // the thickness by device scale factor since we're working in pixels.
+-    const float stroke_thickness =
+-        outline_visible_
+-            ? views::Separator::kThickness * 2 * dsf
+-            // TODO(crbug.com/463994274): Avoid drawing a hairline stroke.
+-            : 0;
+-
+-    cc::PaintFlags flags;
+-    flags.setStrokeWidth(stroke_thickness);
+-    flags.setColor(color().ResolveToSkColor(view.GetColorProvider()));
+-    flags.setStyle(cc::PaintFlags::kStroke_Style);
+-    flags.setAntiAlias(true);
+-    if (!outline_visible_) {
+-      // TODO(crbug.com/463994274): Zero stroke width still draws a hairline. We
+-      // can't remove this rectangle, or we get some visual artifacts, so
+-      // instead just draw it in the background color.
+-      std::optional<SkColor> bg_color =
+-          ThemedBackground::GetBackgroundColor(&view, browser_view_);
+-      if (bg_color) {
+-        flags.setColor(*bg_color);
+-      }
+-    }
+-    canvas->sk_canvas()->drawRRect(rect, flags);
+-  }
+-
+-  gfx::Insets GetInsets() const override {
+-    // This additional inset matches the growth inside BorderView::Layout()
+-    // below to let us paint on top of the toolbar separator. This additional
+-    // inset is outside the SidePanel itself, but not outside the BorderView. If
+-    // there is a header we want to increase the top inset to give room for the
+-    // header to paint on top of the border area.
+-    int top_inset =
+-        views::Separator::kThickness + header_height_ - GetBorderInsets().top();
+-    return GetBorderInsets() + gfx::Insets::TLBR(top_inset, 0, 0, 0);
+-  }
+-  gfx::Size GetMinimumSize() const override {
+-    return gfx::Size(GetInsets().width(), GetInsets().height());
+-  }
+-
+- private:
+-  int header_height_ = 0;
+-  gfx::RoundedCornersF border_radii_;
+-  bool outline_visible_ = true;
+-  const raw_ptr<BrowserView> browser_view_;
+-};
+-
+ class ContentParentBackground : public views::Background {
+  public:
+   ContentParentBackground(BrowserView* browser_view,
+@@ -329,56 +195,6 @@ END_METADATA
+ 
+ }  // namespace
+ 
+-class SidePanel::BorderView : public views::View {
+-  METADATA_HEADER(BorderView, views::View)
+-
+- public:
+-  explicit BorderView(BrowserView* browser_view) {
+-    SetVisible(false);
+-    auto border = std::make_unique<SidePanelBorder>(browser_view);
+-    border_ = border.get();
+-    SetBorder(std::move(border));
+-    // Don't allow the view to process events. If we do allow this then events
+-    // won't get passed on to the side panel hosted content.
+-    SetCanProcessEventsWithinSubtree(false);
+-  }
+-
+-  void HeaderViewChanged(views::View* header_view) {
+-    border_->SetHeaderHeight(
+-        header_view ? header_view->GetPreferredSize().height() : 0);
+-  }
+-
+-  void SetOutlineVisibilty(bool visible) {
+-    border_->SetOutlineVisibility(visible);
+-    SchedulePaint();
+-  }
+-
+-  void SetBorderRadii(const gfx::RoundedCornersF& radii) {
+-    border_->SetBorderRadii(radii);
+-    SchedulePaint();
+-  }
+-
+-  void Layout(PassKey) override {
+-    // Let BorderView grow slightly taller so that it overlaps the divider into
+-    // the toolbar or bookmarks bar above it.
+-    gfx::Rect bounds = parent()->GetLocalBounds();
+-    bounds.Inset(gfx::Insets::TLBR(-views::Separator::kThickness, 0, 0, 0));
+-
+-    SetBoundsRect(bounds);
+-  }
+-
+-  void OnThemeChanged() override {
+-    SchedulePaint();
+-    View::OnThemeChanged();
+-  }
+-
+- private:
+-  raw_ptr<SidePanelBorder> border_;
+-};
+-
+-BEGIN_METADATA(SidePanel, BorderView)
+-END_METADATA
+-
+ // Ensures immediate children of the SidePanel have their layers clipped to
+ // their visible bounds to prevent incorrect clipping during animation.
+ // TODO: 344626785 - Remove this once WebView layer behavior has been fixed.
+@@ -430,7 +246,7 @@ class SidePanel::VisibleBoundsViewClippe
+ 
+ SidePanel::SidePanel(BrowserView* browser_view,
+                      SidePanelEntry::PanelType type,
+-                     bool has_border)
++                     bool /*has_border*/)
+     : browser_view_(browser_view),
+       type_(type),
+       visible_bounds_view_clipper_(
+@@ -441,18 +257,11 @@ SidePanel::SidePanel(BrowserView* browse
+ 
+   // The default z-order is the order in which children were added to the
+   // parent view. content_parent_view_ is added first so it exists behind
+-  // border_view_ and resize_area_.
++  // resize_area_.
+   content_parent_view_ = AddChildView(std::make_unique<ContentParentView>(
+-      browser_view, /*should_round_corners=*/!has_border, type));
++      browser_view, /*should_round_corners=*/false, type));
+   content_parent_view_->SetVisible(false);
+ 
+-  if (has_border) {
+-    std::unique_ptr<BorderView> border_view =
+-        std::make_unique<BorderView>(browser_view);
+-    border_view_ = border_view.get();
+-    AddChildView(std::move(border_view));
+-  }
+-
+   std::unique_ptr<views::SidePanelResizeArea> resize_area =
+       std::make_unique<views::SidePanelResizeArea>(this);
+   resize_area_ = resize_area.get();
+@@ -482,15 +291,12 @@ SidePanel::SidePanel(BrowserView* browse
+ 
+   SetVisible(false);
+   SetLayoutManager(std::make_unique<views::FillLayout>());
++  UpdateBorderInsets();
+ 
+   // Set the panel width from the preference or use the minimum size as the
+   // default.
+   SetPanelWidth(GetMinimumSize().width());
+ 
+-  if (has_border) {
+-    SetBorder(views::CreateEmptyBorder(GetBorderInsets()));
+-  }
+-
+   SetProperty(views::kElementIdentifierKey, kSidePanelElementId);
+ }
+ 
+@@ -531,12 +337,6 @@ void SidePanel::SetBackgroundRadii(const
+     return;
+   }
+   background_radii_ = radii;
+-
+-  if (border_view_) {
+-    // Since the border_view paints the background, by adding rounded
+-    // corners to border will paint a rounded background for the side panel.
+-    border_view_->SetBorderRadii(background_radii_);
+-  }
+ }
+ 
+ void SidePanel::UpdateWidthOnEntryChanged() {
+@@ -575,6 +375,14 @@ bool SidePanel::IsRightAligned() const {
+   return horizontal_alignment() == HorizontalAlignment::kRight;
+ }
+ 
++gfx::Insets SidePanel::GetBorderInsets() const {
++  return GetBorderInsetsForAlignment(horizontal_alignment_);
++}
++
++void SidePanel::UpdateBorderInsets() {
++  SetBorder(views::CreateEmptyBorder(GetBorderInsets()));
++}
++
+ gfx::Size SidePanel::GetMinimumSize() const {
+   const int min_height = 0;
+   return gfx::Size(
+@@ -620,44 +428,17 @@ gfx::Rect SidePanel::GetContentAnimation
+   return animating_bounds;
+ }
+ 
+-void SidePanel::AddHeaderView(std::unique_ptr<views::View> view) {
+-  // If a header view already exists make sure we remove it so that it is
+-  // replaced.
+-  if (header_view_) {
+-    auto header_view = RemoveChildViewT(header_view_);
+-    header_view_ = nullptr;
+-  }
+-  header_view_ = view.get();
+-  AddChildView(std::move(view));
+-  header_view_->InsertAfterInFocusList(resize_area_);
+-  header_view_->DeprecatedLayoutImmediately();
+-  if (border_view_) {
+-    border_view_->HeaderViewChanged(header_view_);
+-  }
+-  // Update the border so that the insets include space for the header to be
+-  // placed on top of the border area.
+-  int top_inset = header_view_->height() - GetBorderInsets().top();
+-  SetBorder(views::CreateEmptyBorder(GetBorderInsets() +
+-                                     gfx::Insets::TLBR(top_inset, 0, 0, 0)));
+-}
++void SidePanel::AddHeaderView(std::unique_ptr<views::View> /*view*/) {}
+ 
+ void SidePanel::RemoveHeaderView() {
+-  SetBorder(views::CreateEmptyBorder(GetBorderInsets().set_top(0)));
+-  if (border_view_) {
+-    border_view_->HeaderViewChanged(nullptr);
+-  }
+   if (header_view_) {
+     auto header_view = RemoveChildViewT(header_view_);
+     header_view_ = nullptr;
+   }
++  UpdateBorderInsets();
+ }
+ 
+-void SidePanel::SetOutlineVisibility(bool visible) {
+-  if (!border_view_) {
+-    return;
+-  }
+-  border_view_->SetOutlineVisibilty(visible);
+-}
++void SidePanel::SetOutlineVisibility(bool /*visible*/) {}
+ 
+ gfx::Size SidePanel::GetContentSizeUpperBound() const {
+   const int side_panel_width = width() > 0 ? width() : GetMinimumSize().width();
+@@ -836,7 +617,7 @@ void SidePanel::UpdateVisibility(bool sh
+   // TODO(pbos): Iterate content instead. Requires moving the owned pointer out
+   // of owned contents before resetting it.
+   for (views::View* view : children()) {
+-    if (view == border_view_ || view == resize_area_ || view == header_view_ ||
++    if (view == resize_area_ || view == header_view_ ||
+         !view->GetVisible()) {
+       continue;
+     }
+@@ -845,29 +626,6 @@ void SidePanel::UpdateVisibility(bool sh
+       views_to_hide.push_back(view);
+     }
+   }
+-  // Make sure the border visibility matches the side panel. Also dynamically
+-  // create and destroy the layer to reclaim memory and avoid painting and
+-  // compositing this border when it's not showing. See
+-  // https://crbug.com/1269090.
+-  // TODO(pbos): Should layer visibility/painting be automatically tied to
+-  // parent visibility? I.e. the difference between GetVisible() and IsDrawn().
+-  bool side_panel_open_or_closing = GetVisible() || should_be_open;
+-  if (border_view_ &&
+-      side_panel_open_or_closing != border_view_->GetVisible()) {
+-    border_view_->SetVisible(side_panel_open_or_closing);
+-    if (side_panel_open_or_closing) {
+-      border_view_->SetPaintToLayer();
+-      border_view_->layer()->SetFillsBoundsOpaquely(false);
+-      if (header_view_ && header_view_->GetVisible()) {
+-        border_view_->HeaderViewChanged(header_view_);
+-        int top_inset = header_view_->height() - GetBorderInsets().top();
+-        SetBorder(views::CreateEmptyBorder(
+-            GetBorderInsets() + gfx::Insets::TLBR(top_inset, 0, 0, 0)));
+-      }
+-    } else {
+-      border_view_->DestroyLayer();
+-    }
+-  }
+   if (animate_transition) {
+     if (should_be_open) {
+       // If the side panel should remain open but there are views to hide, hide
+@@ -957,6 +715,7 @@ void SidePanel::UpdateHorizontalAlignmen
+       GetHorizontalAlignment(browser_view_->GetProfile()->GetPrefs(), type_,
+                              use_default_horizontal_alignment_);
+ 
++  UpdateBorderInsets();
+   InvalidateLayout();
+ }
+ 
 --- a/chrome/browser/ui/views/side_panel/side_panel_resize_area.cc
 +++ b/chrome/browser/ui/views/side_panel/side_panel_resize_area.cc
-@@ -29,11 +29,11 @@ SidePanelResizeHandle::SidePanelResizeHa
+@@ -29,7 +29,7 @@ SidePanelResizeHandle::SidePanelResizeHa
      : side_panel_(side_panel) {
    SetProperty(views::kElementIdentifierKey, kSidePanelResizeHandleElementId);
    SetVisible(false);
@@ -26,8 +454,3 @@
    SetPreferredSize(preferred_size);
    SetCanProcessEventsWithinSubtree(false);
  
--  const int resize_handle_left_margin = 2;
-+  const int resize_handle_left_margin = 1;
-   SetProperty(views::kMarginsKey,
-               gfx::Insets().set_left(resize_handle_left_margin));
- }


### PR DESCRIPTION
- side panels no longer have a rounded frame around them.
- side panels no longer have a header on top.
- added logic for maintaining the resize area in all layout options, for consistency with other resizers (such as in split view).

<details>
<summary>before</summary>
<img width="428" height="879" alt="image" src="https://github.com/user-attachments/assets/0db58ba3-a184-45ee-906d-e832f09a466d" />
</details>

<details>
<summary>after</summary>
<img width="438" height="885" alt="image" src="https://github.com/user-attachments/assets/477dd67b-c28c-4ce2-bc10-0d73d1e7b2a8" />
</details>

various layouts with resizing:

https://github.com/user-attachments/assets/2fa9b4d2-0cb3-4fa5-8e42-354a87339528

