### PR TITLE
patches/ublock: compatify generate_file_list script

### DIFF
--- a/patches/helium/core/ublock-setup-sources.patch
+++ b/patches/helium/core/ublock-setup-sources.patch
@@ -71,12 +71,13 @@
 +}
 --- /dev/null
 +++ b/third_party/ublock/generate_file_list.py
-@@ -0,0 +1,19 @@
+@@ -0,0 +1,20 @@
 +# Copyright 2025 The Helium Authors
 +# You can use, redistribute, and/or modify this source code under
 +# the terms of the GPL-3.0 license that can be found in the LICENSE file.
 +
 +import json
++import os
 +from sys import argv
 +from pathlib import Path
 +
@@ -86,8 +87,8 @@
 +with open(out_file, 'w') as f:
 +  f.write(json.dumps(
 +    { "base_dir": ublock_src.as_posix(),
-+      "files":   [ (root / file).relative_to(ublock_src).as_posix()
-+                   for root, _, files in ublock_src.walk()
++      "files":   [ (Path(root) / file).relative_to(ublock_src).as_posix()
++                   for root, _, files in os.walk(ublock_src)
 +                   for file in files ]
 +    }
 +  ))


### PR DESCRIPTION
should work on any reasonable python version now whereas before it worked on >=3.12 only