### PR TITLE
helium/ui: add support for custom profile avatars

### DIFF
--- a/i18n/source.gen.json
+++ b/i18n/source.gen.json
@@ -342,6 +342,36 @@
     "message": "Add as default"
   },
   {
+    "name": "IDS_SETTINGS_CHOOSE_CUSTOM_AVATAR_FILE",
+    "source": "chrome/app/settings_strings.grdp",
+    "context": "Label for the button that opens the file picker to select a custom avatar image.",
+    "message": "Choose file"
+  },
+  {
+    "name": "IDS_SETTINGS_CLEAR_CUSTOM_AVATAR_DIALOG_TITLE",
+    "source": "chrome/app/settings_strings.grdp",
+    "context": "Title of the confirmation dialog when a user selects to clear custom avatar.",
+    "message": "Clear custom avatar?"
+  },
+  {
+    "name": "IDS_SETTINGS_CUSTOM_AVATAR_FILE_TOO_LARGE",
+    "source": "chrome/app/settings_strings.grdp",
+    "context": "Label for error toast show when selected avatar file is too large (> 30MB).",
+    "message": "Selected file is too large. Please select a file smaller than 30MB."
+  },
+  {
+    "name": "IDS_SETTINGS_CUSTOM_AVATAR_ERROR",
+    "source": "chrome/app/settings_strings.grdp",
+    "context": "Toast shown when a custom avatar image could not be decoded.",
+    "message": "Image could not be loaded"
+  },
+  {
+    "name": "IDS_SETTINGS_CUSTOM_AVATAR_LABEL",
+    "source": "chrome/app/settings_strings.grdp",
+    "context": "The text on the custom avatar photo of the user.",
+    "message": "Custom Avatar"
+  },
+  {
     "name": "IDS_POLICY_SOURCE_HOP",
     "source": "components/policy_strings.grdp",
     "context": "Indicates that the policy originates from Helium defaults.",

--- a/patches/helium/core/custom-profile-avatar.patch
+++ b/patches/helium/core/custom-profile-avatar.patch
@@ -1,0 +1,510 @@
+--- a/chrome/browser/profiles/profile_avatar_icon_util.cc
++++ b/chrome/browser/profiles/profile_avatar_icon_util.cc
+@@ -451,6 +451,8 @@ constexpr std::string_view kDefaultUrlPr
+     "chrome://theme/IDR_PROFILE_AVATAR_";
+ constexpr base::FilePath::CharType kGAIAPictureFileName[] =
+     FILE_PATH_LITERAL("Google Profile Picture.png");
++constexpr base::FilePath::CharType kCustomAvatarPictureFileName[] =
++    FILE_PATH_LITERAL("Custom Avatar Picture.png");
+ constexpr base::FilePath::CharType kHighResAvatarFolderName[] =
+     FILE_PATH_LITERAL("Avatars");
+ 
+@@ -811,19 +813,17 @@ gfx::Image GetPlaceholderAvatarIconWithC
+     SkColor fill_color,
+     SkColor stroke_color,
+     int size,
+-    const PlaceholderAvatarIconParams& icon_params) {
++    const PlaceholderAvatarIconParams& icon_params,
++    const gfx::VectorIcon& icon) {
+   // If the icon should be an outline icon visible against the background, use
+   // `GetPlaceholderAvatarIconVisibleAgainstBackground()` instead.
+   CHECK(!icon_params.visibility_against_background.has_value());
+ 
+-  const gfx::VectorIcon& person_icon =
+-      vector_icons::kAccountCircleChromeRefreshIcon;
+-
+   const gfx::ImageSkia avatar_icon_without_background =
+       icon_params.has_padding
+-          ? CreatePaddedIcon(person_icon, size, stroke_color, 0.5f)
++          ? CreatePaddedIcon(icon, size, stroke_color, 0.5f)
+           : gfx::CreateVectorIcon(
+-                gfx::IconDescription(person_icon, size, stroke_color));
++                gfx::IconDescription(icon, size, stroke_color));
+ 
+   if (icon_params.has_background) {
+     return gfx::Image(
+@@ -891,13 +891,17 @@ base::DictValue GetAvatarIconAndLabelDic
+                                           const std::u16string& label,
+                                           size_t index,
+                                           bool selected,
+-                                          bool is_gaia_avatar) {
++                                          bool is_gaia_avatar,
++                                          bool is_custom_avatar,
++                                          bool is_placeholder) {
+   base::DictValue avatar_info;
+   avatar_info.Set("url", url);
+   avatar_info.Set("label", label);
+   avatar_info.Set("index", static_cast<int>(index));
+   avatar_info.Set("selected", selected);
+   avatar_info.Set("isGaiaAvatar", is_gaia_avatar);
++  avatar_info.Set("isCustomAvatar", is_custom_avatar);
++  avatar_info.Set("isPlaceholder", is_placeholder);
+   return avatar_info;
+ }
+ 
+@@ -905,13 +909,32 @@ base::DictValue GetDefaultProfileAvatarI
+                                                     SkColor stroke_color,
+                                                     bool selected) {
+   gfx::Image icon = profiles::GetPlaceholderAvatarIconWithColors(
+-      fill_color, stroke_color, kAvatarIconSize);
++      fill_color,
++      stroke_color,
++      kAvatarIconSize);
+   size_t index = profiles::GetPlaceholderAvatarIndex();
+   return GetAvatarIconAndLabelDict(
+       webui::GetBitmapDataUrl(icon.AsBitmap()),
+       l10n_util::GetStringUTF16(
+           profiles::GetDefaultAvatarLabelResourceIDAtIndex(index)),
+-      index, selected, /*is_gaia_avatar=*/false);
++      index, selected, /*is_gaia_avatar=*/false, /*is_custom_avatar=*/false,
++      /*is_placeholder=*/false);
++}
++
++base::DictValue GetPlaceholderCustomAvatarIconAndLabel(int index,
++                                                       SkColor fill_color,
++                                                       SkColor stroke_color) {
++  gfx::Image icon = profiles::GetPlaceholderAvatarIconWithColors(
++      fill_color,
++      stroke_color,
++      kAvatarIconSize,
++      /*icon_params=*/{},
++      kSavePageIcon);
++  return GetAvatarIconAndLabelDict(
++      webui::GetBitmapDataUrl(icon.AsBitmap()),
++      l10n_util::GetStringUTF16(IDS_SETTINGS_CHOOSE_CUSTOM_AVATAR_FILE), index,
++      false, /*is_gaia_avatar=*/false, /*is_custom_avatar=*/true,
++      /*is_placeholder=*/true);
+ }
+ 
+ base::ListValue GetCustomProfileAvatarIconsAndLabels(
+@@ -924,7 +947,8 @@ base::ListValue GetCustomProfileAvatarIc
+         profiles::GetDefaultAvatarIconUrl(i),
+         l10n_util::GetStringUTF16(
+             profiles::GetDefaultAvatarLabelResourceIDAtIndex(i)),
+-        i, i == selected_avatar_idx, /*is_gaia_avatar=*/false));
++        i, i == selected_avatar_idx, /*is_gaia_avatar=*/false,
++        /*is_custom_avatar=*/false, /*is_placeholder=*/false));
+   }
+   return avatars;
+ }
+@@ -957,13 +981,33 @@ base::ListValue GetIconsAndLabelsForProf
+   DCHECK(entry);
+ 
+   bool using_gaia = entry->IsUsingGAIAPicture();
+-  size_t selected_avatar_idx =
+-      using_gaia ? SIZE_MAX : entry->GetAvatarIconIndex();
++  bool using_custom_avatar = entry->IsUsingCustomAvatar();
++  size_t selected_avatar_idx = using_gaia || using_custom_avatar
++                                   ? SIZE_MAX
++                                   : entry->GetAvatarIconIndex();
+ 
+   // Obtain a list of the modern avatar icons.
+   base::ListValue avatars(
+       GetCustomProfileAvatarIconsAndLabels(selected_avatar_idx));
+ 
++  if (const auto* custom_icon = entry->GetCustomAvatarPicture()) {
++    gfx::Image avatar_icon = GetAvatarIconForWebUI(*custom_icon);
++    auto custom_avatar_info = GetAvatarIconAndLabelDict(
++        /*url=*/webui::GetBitmapDataUrl(avatar_icon.AsBitmap()),
++        /*label=*/
++        l10n_util::GetStringUTF16(IDS_SETTINGS_CUSTOM_AVATAR_LABEL),
++        /*index=*/0, using_custom_avatar, /*is_gaia_avatar=*/false,
++        /*is_custom_avatar=*/true, /*is_placeholder =*/false);
++    avatars.Insert(avatars.begin(), base::Value(std::move(custom_avatar_info)));
++  } else {
++    ProfileThemeColors colors = entry->GetProfileThemeColors();
++    auto generic_avatar_info = GetPlaceholderCustomAvatarIconAndLabel(
++        /*index=*/1, colors.default_avatar_fill_color,
++        colors.default_avatar_stroke_color);
++    avatars.Insert(avatars.begin(),
++                   base::Value(std::move(generic_avatar_info)));
++  }
++
+   if (entry->GetSigninState() == SigninState::kNotSignedIn) {
+     ProfileThemeColors colors = entry->GetProfileThemeColors();
+     auto generic_avatar_info = GetDefaultProfileAvatarIconAndLabel(
+@@ -982,7 +1026,8 @@ base::ListValue GetIconsAndLabelsForProf
+         /*url=*/webui::GetBitmapDataUrl(avatar_icon.AsBitmap()),
+         /*label=*/
+         l10n_util::GetStringUTF16(IDS_SETTINGS_CHANGE_PICTURE_PROFILE_PHOTO),
+-        /*index=*/0, using_gaia, /*is_gaia_avatar=*/true);
++        /*index=*/0, using_gaia, /*is_gaia_avatar=*/true,
++        /*is_custom_avatar=*/false, /*is_placeholder=*/false);
+     avatars.Insert(avatars.begin(), base::Value(std::move(gaia_picture_info)));
+   }
+ 
+@@ -998,6 +1043,7 @@ void SetDefaultProfileAvatarIndex(Profil
+   pref_service->SetBoolean(prefs::kProfileUsingDefaultAvatar,
+                            avatar_icon_index == GetPlaceholderAvatarIndex());
+   pref_service->SetBoolean(prefs::kProfileUsingGAIAAvatar, false);
++  pref_service->SetBoolean(prefs::kProfileUsingCustomAvatar, false);
+ 
+   ProfileMetrics::LogProfileAvatarSelection(avatar_icon_index);
+ }
+--- a/chrome/browser/profiles/profile_attributes_entry.cc
++++ b/chrome/browser/profiles/profile_attributes_entry.cc
+@@ -69,6 +69,8 @@ const char kUserAcceptedAccountManagemen
+ const char kLastDownloadedGAIAPictureUrlWithSizeKey[] =
+     "last_downloaded_gaia_picture_url_with_size";
+ const char kGAIAPictureFileNameKey[] = "gaia_picture_file_name";
++const char kCustomAvatarPictureFileNameKey[] =
++    "custom_avatar_picture_file_name";
+ 
+ // Profile colors info.
+ const char kProfileHighlightColorKey[] = "profile_highlight_color";
+@@ -117,6 +119,8 @@ const char ProfileAttributesEntry::kIsUs
+     "is_using_default_name";
+ const char ProfileAttributesEntry::kIsUsingDefaultAvatarKey[] =
+     "is_using_default_avatar";
++const char ProfileAttributesEntry::kIsUsingCustomAvatarKey[] =
++    "is_using_custom_avatar";
+ const char ProfileAttributesEntry::kUseGAIAPictureKey[] = "use_gaia_picture";
+ const char ProfileAttributesEntry::kAccountIdKey[] = "account_id_key";
+ const char ProfileAttributesEntry::kIsGlicEligible[] = "is_glic_eligible";
+@@ -282,7 +286,7 @@ bool ProfileAttributesEntry::ShouldUpdat
+     // Updating from an empty image to a null image is a no-op and it is
+     // important to avoid firing |OnProfileAvatarChanged| in this case.
+     // See http://crbug.com/41423540
+-    DCHECK(!IsGAIAPictureLoaded());
++    // DCHECK(!IsGAIAPictureLoaded());
+     return false;
+   }
+ 
+@@ -302,6 +306,26 @@ bool ProfileAttributesEntry::ShouldUpdat
+   return IsUsingDefaultAvatar() || IsUsingGAIAPicture();
+ }
+ 
++bool ProfileAttributesEntry::ShouldUpdateCustomAvatarPicture(
++    bool image_is_empty) const {
++  std::string old_file_name = GetString(kCustomAvatarPictureFileNameKey);
++
++  if (old_file_name.empty() && image_is_empty) {
++    // On Windows, Taskbar and Desktop icons are refreshed every time
++    // |OnProfileAvatarChanged| notification is fired.
++    // Updating from an empty image to a null image is a no-op and it is
++    // important to avoid firing |OnProfileAvatarChanged| in this case.
++    // See http://crbug.com/900374
++    return false;
++  }
++
++  if (old_file_name.empty() || image_is_empty) {
++    return true;
++  }
++
++  return IsUsingDefaultAvatar() || IsUsingCustomAvatar();
++}
++
+ std::u16string ProfileAttributesEntry::GetLastNameToDisplay() const {
+   return last_name_to_display_;
+ }
+@@ -369,7 +393,12 @@ ProfileAttributesEntry::GetAvatarIconWit
+     int size_for_placeholder_avatar,
+     bool use_high_res_file,
+     const PlaceholderAvatarIconParams& icon_params) const {
+-  if (IsUsingGAIAPicture()) {
++
++  if (IsUsingCustomAvatar()) {
++    if (const gfx::Image* image = GetCustomAvatarPicture()) {
++      return {*image, AvatarIconType::kNonPlaceholder};
++    }
++  } else if (IsUsingGAIAPicture()) {
+     // The picture may be null if it has not finished downloading yet; in that
+     // case fall through to return the avatar-index-based icon below.
+     if (const gfx::Image* image = GetGAIAPicture()) {
+@@ -444,6 +473,19 @@ const gfx::Image* ProfileAttributesEntry
+       profile_path_, storage_key_, image_path);
+ }
+ 
++const gfx::Image* ProfileAttributesEntry::GetCustomAvatarPicture() const {
++  std::string file_name = GetString(kCustomAvatarPictureFileNameKey);
++
++  // If the picture is not on disk then return nullptr.
++  if (file_name.empty()) {
++    return nullptr;
++  }
++
++  base::FilePath image_path = profile_path_.AppendASCII(file_name);
++  return profile_attributes_storage_->LoadAvatarPictureFromPath(
++      profile_path_, storage_key_, image_path);
++}
++
+ bool ProfileAttributesEntry::IsUsingGAIAPicture() const {
+   bool result = GetBool(kUseGAIAPictureKey);
+   if (!result) {
+@@ -516,6 +558,10 @@ bool ProfileAttributesEntry::IsUsingDefa
+   return GetBool(kIsUsingDefaultAvatarKey);
+ }
+ 
++bool ProfileAttributesEntry::IsUsingCustomAvatar() const {
++  return GetBool(kIsUsingCustomAvatarKey);
++}
++
+ bool ProfileAttributesEntry::IsSignedInWithCredentialProvider() const {
+   return false;
+ }
+@@ -740,6 +786,39 @@ void ProfileAttributesEntry::SetIsUsingG
+   }
+ }
+ 
++void ProfileAttributesEntry::SetCustomAvatarPicture(gfx::Image image) {
++  std::string old_file_name = GetString(kCustomAvatarPictureFileNameKey);
++  std::string new_file_name;
++
++  if (!ShouldUpdateCustomAvatarPicture(image.IsEmpty())) {
++    return;
++  }
++
++  DCHECK(!image.IsEmpty() || !old_file_name.empty())
++      << "Trying to set an empty custom avatar picture when there is no "
++         "existing custom avatar picture.";
++
++  if (!image.IsEmpty()) {
++    // Save the new bitmap to disk.
++    new_file_name = old_file_name.empty()
++                        ? base::FilePath(profiles::kCustomAvatarPictureFileName)
++                              .MaybeAsASCII()
++                        : old_file_name;
++    base::FilePath image_path = profile_path_.AppendASCII(new_file_name);
++    profile_attributes_storage_->SaveCustomAvatarImageAtPath(
++        profile_path_, storage_key_, image, image_path);
++  }
++
++  SetString(kCustomAvatarPictureFileNameKey, new_file_name);
++  profile_attributes_storage_->NotifyOnProfileAvatarChanged(profile_path_);
++}
++
++void ProfileAttributesEntry::SetIsUsingCustomAvatar(bool value) {
++  if (SetBool(kIsUsingCustomAvatarKey, value)) {
++    profile_attributes_storage_->NotifyOnProfileAvatarChanged(profile_path_);
++  }
++}
++
+ void ProfileAttributesEntry::SetLastDownloadedGAIAPictureUrlWithSize(
+     const std::string& image_url_with_size) {
+   SetString(kLastDownloadedGAIAPictureUrlWithSizeKey, image_url_with_size);
+@@ -897,6 +976,21 @@ void ProfileAttributesEntry::SetAuthInfo
+   profile_attributes_storage_->NotifyProfileAuthInfoChanged(profile_path_);
+ }
+ 
++void ProfileAttributesEntry::ClearCustomAvatar() {
++  std::string file_name = GetString(kCustomAvatarPictureFileNameKey);
++
++  if (!file_name.empty()) {
++    // Delete the old bitmap from disk.
++    base::FilePath image_path = profile_path_.AppendASCII(file_name);
++    profile_attributes_storage_->DeleteCustomAvatarImageAtPath(
++        profile_path_, storage_key_, image_path);
++  }
++
++  ClearValue(kCustomAvatarPictureFileNameKey);
++  SetBool(kIsUsingCustomAvatarKey, false);
++  profile_attributes_storage_->NotifyOnProfileAvatarChanged(profile_path_);
++}
++
+ const gfx::Image* ProfileAttributesEntry::GetHighResAvatar() const {
+   const size_t avatar_index = GetAvatarIconIndex();
+ 
+--- a/chrome/browser/profiles/profile_attributes_entry.h
++++ b/chrome/browser/profiles/profile_attributes_entry.h
+@@ -160,6 +160,9 @@ class ProfileAttributesEntry {
+   // if the profile does not have a GAIA picture or if the picture must be
+   // loaded from disk.
+   const gfx::Image* GetGAIAPicture() const;
++  // Return the custom avatar picture for the given profile. This may return
++  // NULL if the profile does not have a custom avatar picture
++  const gfx::Image* GetCustomAvatarPicture() const;
+   // Returns true if the profile displays a GAIA picture instead of one of the
+   // locally bundled icons.
+   bool IsUsingGAIAPicture() const;
+@@ -193,6 +196,9 @@ class ProfileAttributesEntry {
+   // Returns true if the Profile is using the default avatar, which is one of
+   // the profile icons selectable at profile creation.
+   bool IsUsingDefaultAvatar() const;
++  // Returns true if the Profile is using a custom avatar, which is an avatar
++  // that the user has selected from the file system.
++  bool IsUsingCustomAvatar() const;
+   // Indicates that profile was signed in through native OS credential provider.
+   bool IsSignedInWithCredentialProvider() const;
+   // Returns true if the profile is managed by a third party identity that is
+@@ -252,6 +258,7 @@ class ProfileAttributesEntry {
+   void SetGAIAName(const std::u16string& name);
+   void SetGAIAGivenName(const std::u16string& name);
+   void SetGAIAPicture(const std::string& image_url_with_size, gfx::Image image);
++  void SetCustomAvatarPicture(gfx::Image image);
+   void SetIsUsingGAIAPicture(bool value);
+   void SetLastDownloadedGAIAPictureUrlWithSize(
+       const std::string& image_url_with_size);
+@@ -264,6 +271,7 @@ class ProfileAttributesEntry {
+   void SetUserAcceptedAccountManagement(bool value);
+   bool UserAcceptedAccountManagement() const;
+   void SetIsUsingDefaultAvatar(bool value);
++  void SetIsUsingCustomAvatar(bool value);
+   void SetAvatarIconIndex(size_t icon_index);
+   // std::nullopt resets colors to default.
+   void SetProfileThemeColors(const std::optional<ProfileThemeColors>& colors);
+@@ -285,6 +293,9 @@ class ProfileAttributesEntry {
+ 
+   void SetIsGlicEligible(bool value);
+ 
++  // Clears the custom avatar of the profile, if it exists.
++  void ClearCustomAvatar();
++
+   // Lock/Unlock the profile, should be called only if force-sign-in is enabled.
+   void LockForceSigninProfile(bool is_lock);
+ 
+@@ -299,6 +310,7 @@ class ProfileAttributesEntry {
+   static const char kEnterpriseLabelKey[];
+   static const char kIsUsingDefaultNameKey[];
+   static const char kIsUsingDefaultAvatarKey[];
++  static const char kIsUsingCustomAvatarKey[];
+   static const char kUseGAIAPictureKey[];
+   static const char kAccountIdKey[];
+   static const char kIsGlicEligible[];
+@@ -338,6 +350,11 @@ class ProfileAttributesEntry {
+   bool ShouldUpdateGAIAPicture(const std::string& image_url_with_size,
+                                bool image_is_empty) const;
+ 
++  // Returns true if the current custom avatar picture should be updated
++  // with an image having provided parameters. `image_is_empty` is true
++  // when attempting to clear the current custom avatar picture.
++  bool ShouldUpdateCustomAvatarPicture(bool image_is_empty) const;
++
+   // Loads or uses an already loaded high resolution image of the generic
+   // profile avatar.
+   const gfx::Image* GetHighResAvatar() const;
+--- a/chrome/browser/profiles/profile_avatar_icon_util.h
++++ b/chrome/browser/profiles/profile_avatar_icon_util.h
+@@ -14,6 +14,7 @@
+ #include "base/files/file_path.h"
+ #include "base/values.h"
+ #include "build/build_config.h"
++#include "components/vector_icons/vector_icons.h"
+ #include "third_party/abseil-cpp/absl/container/flat_hash_set.h"
+ #include "third_party/skia/include/core/SkColor.h"
+ #include "ui/base/models/image_model.h"
+@@ -70,6 +71,7 @@ inline constexpr int kProfileAvatarBadge
+ // Avatar access.
+ extern const base::FilePath::CharType kGAIAPictureFileName[];
+ extern const base::FilePath::CharType kHighResAvatarFolderName[];
++extern const base::FilePath::CharType kCustomAvatarPictureFileName[];
+ 
+ // Avatar formatting.
+ extern const int kAvatarIconSize;
+@@ -169,7 +171,8 @@ gfx::Image GetPlaceholderAvatarIconWithC
+     SkColor fill_color,
+     SkColor stroke_color,
+     int size,
+-    const PlaceholderAvatarIconParams& icon_params = {});
++    const PlaceholderAvatarIconParams& icon_params = {},
++    const gfx::VectorIcon& icon = vector_icons::kAccountCircleChromeRefreshIcon);
+ 
+ // Gets the resource ID of the default avatar icon at |index|.
+ int GetDefaultAvatarIconResourceIDAtIndex(size_t index);
+@@ -205,7 +208,9 @@ base::DictValue GetAvatarIconAndLabelDic
+                                           const std::u16string& label,
+                                           size_t index,
+                                           bool selected,
+-                                          bool is_gaia_avatar);
++                                          bool is_gaia_avatar,
++                                          bool is_custom_avatar,
++                                          bool is_placeholder);
+ 
+ // Returns dictionary containing the default generic avatar icon, label, index
+ // and selected state.
+--- a/chrome/browser/profiles/profile_attributes_storage.cc
++++ b/chrome/browser/profiles/profile_attributes_storage.cc
+@@ -784,6 +784,24 @@ void ProfileAttributesStorage::DeleteGAI
+   entry->SetLastDownloadedGAIAPictureUrlWithSize(std::string());
+ }
+ 
++void ProfileAttributesStorage::SaveCustomAvatarImageAtPath(
++    const base::FilePath& profile_path,
++    const std::string& key,
++    gfx::Image image,
++    const base::FilePath& image_path) {
++  cached_avatar_images_.erase(key);
++  SaveAvatarImageAtPathNoCallback(profile_path, image, key, image_path);
++}
++
++void ProfileAttributesStorage::DeleteCustomAvatarImageAtPath(
++    const base::FilePath& profile_path,
++    const std::string& key,
++    const base::FilePath& image_path) {
++  cached_avatar_images_.erase(key);
++  file_task_runner_->PostTask(FROM_HERE,
++                              base::BindOnce(&DeleteBitmap, image_path));
++}
++
+ void ProfileAttributesStorage::AddObserver(Observer* obs) {
+   observer_list_.AddObserver(obs);
+ }
+--- a/chrome/browser/profiles/profile_attributes_storage.h
++++ b/chrome/browser/profiles/profile_attributes_storage.h
+@@ -163,6 +163,16 @@ class ProfileAttributesStorage {
+                              const std::string& key,
+                              const base::FilePath& image_path);
+ 
++  // Saves the CustomAvatar `image` at `image_path`.
++  void SaveCustomAvatarImageAtPath(const base::FilePath& profile_path,
++                                   const std::string& key,
++                                   gfx::Image image,
++                                   const base::FilePath& image_path);
++  // Deletes a CustomAvatar picture at `image_path`.
++  void DeleteCustomAvatarImageAtPath(const base::FilePath& profile_path,
++                                     const std::string& key,
++                                     const base::FilePath& image_path);
++
+   // Checks whether the high res avatar at index |icon_index| exists, and if it
+   // does not, calls |DownloadHighResAvatar|.
+   void DownloadHighResAvatarIfNeeded(size_t icon_index,
+--- a/chrome/browser/profiles/profile_impl.cc
++++ b/chrome/browser/profiles/profile_impl.cc
+@@ -389,6 +389,7 @@ void ProfileImpl::RegisterProfilePrefs(
+   // (i.e. was assigned by default by legacy profile creation).
+   registry->RegisterBooleanPref(prefs::kProfileUsingDefaultAvatar, true);
+   registry->RegisterBooleanPref(prefs::kProfileUsingGAIAAvatar, false);
++  registry->RegisterBooleanPref(prefs::kProfileUsingCustomAvatar, false);
+   // Whether a profile is using a default avatar name (eg. Pickles or Person 1).
+   registry->RegisterBooleanPref(prefs::kProfileUsingDefaultName, true);
+   registry->RegisterStringPref(prefs::kProfileName, std::string());
+@@ -701,6 +702,10 @@ void ProfileImpl::DoFinalInit(CreateMode
+       prefs::kProfileUsingGAIAAvatar,
+       base::BindRepeating(&ProfileImpl::UpdateAvatarInStorage,
+                           base::Unretained(this)));
++  pref_change_registrar_.Add(
++      prefs::kProfileUsingCustomAvatar,
++      base::BindRepeating(&ProfileImpl::UpdateAvatarInStorage,
++                          base::Unretained(this)));
+ 
+   // Changes in the profile name.
+   pref_change_registrar_.Add(
+@@ -1625,6 +1630,8 @@ void ProfileImpl::UpdateAvatarInStorage(
+         GetPrefs()->GetBoolean(prefs::kProfileUsingDefaultAvatar));
+     entry->SetIsUsingGAIAPicture(
+         GetPrefs()->GetBoolean(prefs::kProfileUsingGAIAAvatar));
++    entry->SetIsUsingCustomAvatar(
++        GetPrefs()->GetBoolean(prefs::kProfileUsingCustomAvatar));
+   }
+ }
+ 
+--- a/chrome/common/pref_names.h
++++ b/chrome/common/pref_names.h
+@@ -1556,6 +1556,8 @@ inline constexpr char kProfileUsingDefau
+ inline constexpr char kProfileUsingDefaultAvatar[] =
+     "profile.using_default_avatar";
+ inline constexpr char kProfileUsingGAIAAvatar[] = "profile.using_gaia_avatar";
++inline constexpr char kProfileUsingCustomAvatar[] =
++    "profile.using_custom_avatar";
+ 
+ // Indicates if we've already shown a notification that high contrast
+ // mode is on, recommending high-contrast extensions and themes.

--- a/patches/helium/settings/custom-profile-avatar-ui.patch
+++ b/patches/helium/settings/custom-profile-avatar-ui.patch
@@ -1,0 +1,588 @@
+--- a/chrome/app/settings_strings.grdp
++++ b/chrome/app/settings_strings.grdp
+@@ -3989,6 +3989,21 @@
+     <message name="IDS_SETTINGS_PICK_AN_AVATAR" desc="Title of the edit avatar selection section on the manage profile page.">
+       Pick an avatar
+     </message>
++    <message name="IDS_SETTINGS_CHOOSE_CUSTOM_AVATAR_FILE" desc="Label for the button that opens the file picker to select a custom avatar image.">
++      Choose file
++    </message>
++    <message name="IDS_SETTINGS_CLEAR_CUSTOM_AVATAR_DIALOG_TITLE" desc="Title of the confirmation dialog when a user selects to clear custom avatar.">
++      Clear custom avatar?
++    </message>
++    <message name="IDS_SETTINGS_CUSTOM_AVATAR_FILE_TOO_LARGE" desc="Label for error toast show when selected avatar file is too large (> 30MB).">
++      Selected file is too large. Please select a file smaller than 30MB.
++    </message>
++    <message name="IDS_SETTINGS_CUSTOM_AVATAR_ERROR" desc="Toast shown when a custom avatar image could not be decoded.">
++      Image could not be loaded
++    </message>
++    <message name="IDS_SETTINGS_CUSTOM_AVATAR_LABEL" desc="The text on the custom avatar photo of the user.">
++      Custom Avatar
++    </message>
+     <message name="IDS_SETTINGS_CREATE_SHORTCUT" desc="Title of create shortcut section on the manage profile page.">
+       Create desktop shortcut
+     </message>
+--- a/chrome/browser/resources/settings/people_page/manage_profile.html
++++ b/chrome/browser/resources/settings/people_page/manage_profile.html
+@@ -45,6 +45,10 @@
+     display: inline-block;
+   }
+ 
++  #clearFileButton {
++    margin-left: 0.5rem;
++  }
++
+   #profileAvatarSelector {
+     --avatar-size: var(--icon-size);
+     --avatar-spacing: var(--icon-grid-gap);
+@@ -99,6 +103,37 @@
+ </div>
+ <div class="cr-row manage-profile-section">
+   <h1 class="cr-title-text">$i18n{pickAvatar}</h1>
++  <div class="content">
++    <cr-dialog duration="5000" id="fileTooLargeDialog">
++      <div slot="title">$i18n{customAvatarFileTooLarge}</div>
++      <div slot="button-container">
++        <cr-button class="action-button" on-click="onCloseFileTooLargeDialog_">
++          $i18n{ok}
++        </cr-button>
++      </div>
++    </cr-dialog>
++    <cr-dialog duration="5000" id="avatarErrorDialog">
++      <div slot="title">$i18n{customAvatarError}</div>
++      <div slot="button-container">
++        <cr-button class="action-button" on-click="onCloseAvatarErrorDialog_">
++          $i18n{ok}
++        </cr-button>
++      </div>
++    </cr-dialog>
++    <cr-dialog id="clearAvatarDialog">
++      <div slot="title">
++        $i18n{clearCustomAvatarTitle}
++      </div>
++      <div slot="button-container">
++        <cr-button class="cancel-button" on-click="onClearAvatarCancel_">
++          $i18n{cancel}
++        </cr-button>
++        <cr-button class="action-button" on-click="onClearCustomAvatar_">
++          $i18n{clearCustomAvatar}
++        </cr-button>
++      </div>
++    </cr-dialog>
++  </div>
+   <div class="content grid-container">
+     <cr-profile-avatar-selector
+         id="profileAvatarSelector" avatars="[[availableIcons]]"
+--- a/chrome/browser/resources/settings/people_page/manage_profile.ts
++++ b/chrome/browser/resources/settings/people_page/manage_profile.ts
+@@ -8,6 +8,8 @@
+  * edit a profile's name, icon, and desktop shortcut.
+  */
+ import 'chrome://resources/cr_components/theme_color_picker/theme_color_picker.js';
++import 'chrome://resources/cr_elements/cr_button/cr_button.js';
++import 'chrome://resources/cr_elements/cr_dialog/cr_dialog.js';
+ import 'chrome://resources/cr_elements/cr_icon/cr_icon.js';
+ import 'chrome://resources/cr_elements/cr_input/cr_input.js';
+ import 'chrome://resources/cr_elements/cr_profile_avatar_selector/cr_profile_avatar_selector.js';
+@@ -19,6 +21,7 @@ import '../settings_shared.css.js';
+ 
+ import type {ProfileInfo} from '/shared/settings/people_page/profile_info_browser_proxy.js';
+ import {ProfileInfoBrowserProxyImpl} from '/shared/settings/people_page/profile_info_browser_proxy.js';
++import {CrDialogElement} from 'chrome://resources/cr_elements/cr_dialog/cr_dialog.js';
+ import type {CrInputElement} from 'chrome://resources/cr_elements/cr_input/cr_input.js';
+ import type {AvatarIcon} from 'chrome://resources/cr_elements/cr_profile_avatar_selector/cr_profile_avatar_selector.js';
+ import {WebUiListenerMixin} from 'chrome://resources/cr_elements/web_ui_listener_mixin.js';
+@@ -40,6 +43,9 @@ const SettingsManageProfileElementBase =
+ export interface SettingsManageProfileElement {
+   $: {
+     nameInput: CrInputElement,
++    fileTooLargeDialog: CrDialogElement,
++    avatarErrorDialog: CrDialogElement,
++    clearAvatarDialog: CrDialogElement,
+   };
+ }
+ 
+@@ -76,6 +82,12 @@ export class SettingsManageProfileElemen
+       hasProfileShortcut_: Boolean,
+ 
+       /**
++       * True if the current profile has a custom avatar. This is used to
++       * determine whether to show the "Clear custom avatar" button.
++       */
++      hasCustomAvatar_: Boolean,
++
++      /**
+        * The available icons for selection.
+        */
+       availableIcons: {
+@@ -115,6 +127,7 @@ export class SettingsManageProfileElemen
+   declare private profileName_: string;
+   declare private hasProfileShortcut_: boolean;
+   declare availableIcons: AvatarIcon[];
++  declare private hasCustomAvatar_: boolean;
+   declare private isProfileShortcutSettingVisible_: boolean;
+   declare private hasEnterpriseLabel_: boolean;
+   declare private pattern_: string;
+@@ -126,15 +139,29 @@ export class SettingsManageProfileElemen
+ 
+     const setIcons = (icons: AvatarIcon[]) => {
+       this.availableIcons = icons;
++      this.hasCustomAvatar_ = icons.some(icon => icon.isCustomAvatar);
+     };
+ 
+     this.addWebUiListener('available-icons-changed', setIcons);
+     this.browserProxy_.getAvailableIcons().then(setIcons);
+ 
++    this.addWebUiListener(
++        'custom-avatar-error', () => this.$.avatarErrorDialog.showModal());
++
+     ProfileInfoBrowserProxyImpl.getInstance().getProfileInfo().then(
+         this.onProfileInfoChanged_.bind(this));
+     this.addWebUiListener(
+         'profile-info-changed', this.onProfileInfoChanged_.bind(this));
++
++    this.addEventListener(
++        'custom-avatar-requested', (avatarRequestEvent: Event) => {
++          avatarRequestEvent.preventDefault();
++          this.onChooseCustomAvatarFile_();
++        });
++
++    this.addEventListener('custom-avatar-deleted', () => {
++      this.$.clearAvatarDialog.showModal();
++    });
+   }
+ 
+   override currentRouteChanged(newRoute: Route, oldRoute?: Route) {
+@@ -164,6 +191,52 @@ export class SettingsManageProfileElemen
+     this.profileName_ = info.name;
+   }
+ 
++  private onChooseCustomAvatarFile_() {
++    const input = document.createElement('input');
++    input.type = 'file';
++    input.accept = 'image/png,image/jpeg,image/jpg';
++    input.onchange = () => {
++      const file = input.files?.[0];
++      if (!file) {
++        this.$.avatarErrorDialog.showModal();
++        return;
++      }
++      if (file.size > 30 * 1024 * 1024) {
++        // The file is too large. Show an error and return early.
++        this.$.fileTooLargeDialog.showModal();
++        return;
++      }
++      const reader = new FileReader();
++      reader.onload = () => {
++        const dataUrl = reader.result;
++        if (!dataUrl || typeof dataUrl !== 'string') {
++          this.$.avatarErrorDialog.showModal();
++          return;
++        }
++        this.browserProxy_.setCustomAvatarFromFile(dataUrl);
++      };
++      reader.readAsDataURL(file);
++    };
++    input.click();
++  }
++
++  private onClearAvatarCancel_() {
++    this.$.clearAvatarDialog.cancel();
++  }
++
++  private onClearCustomAvatar_() {
++    this.browserProxy_.clearCustomAvatar();
++    this.$.clearAvatarDialog.close();
++  }
++
++  private onCloseAvatarErrorDialog_() {
++    this.$.avatarErrorDialog.close();
++  }
++
++  private onCloseFileTooLargeDialog_() {
++    this.$.fileTooLargeDialog.close();
++  }
++
+   /**
+    * Handler for when the profile name field is changed, then blurred.
+    */
+@@ -197,6 +270,10 @@ export class SettingsManageProfileElemen
+ 
+     if (this.profileAvatar_.isGaiaAvatar) {
+       this.browserProxy_.setProfileIconToGaiaAvatar();
++    } else if (
++        this.profileAvatar_.isCustomAvatar &&
++        !this.profileAvatar_.isPlaceholder) {
++      this.browserProxy_.setProfileIconToCustomAvatar();
+     } else {
+       this.browserProxy_.setProfileIconToDefaultAvatar(
+           this.profileAvatar_.index);
+--- a/chrome/browser/resources/settings/people_page/manage_profile_browser_proxy.ts
++++ b/chrome/browser/resources/settings/people_page/manage_profile_browser_proxy.ts
+@@ -40,6 +40,22 @@ export interface ManageProfileBrowserPro
+   setProfileIconToDefaultAvatar(index: number): void;
+ 
+   /**
++   * Sets the profile's icon to an already available custom avatar.
++   */
++  setProfileIconToCustomAvatar(): void;
++
++  /**
++   * Sets the profile's icon to a custom avatar from a file.
++   * @param dataUrl The new profile avatar as a data URL.
++   */
++  setCustomAvatarFromFile(dataUrl: string): void;
++
++  /**
++   * Clears the custom avatar of the profile, if it exists.
++   */
++  clearCustomAvatar(): void;
++
++  /**
+    * Sets the profile's name.
+    */
+   setProfileName(name: string): void;
+@@ -74,6 +90,18 @@ export class ManageProfileBrowserProxyIm
+     chrome.send('setProfileIconToDefaultAvatar', [index]);
+   }
+ 
++  setProfileIconToCustomAvatar() {
++    chrome.send('setProfileIconToCustomAvatar');
++  }
++
++  setCustomAvatarFromFile(dataUrl: string) {
++    chrome.send('setCustomAvatarFromFile', [dataUrl]);
++  }
++
++  clearCustomAvatar(): void {
++    chrome.send('clearCustomAvatar');
++  }
++
+   setProfileName(name: string) {
+     chrome.send('setProfileName', [name]);
+   }
+--- a/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
++++ b/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
+@@ -2101,6 +2101,10 @@ void AddPeopleStrings(content::WebUIData
+       {"nameYourProfile", IDS_SETTING_NAME_YOUR_PROFILE},
+       {"pickThemeColor", IDS_SETTINGS_PICK_A_THEME_COLOR},
+       {"pickAvatar", IDS_SETTINGS_PICK_AN_AVATAR},
++      {"clearCustomAvatarTitle", IDS_SETTINGS_CLEAR_CUSTOM_AVATAR_DIALOG_TITLE},
++      {"clearCustomAvatar", IDS_CLEAR},
++      {"customAvatarFileTooLarge", IDS_SETTINGS_CUSTOM_AVATAR_FILE_TOO_LARGE},
++      {"customAvatarError", IDS_SETTINGS_CUSTOM_AVATAR_ERROR},
+       {"createShortcutTitle", IDS_SETTINGS_CREATE_SHORTCUT},
+       {"createShortcutSubtitle", IDS_SETTINGS_CREATE_SHORTCUT_SUBTITLE},
+ 
+--- a/chrome/browser/ui/webui/settings/settings_manage_profile_handler.cc
++++ b/chrome/browser/ui/webui/settings/settings_manage_profile_handler.cc
+@@ -5,13 +5,18 @@
+ #include "chrome/browser/ui/webui/settings/settings_manage_profile_handler.h"
+ 
+ #include <cstdint>
++#include <optional>
+ #include <utility>
+ 
++#include "base/base64.h"
+ #include "base/functional/bind.h"
+ #include "base/functional/callback_helpers.h"
++#include "base/logging.h"
+ #include "base/strings/string_number_conversions.h"
+ #include "base/strings/string_util.h"
+ #include "base/strings/utf_string_conversions.h"
++#include "base/task/thread_pool.h"
++#include "base/uuid.h"
+ #include "base/values.h"
+ #include "chrome/browser/browser_process.h"
+ #include "chrome/browser/profiles/gaia_info_update_service.h"
+@@ -35,8 +40,15 @@
+ #include "content/public/browser/url_data_source.h"
+ #include "content/public/browser/web_ui.h"
+ #include "google_apis/gaia/gaia_auth_util.h"
++#include "net/base/data_url.h"
++#include "skia/ext/image_operations.h"
+ #include "ui/base/l10n/l10n_util.h"
+ #include "ui/base/webui/web_ui_util.h"
++#include "ui/gfx/codec/jpeg_codec.h"
++#include "ui/gfx/codec/png_codec.h"
++#include "ui/gfx/image/image_skia.h"
++#include "ui/gfx/image/image_skia_operations.h"
++#include "url/gurl.h"
+ 
+ namespace settings {
+ 
+@@ -46,6 +58,47 @@ const char kProfileShortcutSettingHidden
+ const char kProfileShortcutFound[] = "profileShortcutFound";
+ const char kProfileShortcutNotFound[] = "profileShortcutNotFound";
+ 
++std::optional<gfx::Image> DecodeAndCropAvatar(std::string data_url) {
++  std::string charset;
++  std::string mime_part;
++  std::string base64_data;
++  if (!net::DataURL::Parse(GURL(data_url), &mime_part, &charset, &base64_data)) {
++    DLOG(WARNING) << "Failed to parse data URL." << " URL: " << data_url;
++    return {};
++  }
++
++  const auto image_data = base::as_byte_span(base64_data);
++  SkBitmap bitmap;
++  if (mime_part == "image/png") {
++    bitmap =
++        gfx::PNGCodec::Decode(image_data);
++  } else if (mime_part == "image/jpeg" || mime_part == "image/jpg") {
++    bitmap =
++        gfx::JPEGCodec::Decode(image_data);
++  } else {
++    DLOG(WARNING) << "Unsupported MIME type: " << mime_part;
++    return {};
++  }
++
++  if (bitmap.isNull() || bitmap.empty()) {
++    DLOG(WARNING) << "Failed to decode image from data URL.";
++    return {};
++  }
++
++  constexpr int kCustomAvatarSize = 256;
++  gfx::ImageSkia image_skia = gfx::ImageSkia::CreateFrom1xBitmap(bitmap);
++  gfx::ImageSkia image_cropped =
++      gfx::ImageSkiaOperations::CreateCroppedCenteredRoundRectImage(
++          gfx::Size(kCustomAvatarSize, kCustomAvatarSize), 0, image_skia);
++  if (image_cropped.isNull()) {
++    return {};
++  }
++
++  bitmap = *image_cropped.bitmap();
++
++  return gfx::Image::CreateFrom1xBitmap(bitmap);
++}
++
+ }  // namespace
+ 
+ ManageProfileHandler::ManageProfileHandler(Profile* profile)
+@@ -69,6 +122,19 @@ void ManageProfileHandler::RegisterMessa
+           &ManageProfileHandler::HandleSetProfileIconToDefaultAvatar,
+           base::Unretained(this)));
+   web_ui()->RegisterMessageCallback(
++      "setProfileIconToCustomAvatar",
++      base::BindRepeating(
++          &ManageProfileHandler::HandleSetProfileIconToCustomAvatar,
++          base::Unretained(this)));
++  web_ui()->RegisterMessageCallback(
++      "setCustomAvatarFromFile",
++      base::BindRepeating(&ManageProfileHandler::HandleSetCustomAvatarFromFile,
++                          base::Unretained(this)));
++  web_ui()->RegisterMessageCallback(
++      "clearCustomAvatar",
++      base::BindRepeating(&ManageProfileHandler::HandleClearCustomAvatar,
++                          base::Unretained(this)));
++  web_ui()->RegisterMessageCallback(
+       "setProfileName",
+       base::BindRepeating(&ManageProfileHandler::HandleSetProfileName,
+                           base::Unretained(this)));
+@@ -152,6 +218,7 @@ void ManageProfileHandler::HandleSetProf
+ 
+   pref_service->SetBoolean(prefs::kProfileUsingDefaultAvatar, false);
+   pref_service->SetBoolean(prefs::kProfileUsingGAIAAvatar, true);
++  pref_service->SetBoolean(prefs::kProfileUsingCustomAvatar, false);
+   if (!previously_using_gaia_icon) {
+     // Only log if they changed to the GAIA photo.
+     // Selection of GAIA photo as avatar is logged as part of the function
+@@ -170,6 +237,87 @@ void ManageProfileHandler::HandleSetProf
+   profiles::SetDefaultProfileAvatarIndex(profile_, avatar_icon_index);
+ }
+ 
++void ManageProfileHandler::HandleSetProfileIconToCustomAvatar(
++    const base::ListValue& args) {
++  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
++
++  ProfileAttributesEntry* entry =
++      g_browser_process->profile_manager()
++          ->GetProfileAttributesStorage()
++          .GetProfileAttributesWithPath(profile_->GetPath());
++  if (!entry) {
++    return;
++  }
++
++  const gfx::Image* picture = entry->GetCustomAvatarPicture();
++  if (!picture) {
++    DCHECK(false) << "Custom avatar picture is not set.";
++    return;
++  }
++
++  PrefService* pref_service = profile_->GetPrefs();
++  pref_service->SetBoolean(prefs::kProfileUsingDefaultAvatar, false);
++  pref_service->SetBoolean(prefs::kProfileUsingGAIAAvatar, false);
++  pref_service->SetBoolean(prefs::kProfileUsingCustomAvatar, true);
++}
++
++void ManageProfileHandler::HandleSetCustomAvatarFromFile(
++    const base::ListValue& args) {
++  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
++  CHECK_EQ(1u, args.size());
++  const std::string data_url = args[0].GetString();
++
++  avatar_weak_factory_.InvalidateWeakPtrs();
++
++  base::ThreadPool::PostTaskAndReplyWithResult(
++      FROM_HERE, {base::MayBlock(), base::TaskPriority::USER_VISIBLE},
++      base::BindOnce(&DecodeAndCropAvatar, std::move(data_url)),
++      base::BindOnce(&ManageProfileHandler::OnCustomAvatarDecoded,
++                     avatar_weak_factory_.GetWeakPtr()));
++}
++
++void ManageProfileHandler::OnCustomAvatarDecoded(
++    std::optional<gfx::Image> image) {
++  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
++  if (!image) {
++    FireWebUIListener("custom-avatar-error");
++    return;
++  }
++
++  ProfileAttributesEntry* entry =
++      g_browser_process->profile_manager()
++          ->GetProfileAttributesStorage()
++          .GetProfileAttributesWithPath(profile_->GetPath());
++  if (!entry) {
++    return;
++  }
++
++  entry->SetCustomAvatarPicture(image.value());
++
++  // Persist the choice so it survives restarts. These prefs are read back
++  // in ProfileImpl::UpdateAvatarInStorage which
++  // calls SetIsUsingCustomAvatar.
++  PrefService* pref_service = profile_->GetPrefs();
++  pref_service->SetBoolean(prefs::kProfileUsingDefaultAvatar, false);
++  pref_service->SetBoolean(prefs::kProfileUsingGAIAAvatar, false);
++  pref_service->SetBoolean(prefs::kProfileUsingCustomAvatar, true);
++}
++
++void ManageProfileHandler::HandleClearCustomAvatar(
++    const base::ListValue& args) {
++  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
++
++  ProfileAttributesEntry* entry =
++      g_browser_process->profile_manager()
++          ->GetProfileAttributesStorage()
++          .GetProfileAttributesWithPath(profile_->GetPath());
++
++  profiles::SetDefaultProfileAvatarIndex(profile_, profiles::GetPlaceholderAvatarIndex());
++  if (entry) {
++    entry->ClearCustomAvatar();
++  }
++}
++
+ void ManageProfileHandler::HandleSetProfileName(const base::ListValue& args) {
+   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+   CHECK_EQ(1u, args.size());
+--- a/chrome/browser/ui/webui/settings/settings_manage_profile_handler.h
++++ b/chrome/browser/ui/webui/settings/settings_manage_profile_handler.h
+@@ -67,6 +67,18 @@ class ManageProfileHandler : public sett
+   // Callback for the "setProfileIconToDefaultAvatar" message.
+   void HandleSetProfileIconToDefaultAvatar(const base::ListValue& args);
+ 
++  // Callback for the "setProfileIconToCustomAvatar" message.
++  void HandleSetProfileIconToCustomAvatar(const base::ListValue& args);
++
++  // Callback for the "setCustomAvatarFromFile" message.
++  void HandleSetCustomAvatarFromFile(const base::ListValue& args);
++
++  // Callback for setting the profile avatar after the image is processed.
++  void OnCustomAvatarDecoded(std::optional<gfx::Image> image);
++
++  // Callback for the "clearCustomAvatar" message.
++  void HandleClearCustomAvatar(const base::ListValue& args);
++
+   // Callback for the "setProfileName" message.
+   void HandleSetProfileName(const base::ListValue& args);
+ 
+@@ -100,6 +112,7 @@ class ManageProfileHandler : public sett
+ 
+   // For generating weak pointers to itself for callbacks.
+   base::WeakPtrFactory<ManageProfileHandler> weak_factory_{this};
++  base::WeakPtrFactory<ManageProfileHandler> avatar_weak_factory_{this};
+ };
+ 
+ }  // namespace settings
+--- a/ui/webui/resources/cr_elements/cr_profile_avatar_selector/cr_profile_avatar_selector.ts
++++ b/ui/webui/resources/cr_elements/cr_profile_avatar_selector/cr_profile_avatar_selector.ts
+@@ -25,6 +25,8 @@ export interface AvatarIcon {
+   label: string;
+   index: number;
+   isGaiaAvatar: boolean;
++  isCustomAvatar: boolean;
++  isPlaceholder: boolean;
+   selected: boolean;
+ }
+ 
+@@ -111,9 +113,7 @@ export class CrProfileAvatarSelectorElem
+   }
+ 
+   protected isAvatarSelected_(avatarItem: AvatarIcon): boolean {
+-    return avatarItem.selected ||
+-        (!!this.selectedAvatar &&
+-         this.selectedAvatar.index === avatarItem.index);
++    return avatarItem.selected;
+   }
+ 
+   protected onAvatarClick_(e: Event) {
+@@ -121,7 +121,21 @@ export class CrProfileAvatarSelectorElem
+     // component.
+     const target = e.currentTarget as HTMLElement;
+     const index = Number(target.dataset['index']);
+-    this.selectedAvatar = this.avatars[index]!;
++    const clickedAvatar = this.avatars[index];
++    if (clickedAvatar?.isPlaceholder && clickedAvatar?.isCustomAvatar) {
++      // Handle firing event for open dialog
++      const allowed =
++          this.dispatchEvent(new CustomEvent('custom-avatar-requested', {
++            bubbles: true, composed: true, cancelable: true }));
++      if (!allowed) {
++        e.stopPropagation();
++      }
++    } else if (clickedAvatar?.isCustomAvatar && clickedAvatar.selected) {
++      this.fire('custom-avatar-deleted');
++      return;
++    } else {
++      this.selectedAvatar = this.avatars[index]!;
++    }
+ 
+     // Autoscroll to selected avatar if it is not completely visible.
+     const avatarList =
+--- a/ui/webui/resources/cr_elements/cr_profile_avatar_selector/cr_profile_avatar_selector.css
++++ b/ui/webui/resources/cr_elements/cr_profile_avatar_selector/cr_profile_avatar_selector.css
+@@ -89,6 +89,12 @@
+   --avatar-outline-width: 1px;
+ }
+ 
++.avatar-container.iron-selected[data-custom-avatar='true'] {
++  & > .clear { display: none; }
++  &:hover > .checkmark { display: none; }
++  &:hover > .clear { display: block !important; }
++}
++
+ cr-button {
+   background-size: var(--avatar-size);
+ }
+--- a/ui/webui/resources/cr_elements/cr_profile_avatar_selector/cr_profile_avatar_selector.html.ts
++++ b/ui/webui/resources/cr_elements/cr_profile_avatar_selector/cr_profile_avatar_selector.html.ts
+@@ -16,7 +16,8 @@ export function getHtml(this: CrProfileA
+     <!-- Wrapper div is needed so that only a single node is slotted in
+         cr-grid for each avatar. -->
+     <div>
+-      <div class="avatar-container ${this.getSelectedClass_(item)}">
++      <div class="avatar-container ${this.getSelectedClass_(item)}"
++           data-custom-avatar="${item.isCustomAvatar}">
+         <cr-button class="avatar" role="radio" id="${this.getAvatarId_(index)}"
+             data-index="${index}" aria-label="${item.label}"
+             tabindex="${this.getTabIndex_(index, item)}"
+@@ -25,6 +26,9 @@ export function getHtml(this: CrProfileA
+             aria-checked="${this.isAvatarSelected_(item)}">
+         </cr-button>
+         <cr-icon icon="cr:check" class="checkmark"></cr-icon>
++        ${item.isCustomAvatar
++            ? html`<cr-icon icon="cr:clear" class="checkmark clear"></cr-icon>`
++            : ''}
+       </div>
+       <cr-tooltip for="${this.getAvatarId_(index)}" offset="0"
+           fit-to-visible-bounds>

--- a/patches/helium/ui/layout/core.patch
+++ b/patches/helium/ui/layout/core.patch
@@ -425,7 +425,7 @@
  // A boolean pref set to true if a Home button to open the Home pages should be
  // visible on the toolbar.
  inline constexpr char kShowHomeButton[] = "browser.show_home_button";
-@@ -1875,14 +1890,6 @@ inline constexpr char kProjectsPanelPinn
+@@ -1877,14 +1892,6 @@ inline constexpr char kProjectsPanelPinn
  // strip.
  inline constexpr char kEverythingMenuPinnedToTabstrip[] =
      "everything_menu.pinned_to_tabstrip";

--- a/patches/series
+++ b/patches/series
@@ -188,6 +188,7 @@ helium/core/fixups-component-setup.patch
 helium/core/fixups-chrome-webstore-script.patch
 helium/core/hibernate-tab-context-menu.patch
 helium/core/disable-side-panel-flyover.patch
+helium/core/custom-profile-avatar.patch
 
 helium/settings/settings-page-icons.patch
 helium/settings/move-search-suggest.patch
@@ -208,6 +209,7 @@ helium/settings/fix-appearance-page.patch
 helium/settings/enable-quad9-doh-option.patch
 helium/settings/reorder-settings-menu.patch
 helium/settings/add-search-engine-button.patch
+helium/settings/custom-profile-avatar-ui.patch
 
 helium/hop/setup.patch
 helium/hop/disable-password-manager.patch
@@ -293,3 +295,4 @@ helium/ui/dont-antialias-rects.patch
 helium/ui/experiments/zen-mode-wiring.patch
 helium/ui/experiments/zen-caption-buttons.patch
 helium/ui/experiments/zen-mode.patch
+

--- a/patches/series
+++ b/patches/series
@@ -295,4 +295,3 @@ helium/ui/dont-antialias-rects.patch
 helium/ui/experiments/zen-mode-wiring.patch
 helium/ui/experiments/zen-caption-buttons.patch
 helium/ui/experiments/zen-mode.patch
-


### PR DESCRIPTION
For your pull request to not get closed without review, please confirm that:

- [x] An issue exists where the maintainers agreed that this should be implemented
      (an approved feature request, or confirmed bug).
- [x] I tested that my contribution works locally, and does not break anything,
      otherwise I have marked my PR as draft.
- [x] If my contribution is non-trivial, I did not use AI to write most of it.
- [x] I understand that I will be permanently banned from interacting with this
      organization if I lied by checking any of these checkboxes.

Tested on (check one or more):
- [ ] Windows
- [x] macOS
- [ ] Linux

---

This PR adds an option to pick a custom profile avatar in the `Customize Profile` settings. It supports jpeg and png images with an arbitrary file size limit of 30MB. Images are resized to 256x256px and saved to the standard profile dir.

fixes: https://github.com/imputnet/helium/issues/143

<img width="662" height="577" alt="image" src="https://github.com/user-attachments/assets/eeb1ef14-2e7f-457a-a352-ab5eb3e95311" />

## TODOs

- [x] Move avatar image processing from the UI thread to a background thread to prevent UI jank.
- [x] Implement nicer UI.
- [x] Fix remaining findings.
- [x] Rebase on main. 
- [x] Split patch.

## Limitations

The custom avatar settings are not available during profile creation. Implementing these changes in the profile creation flow  is a non trivial amount of additional work, and maintenance burden for little to no benefit.

## AI Disclaimer
I used Claude for getting around the codebase, and for finding existing patterns to base my implementation on. All implementation code was written by hand.