### PR TITLE
helium/core: fix opening tabgroups when focused in a tabgroup

### DIFF
--- a/patches/helium/core/hibernate-tab-context-menu.patch
+++ b/patches/helium/core/hibernate-tab-context-menu.patch
@@ -107,7 +107,7 @@
  }  // namespace
  
  TabGroupModelFactory::TabGroupModelFactory() {
-@@ -2485,6 +2537,21 @@ bool TabStripModel::IsContextMenuCommand
+@@ -2494,6 +2546,21 @@ bool TabStripModel::IsContextMenuCommand
      case CommandReload:
        return delegate_->CanReload();
  
@@ -129,7 +129,7 @@
      case CommandCloseOtherTabs:
      case CommandCloseTabsToRight: {
        return !GetIndicesClosedByCommand(context_index, command_id).empty();
-@@ -2651,6 +2718,27 @@ void TabStripModel::ExecuteContextMenuCo
+@@ -2660,6 +2727,27 @@ void TabStripModel::ExecuteContextMenuCo
        }
        break;
      }

--- a/patches/helium/core/open-new-tabs-next-to-active-tab-option.patch
+++ b/patches/helium/core/open-new-tabs-next-to-active-tab-option.patch
@@ -1,12 +1,13 @@
 --- a/chrome/common/pref_names.h
 +++ b/chrome/common/pref_names.h
-@@ -1305,6 +1305,10 @@ inline constexpr char
+@@ -1305,6 +1305,11 @@ inline constexpr char
          "restricted_managed_guest_session_extension_cleanup_exempt_list";
  #endif  // BUILDFLAG(IS_CHROMEOS)
  
-+// A boolean pref set to true if new tabs should be created to the next of current active one,
-+// instead of tab strip end.
-+inline constexpr char kNewTabNextToActive[] = "helium.browser.new_tab_next_to_active";
++// A boolean pref set to true if new tabs should be created to the next of
++// current active one, instead of tab strip end.
++inline constexpr char kNewTabNextToActive[] =
++    "helium.browser.new_tab_next_to_active";
 +
  // A boolean pref set to true if a Home button to open the Home pages should be
  // visible on the toolbar.
@@ -39,13 +40,22 @@
  #include "components/reading_list/core/reading_list_model.h"
  #include "components/split_tabs/split_tab_id.h"
  #include "components/split_tabs/split_tab_visual_data.h"
-@@ -1733,7 +1735,11 @@ void TabStripModel::AddTab(std::unique_p
+@@ -1733,7 +1735,20 @@ void TabStripModel::AddTab(std::unique_p
      // For all other types, respect what was passed to us, normalizing -1s and
      // values that are too large.
      if (index < 0 || index > count()) {
 -      index = count();
-+      if (count() >= 1 && profile_->GetPrefs()->GetBoolean(prefs::kNewTabNextToActive)) {
-+        index = active_index() + 1;
++      const bool new_tab_next_to_active =
++          profile_->GetPrefs()->GetBoolean(prefs::kNewTabNextToActive);
++      const auto opener_group = GetTabGroupForTab(active_index());
++
++      if (count() >= 1 && new_tab_next_to_active) {
++        if (group_model_ && opener_group && !(add_types & ADD_ACTIVE)) {
++          index = static_cast<int>(
++              group_model_->GetTabGroup(*opener_group)->ListTabs().end());
++        } else {
++          index = active_index() + 1;
++        }
 +      } else {
 +        index = count();
 +      }

--- a/patches/helium/core/tab-cycling-mru.patch
+++ b/patches/helium/core/tab-cycling-mru.patch
@@ -1,8 +1,8 @@
 --- a/chrome/common/pref_names.h
 +++ b/chrome/common/pref_names.h
-@@ -1309,6 +1309,10 @@ inline constexpr char
- // instead of tab strip end.
- inline constexpr char kNewTabNextToActive[] = "helium.browser.new_tab_next_to_active";
+@@ -1310,6 +1310,10 @@ inline constexpr char
+ inline constexpr char kNewTabNextToActive[] =
+     "helium.browser.new_tab_next_to_active";
  
 +// A boolean pref set to true if MRU (Most Recently Used) order should be used
 +// when cycling through tabs with Ctrl+Tab.
@@ -24,7 +24,7 @@
    registry->RegisterBooleanPref(prefs::kShowHomeButton, false,
 --- a/chrome/browser/ui/tabs/tab_strip_model.cc
 +++ b/chrome/browser/ui/tabs/tab_strip_model.cc
-@@ -1832,11 +1832,11 @@ void TabStripModel::CloseSelectedTabs()
+@@ -1841,11 +1841,11 @@ void TabStripModel::CloseSelectedTabs()
  }
  
  void TabStripModel::SelectNextTab(TabStripUserGestureDetails detail) {
@@ -38,7 +38,7 @@
  }
  
  void TabStripModel::SelectLastTab(TabStripUserGestureDetails detail) {
-@@ -3994,6 +3994,18 @@ TabStripSelectionChange TabStripModel::S
+@@ -4003,6 +4003,18 @@ TabStripSelectionChange TabStripModel::S
    return selection;
  }
  

--- a/patches/helium/ui/layout/centered-address-bar.patch
+++ b/patches/helium/ui/layout/centered-address-bar.patch
@@ -1,6 +1,6 @@
 --- a/chrome/common/pref_names.h
 +++ b/chrome/common/pref_names.h
-@@ -1328,6 +1328,11 @@ inline constexpr char kHeliumVerticalCol
+@@ -1329,6 +1329,11 @@ inline constexpr char kHeliumVerticalCol
  inline constexpr char kHeliumVerticalUncollapsedWidth[] =
      "helium.browser.vertical_uncollapsed_width";
  

--- a/patches/helium/ui/layout/core.patch
+++ b/patches/helium/ui/layout/core.patch
@@ -344,7 +344,7 @@
  }  // namespace tabs
 --- a/chrome/common/pref_names.h
 +++ b/chrome/common/pref_names.h
-@@ -1313,6 +1313,21 @@ inline constexpr char kNewTabNextToActiv
+@@ -1314,6 +1314,21 @@ inline constexpr char kNewTabNextToActiv
  // when cycling through tabs with Ctrl+Tab.
  inline constexpr char kTabCyclingMRU[] = "helium.browser.mru_tab_cycling";
  
@@ -366,7 +366,7 @@
  // A boolean pref set to true if a Home button to open the Home pages should be
  // visible on the toolbar.
  inline constexpr char kShowHomeButton[] = "browser.show_home_button";
-@@ -2002,9 +2017,6 @@ inline constexpr char kGoogleSearchSideP
+@@ -2003,9 +2018,6 @@ inline constexpr char kGoogleSearchSideP
  // True when the tab search button is on the right side of the tab strip even in
  // RTL.
  inline constexpr char kTabSearchRightAligned[] = "tab_search.is_right_aligned";

--- a/patches/helium/ui/layout/minimal-location-bar.patch
+++ b/patches/helium/ui/layout/minimal-location-bar.patch
@@ -1,6 +1,6 @@
 --- a/chrome/common/pref_names.h
 +++ b/chrome/common/pref_names.h
-@@ -1333,6 +1333,10 @@ inline constexpr char kHeliumVerticalUnc
+@@ -1334,6 +1334,10 @@ inline constexpr char kHeliumVerticalUnc
  inline constexpr char kHeliumCenteredLocationBar[] =
      "helium.browser.centered_location_bar";
  

--- a/patches/helium/ui/layout/shortcuts.patch
+++ b/patches/helium/ui/layout/shortcuts.patch
@@ -1,6 +1,6 @@
 --- a/chrome/common/pref_names.h
 +++ b/chrome/common/pref_names.h
-@@ -1558,6 +1558,11 @@ inline constexpr char kPrefersDefaultScr
+@@ -1559,6 +1559,11 @@ inline constexpr char kPrefersDefaultScr
  inline constexpr char kCopyPageUrlShortcut[] =
      "helium.settings.a11y.copy_page_url_shortcut";
  

--- a/patches/helium/ui/layout/toolbar-actions.patch
+++ b/patches/helium/ui/layout/toolbar-actions.patch
@@ -1,6 +1,6 @@
 --- a/chrome/common/pref_names.h
 +++ b/chrome/common/pref_names.h
-@@ -1396,6 +1396,16 @@ inline constexpr char kShowMenuButton[]
+@@ -1397,6 +1397,16 @@ inline constexpr char kShowMenuButton[]
  // the toolbar.
  inline constexpr char kShowMediaButton[] = "helium.browser.show_media_button";
  

--- a/patches/helium/ui/toolbar-button-prefs.patch
+++ b/patches/helium/ui/toolbar-button-prefs.patch
@@ -1,6 +1,6 @@
 --- a/chrome/common/pref_names.h
 +++ b/chrome/common/pref_names.h
-@@ -1348,6 +1348,30 @@ inline constexpr char kSplitViewDragAndD
+@@ -1349,6 +1349,30 @@ inline constexpr char kSplitViewDragAndD
  inline constexpr char kSplitViewDragAndDropNudgeUsedCount[] =
      "browser.split_view_drag_and_drop_nudge_used_count";
  


### PR DESCRIPTION
... and with `Open new tabs next to the active tab` enabled

fixes #1163