### PR TITLE
helium/ui: don't antialias rects

### DIFF
--- a/patches/helium/ui/dont-antialias-rects.patch
+++ b/patches/helium/ui/dont-antialias-rects.patch
@@ -1,0 +1,22 @@
+--- a/ui/views/view.cc
++++ b/ui/views/view.cc
+@@ -1445,7 +1445,18 @@ void View::Paint(const PaintInfo& parent
+ 
+       const SkPath clip_path_in_parent = clip_path_.makeTransform(
+           gfx::TransformToFlattenedSkMatrix(to_parent_recording_space));
+-      clip_recorder.ClipPathWithAntiAliasing(clip_path_in_parent);
++
++      // Only use anti-aliased clipping for non-rectangular paths (e.g. rounded
++      // corners). Axis-aligned rects do not benefit from AA, and AA clipping at
++      // fractional pixel boundaries (from non-integer device scale factors)
++      // produces semi-transparent edges that cause visible seams between
++      // adjacent views.
++      SkRect rect;
++      if (clip_path_in_parent.isRect(&rect)) {
++        clip_recorder.ClipRect(gfx::ToEnclosingRect(gfx::SkRectToRectF(rect)));
++      } else {
++        clip_recorder.ClipPathWithAntiAliasing(clip_path_in_parent);
++      }
+     }
+   }
+ 

--- a/patches/helium/ui/dont-antialias-rects.patch
+++ b/patches/helium/ui/dont-antialias-rects.patch
@@ -20,3 +20,23 @@
      }
    }
  
+--- a/chrome/browser/ui/views/frame/custom_corners_background.cc
++++ b/chrome/browser/ui/views/frame/custom_corners_background.cc
+@@ -186,9 +186,14 @@ void CustomCornersBackground::Paint(gfx:
+       CornerToRadiusVector(corners.upper_trailing, default_radius_),
+       CornerToRadiusVector(corners.lower_trailing, default_radius_),
+       CornerToRadiusVector(corners.lower_leading, default_radius_)};
+-  const SkPath path =
+-      SkPath::RRect(SkRRect::MakeRectRadii(gfx::RectToSkRect(rect), radii));
+-  PaintPath(canvas, path, primary_color_, /*anti_alias=*/true);
++  const SkRRect rrect = SkRRect::MakeRectRadii(gfx::RectToSkRect(rect), radii);
++  const SkPath path = SkPath::RRect(rrect);
++  const bool anti_alias = rrect.getType() != SkRRect::kRect_Type;
++  // Only use anti-aliasing when the path has actual rounded corners.
++  // Anti-aliased clipping of axis-aligned rects at fractional pixel
++  // boundaries produces semi-transparent edges that cause visible gaps
++  // between adjacent views.
++  PaintPath(canvas, path, primary_color_, anti_alias);
+ 
+   // Paint strokes around the outside. Corners get strokes if they are between
+   // two sides with strokes and have a radius. Multiple paths may be drawn if

--- a/patches/series
+++ b/patches/series
@@ -283,3 +283,4 @@ helium/ui/layout/vertical.patch
 helium/ui/pdf-viewer.patch
 helium/ui/hide-pip-live-caption-button.patch
 helium/ui/disable-ink-ripple-effect.patch
+helium/ui/dont-antialias-rects.patch


### PR DESCRIPTION
this seemingly fixes the 1px gap for me on linux on fractional scaling, let's see if everyone else agrees

before and after (on --force-device-scale-factor=1.25):
<img width="347" height="127" alt="Screenshot 2026-03-28 at 0 05 42" src="https://github.com/user-attachments/assets/102d13f6-ce04-4135-af85-2981c325c33d" />


<img width="452" height="141" alt="Screenshot 2026-03-28 at 0 05 11" src="https://github.com/user-attachments/assets/cc03bcee-6409-4e15-a043-5c662de7442f" />



before and after (on --force-device-scale-factor=2.5):

<img width="506" height="248" alt="Screenshot 2026-03-28 at 0 01 21" src="https://github.com/user-attachments/assets/6338b6aa-3477-4ff8-b977-3ae256044b7c" />

<img width="624" height="244" alt="Screenshot 2026-03-28 at 0 01 50" src="https://github.com/user-attachments/assets/06e5c62d-2cef-4ebb-8982-d9eb9819f1b6" />

related: #501
