### PR TITLE
[LLM Slop] helium/ui/layout: add New Tab Group to sidebar context menu

### DIFF
--- a/patches/helium/ui/layout/context-menu.patch
+++ b/patches/helium/ui/layout/context-menu.patch
@@ -23,7 +23,7 @@
  #define IDC_ADD_NEW_TAB_TO_GROUP      34100
 --- a/chrome/app/generated_resources.grd
 +++ b/chrome/app/generated_resources.grd
-@@ -10444,6 +10444,45 @@ Keep your key file in a safe place. You
+@@ -10444,6 +10444,61 @@ Keep your key file in a safe place. You
          Create split view
        </message>
  
@@ -65,6 +65,21 @@
 +        </else>
 +      </if>
 +      <!-- /Helium Browser Layout Strings -->
++
++      <!-- Helium New Tab Group String -->
++      <if expr="use_titlecase">
++        <then>
++          <message name="IDS_NEW_TAB_GROUP_HELIUM" desc="In Title Case: Menu item to create a new tab group with the current tab.">
++            New Tab Group
++          </message>
++        </then>
++        <else>
++          <message name="IDS_NEW_TAB_GROUP_HELIUM" desc="Menu item to create a new tab group with the current tab.">
++            New tab group
++          </message>
++        </else>
++      </if>
++      <!-- /Helium New Tab Group String -->
 +
        <!-- Vertical Tab Strings -->
        <if expr="use_titlecase">
@@ -143,7 +158,7 @@
  
  #if BUILDFLAG(IS_CHROMEOS)
      case IDC_TAKE_SCREENSHOT:
-@@ -1514,6 +1526,14 @@ void BrowserCommandController::InitComma
+@@ -1514,6 +1526,15 @@ void BrowserCommandController::InitComma
    command_updater_.UpdateCommandEnabled(IDC_SHOW_SEARCH_TOOLS, true);
    command_updater_.UpdateCommandEnabled(IDC_SHOW_AI_MODE_OMNIBOX_BUTTON, true);
  
@@ -154,6 +169,7 @@
 +  command_updater_.UpdateCommandEnabled(IDC_BROWSER_LAYOUT_VERTICAL, true);
 +  command_updater_.UpdateCommandEnabled(IDC_BROWSER_LAYOUT_VERTICAL_RIGHT,
 +                                        true);
++  command_updater_.UpdateCommandEnabled(IDC_ADD_NEW_TAB_TO_GROUP, true);
 +
    // Window management commands
    command_updater_.UpdateCommandEnabled(IDC_CLOSE_WINDOW, true);
@@ -188,10 +204,13 @@
  SystemMenuModelBuilder::SystemMenuModelBuilder(
      ui::AcceleratorProvider* provider,
      Browser* browser)
-@@ -107,6 +103,25 @@ void SystemMenuModelBuilder::BuildSystem
+@@ -107,6 +103,28 @@ void SystemMenuModelBuilder::BuildSystem
  
    if (!browser()->profile()->IsOffTheRecord()) {
      model->AddSeparator(ui::NORMAL_SEPARATOR);
++    model->AddItemWithStringId(IDC_ADD_NEW_TAB_TO_GROUP,
++                               IDS_NEW_TAB_GROUP_HELIUM);
++    model->AddSeparator(ui::NORMAL_SEPARATOR);
 +
 +    browser_layout_menu_contents_ =
 +        std::make_unique<ui::SimpleMenuModel>(&menu_delegate_);


### PR DESCRIPTION
Right-clicking the sidebar has no shortcut for creating a tab group — you have to go through Settings → Tab Groups → New Tab Group, which is a few too many clicks for something you might do often.

This adds "New Tab Group" directly to the sidebar context menu. It uses the existing `IDC_ADD_NEW_TAB_TO_GROUP` command, so the active tab gets grouped immediately. The item sits between "Name Window..." and "Browser Layout" with its own separator.

## Changes

- New string resource `IDS_NEW_TAB_GROUP_HELIUM` in `generated_resources.grd`
- Menu item added to `system_menu_model_builder.cc` in the non-incognito section
- `IDC_ADD_NEW_TAB_TO_GROUP` explicitly enabled in `InitCommandState`

## Result

```
New Tab
Reopen Closed Group
Bookmark All Tabs...
Name Window...
───────────────
New Tab Group        ← new
───────────────
Browser Layout    ▶
Customize Helium
───────────────
Task Manager
```