### PR TITLE
helium/ui/selected-keyword: "Search <engine>" -> "<engine>"

### DIFF
--- a/patches/helium/ui/selected-keyword-view.patch
+++ b/patches/helium/ui/selected-keyword-view.patch
@@ -28,3 +28,19 @@
  }
  
  void SelectedKeywordView::SetLabelForCurrentWidth() {
+--- a/components/search_engines/template_url.cc
++++ b/components/search_engines/template_url.cc
+@@ -2389,11 +2389,7 @@ std::u16string TemplateURL::GetFullName(
+   if (is_ask_type()) {
+     return l10n_util::GetStringFUTF16(IDS_OMNIBOX_SELECTED_KEYWORD_ASK_TEXT,
+                                       short_name);
+-  } else if (starter_pack_id() ==
+-             template_url_starter_pack_data::StarterPackId::kPage) {
+-    return l10n_util::GetStringUTF16(IDS_STARTER_PACK_PAGE_KEYWORD_TEXT);
+-  } else if (type() == TemplateURL::OMNIBOX_API_EXTENSION) {
+-    return short_name;
+   }
+-  return l10n_util::GetStringFUTF16(IDS_OMNIBOX_KEYWORD_TEXT_MD, short_name);
++
++  return short_name;
+ }


### PR DESCRIPTION
accidentally broke this in #1027, caused by [7544039](https://chromium-review.googlesource.com/c/chromium/src/+/7544039)

before:
<img width="228" height="88" alt="image" src="https://github.com/user-attachments/assets/62046efb-d72d-4a89-880b-e2bdb32f3ee7" />

after:
<img width="206" height="82" alt="image" src="https://github.com/user-attachments/assets/c95eb45b-27b8-450a-b4af-bb885f4a2aa5" />

(accidentally merged #1056 into dead branch)