### PR TITLE
helium/ui/layout: remove experimental label from vertical layout

### DIFF
--- a/patches/helium/ui/layout/context-menu.patch
+++ b/patches/helium/ui/layout/context-menu.patch
@@ -40,7 +40,7 @@
 +            Compact
 +          </message>
 +          <message name="IDS_BROWSER_LAYOUT_VERTICAL" desc="In Title Case: Option for vertical layout.">
-+            Vertical (Experimental)
++            Vertical
 +          </message>
 +          <message name="IDS_BROWSER_LAYOUT_VERTICAL_RIGHT" desc="In Title Case: Option to move vertical tabs to the right side.">
 +            Tabs on Right Side
@@ -57,7 +57,7 @@
 +            Compact
 +          </message>
 +          <message name="IDS_BROWSER_LAYOUT_VERTICAL" desc="Option for vertical layout.">
-+            Vertical (experimental)
++            Vertical
 +          </message>
 +          <message name="IDS_BROWSER_LAYOUT_VERTICAL_RIGHT" desc="Option to move vertical tabs to the right side.">
 +            Tabs on right side

--- a/patches/helium/ui/layout/settings.patch
+++ b/patches/helium/ui/layout/settings.patch
@@ -38,7 +38,7 @@
 +    Compact
 +  </message>
 +  <message name="IDS_SETTINGS_BROWSER_LAYOUT_VERTICAL" desc="Vertical option in the browser layout dropdown.">
-+    Vertical (experimental)
++    Vertical
 +  </message>
 +  <message name="IDS_SETTINGS_TAB_STRIP_RIGHT_ALIGN" desc="Label for the toggle that displays vertical tabs on the right side of the browser window.">
 +    Show vertical tabs on right side


### PR DESCRIPTION
they're stable and have been (more or less) since first release, i was just being extra cautious