### PR TITLE
helium/layout: fix for dynamic tab strip in gtk mode

### DIFF
--- a/patches/helium/ui/layout/dynamic.patch
+++ b/patches/helium/ui/layout/dynamic.patch
@@ -166,6 +166,19 @@
    // Lay out the bookmarks bar if one is present.
    const bool bookmarks_visible = delegate().IsBookmarkBarVisible();
    if (IsParentedTo(views().bookmark_bar, views().top_container)) {
+@@ -1058,8 +1135,10 @@ gfx::Rect BrowserViewTabbedLayoutImpl::C
+ void BrowserViewTabbedLayoutImpl::ConfigureTopContainerBackground(
+     const BrowserLayoutParams& params,
+     CustomCornersBackground* background) {
+-  // Fall back to default implementation when vertical tabstrip not present.
+-  if (!delegate().ShouldDrawVerticalTabStrip()) {
++  // Fall back to default implementation when neither vertical nor dynamic
++  // tabstrip is present.
++  if (!delegate().ShouldDrawVerticalTabStrip() &&
++      !IsDynamicTabStrip(GetTabStripType())) {
+     BrowserViewLayoutImpl::ConfigureTopContainerBackground(params, background);
+     return;
+   }
 --- a/chrome/browser/ui/views/frame/layout/browser_view_tabbed_layout_impl.h
 +++ b/chrome/browser/ui/views/frame/layout/browser_view_tabbed_layout_impl.h
 @@ -110,6 +110,8 @@ class BrowserViewTabbedLayoutImpl : publ


### PR DESCRIPTION
before:
<img width="767" height="131" alt="Screenshot 2026-04-06 at 19 12 01" src="https://github.com/user-attachments/assets/c8e46b0f-6536-437f-9729-0e889259ed45" />

after:
<img width="627" height="195" alt="Screenshot 2026-04-06 at 19 14 28" src="https://github.com/user-attachments/assets/636d2536-83b1-44ab-8fa3-cf14ccc2da08" />