### PR TITLE
helium/ui: fill side panel resize area background

### DIFF
--- a/patches/helium/ui/side-panel-resize-area-background.patch
+++ b/patches/helium/ui/side-panel-resize-area-background.patch
@@ -1,0 +1,67 @@
+--- a/chrome/browser/ui/views/side_panel/side_panel.h
++++ b/chrome/browser/ui/views/side_panel/side_panel.h
+@@ -47,6 +47,7 @@ class SidePanel : public views::Accessib
+     return animation_coordinator_.get();
+   }
+ 
++  BrowserView* browser_view() const { return browser_view_; }
+   void SetPanelWidth(int width);
+   bool ShouldRestrictMaxWidth() const;
+   void UpdateWidthOnEntryChanged();
+--- a/chrome/browser/ui/views/side_panel/side_panel_resize_area.h
++++ b/chrome/browser/ui/views/side_panel/side_panel_resize_area.h
+@@ -7,6 +7,7 @@
+ 
+ #include <optional>
+ 
++#include "base/callback_list.h"
+ #include "base/memory/raw_ptr.h"
+ #include "chrome/browser/ui/views/side_panel/side_panel.h"
+ #include "ui/views/controls/image_view.h"
+@@ -42,6 +43,8 @@ class SidePanelResizeArea : public Resiz
+     return resize_handle_;
+   }
+ 
++  void AddedToWidget() override;
++  void OnThemeChanged() override;
+   void OnMouseReleased(const ui::MouseEvent& event) override;
+   bool OnKeyPressed(const ui::KeyEvent& event) override;
+   void OnMouseMoved(const ui::MouseEvent& event) override;
+@@ -56,6 +59,7 @@ class SidePanelResizeArea : public Resiz
+ 
+   raw_ptr<SidePanel> side_panel_;
+   raw_ptr<SidePanelResizeHandle> resize_handle_;
++  base::CallbackListSubscription paint_as_active_subscription_;
+ };
+ 
+ }  // namespace views
+--- a/chrome/browser/ui/views/side_panel/side_panel_resize_area.cc
++++ b/chrome/browser/ui/views/side_panel/side_panel_resize_area.cc
+@@ -8,6 +8,8 @@
+ #include "base/i18n/rtl.h"
+ #include "chrome/browser/ui/browser_element_identifiers.h"
+ #include "chrome/browser/ui/color/chrome_color_id.h"
++#include "chrome/browser/ui/views/frame/browser_view.h"
++#include "chrome/browser/ui/views/frame/themed_background.h"
+ #include "chrome/grit/generated_resources.h"
+ #include "ui/accessibility/mojom/ax_node_data.mojom.h"
+ #include "ui/base/l10n/l10n_util.h"
+@@ -76,6 +78,18 @@ SidePanelResizeArea::SidePanelResizeArea
+       }));
+ }
+ 
++void SidePanelResizeArea::AddedToWidget() {
++  paint_as_active_subscription_ =
++      GetWidget()->RegisterPaintAsActiveChangedCallback(base::BindRepeating(
++          &SidePanelResizeArea::SchedulePaint, base::Unretained(this)));
++}
++
++void SidePanelResizeArea::OnThemeChanged() {
++  ResizeArea::OnThemeChanged();
++  SetBackground(
++      std::make_unique<ThemedBackground>(side_panel_->browser_view()));
++}
++
+ void SidePanelResizeArea::OnMouseReleased(const ui::MouseEvent& event) {
+   ResizeArea::OnMouseReleased(event);
+   side_panel_->RecordMetricsIfResized();

--- a/patches/series
+++ b/patches/series
@@ -233,6 +233,7 @@ helium/ui/app-menu-button.patch
 helium/ui/remove-reading-list-from-app-menu.patch
 helium/ui/fix-customize-side-panel.patch
 helium/ui/side-panel.patch
+helium/ui/side-panel-resize-area-background.patch
 helium/ui/remove-dead-toolbar-actions.patch
 helium/ui/remove-dead-profile-actions.patch
 helium/ui/clean-up-installed-extension-bubble.patch


### PR DESCRIPTION
fixes #1066

before and after:
<div style="display: inline">
<img width="318" height="415"  src="https://github.com/user-attachments/assets/f6b33788-ec18-4c4f-9687-461d23400695" />
<img width="308" height="408" src="https://github.com/user-attachments/assets/e69f5499-26c5-4e56-bf98-8bf6a91bd726" />
</div>