### PR TITLE
helium/core/keyboard-shortcuts: fix cmd+shift+c enabling

### DIFF
--- a/patches/helium/core/keyboard-shortcuts.patch
+++ b/patches/helium/core/keyboard-shortcuts.patch
@@ -38,20 +38,33 @@
    // We need to register the type of these preferences in order to query
    // them even though they're only typically controlled via policy.
    registry->RegisterBooleanPref(policy::policy_prefs::kHideWebStoreIcon, false);
+--- a/chrome/browser/ui/browser_command_controller.h
++++ b/chrome/browser/ui/browser_command_controller.h
+@@ -148,6 +148,9 @@ class BrowserCommandController : public
+   // Update commands whose state depends on the tab's state.
+   void UpdateCommandsForTabState();
+ 
++  // Updates the CMD+Shift+C shortcut command.
++  void UpdateCommandForCopyInspect();
++
+   // Update Zoom commands based on zoom state.
+   void UpdateCommandsForZoomState();
+ 
 --- a/chrome/browser/ui/browser_command_controller.cc
 +++ b/chrome/browser/ui/browser_command_controller.cc
-@@ -320,6 +320,10 @@ BrowserCommandController::BrowserCommand
+@@ -320,6 +320,11 @@ BrowserCommandController::BrowserCommand
                            base::Unretained(this)));
  #endif  // BUILDFLAG(ENABLE_PRINTING)
    profile_pref_registrar_.Add(
 +      prefs::kCopyPageUrlShortcut,
-+      base::BindRepeating(&BrowserCommandController::UpdateCommandsForDevTools,
-+                          base::Unretained(this)));
++      base::BindRepeating(
++          &BrowserCommandController::UpdateCommandForCopyInspect,
++          base::Unretained(this)));
 +  profile_pref_registrar_.Add(
        policy::policy_prefs::kDownloadRestrictions,
        base::BindRepeating(&BrowserCommandController::UpdateSaveAsState,
                            base::Unretained(this)));
-@@ -451,7 +455,9 @@ bool BrowserCommandController::IsReserve
+@@ -451,7 +456,9 @@ bool BrowserCommandController::IsReserve
           command_id == IDC_NEW_INCOGNITO_WINDOW || command_id == IDC_NEW_TAB ||
           command_id == IDC_NEW_WINDOW || command_id == IDC_RESTORE_TAB ||
           command_id == IDC_SELECT_NEXT_TAB ||
@@ -62,7 +75,7 @@
  }
  
  void BrowserCommandController::TabStateChanged() {
-@@ -1262,6 +1268,14 @@ bool BrowserCommandController::ExecuteCo
+@@ -1262,6 +1269,14 @@ bool BrowserCommandController::ExecuteCo
      case IDC_DUPLICATE_TARGET_TAB:
        DuplicateKeyboardFocusedTab(browser_);
        break;
@@ -77,15 +90,46 @@
      // Hosted App commands
      case IDC_COPY_URL:
        CopyURL(browser_, browser_->tab_strip_model()->GetActiveWebContents());
-@@ -2033,6 +2047,12 @@ void BrowserCommandController::UpdateCom
+@@ -1722,6 +1737,7 @@ void BrowserCommandController::InitComma
+                                         is_web_app_or_custom_tab);
+   command_updater_.UpdateCommandEnabled(IDC_WEB_APP_MENU_APP_INFO,
+                                         is_web_app_or_custom_tab);
++  UpdateCommandForCopyInspect();
+ 
+   // Tab management commands
+   const bool supports_tabs =
+@@ -2025,6 +2041,25 @@ void BrowserCommandController::UpdateCom
+   UpdatePrintingState();
+ }
+ 
++void BrowserCommandController::UpdateCommandForCopyInspect() {
++  if (is_locked_fullscreen_) {
++    return;
++  }
++
++  const bool copy_url_enabled =
++      IsWebAppOrCustomTab(browser_) ||
++      !sharing_hub::SharingIsDisabledByPolicy(browser_->profile());
++  const bool inspect_enabled =
++      DevToolsWindow::AllowDevToolsFor(
++          profile(), browser_->tab_strip_model()->GetActiveWebContents());
++
++  const bool use_copy_shortcut =
++      profile()->GetPrefs()->GetBoolean(prefs::kCopyPageUrlShortcut);
++  command_updater_.UpdateCommandEnabled(
++      IDC_COPY_OR_INSPECT_SHORTCUT,
++      use_copy_shortcut ? copy_url_enabled : inspect_enabled);
++}
++
+ // TODO(crbug.com/442892562): Remove this function once the feature is launched.
+ void BrowserCommandController::UpdateCommandsForDevTools() {
+   if (is_locked_fullscreen_) {
+@@ -2033,6 +2068,9 @@ void BrowserCommandController::UpdateCom
  
    bool dev_tools_enabled = DevToolsWindow::AllowDevToolsFor(
        profile(), browser_->tab_strip_model()->GetActiveWebContents());
 +
-+  PrefService* prefs = profile()->GetPrefs();
-+  bool copy = prefs->GetBoolean(prefs::kCopyPageUrlShortcut);
-+  command_updater_.UpdateCommandEnabled(IDC_COPY_OR_INSPECT_SHORTCUT,
-+                                        copy || dev_tools_enabled);
++  UpdateCommandForCopyInspect();
 +
    command_updater_.UpdateCommandEnabled(IDC_DEV_TOOLS, dev_tools_enabled);
    command_updater_.UpdateCommandEnabled(IDC_DEV_TOOLS_CONSOLE,

--- a/patches/helium/ui/experiments/zen-mode.patch
+++ b/patches/helium/ui/experiments/zen-mode.patch
@@ -1181,7 +1181,7 @@
    // AppMenuIconController::Delegate:
 --- a/chrome/browser/ui/browser_command_controller.cc
 +++ b/chrome/browser/ui/browser_command_controller.cc
-@@ -1301,10 +1301,18 @@ bool BrowserCommandController::ExecuteCo
+@@ -1302,10 +1302,18 @@ bool BrowserCommandController::ExecuteCo
        bool copy = prefs->GetBoolean(prefs::kCopyPageUrlShortcut);
  
        return ExecuteCommandWithDisposition(

--- a/patches/helium/ui/layout/context-menu.patch
+++ b/patches/helium/ui/layout/context-menu.patch
@@ -128,7 +128,7 @@
    if (!current_tab) {
 --- a/chrome/browser/ui/browser_command_controller.cc
 +++ b/chrome/browser/ui/browser_command_controller.cc
-@@ -733,6 +733,21 @@ bool BrowserCommandController::ExecuteCo
+@@ -734,6 +734,21 @@ bool BrowserCommandController::ExecuteCo
      case IDC_NAME_WINDOW:
        PromptToNameWindow(browser_);
        break;
@@ -150,7 +150,7 @@
  
  #if BUILDFLAG(IS_CHROMEOS)
      case IDC_TAKE_SCREENSHOT:
-@@ -1545,6 +1560,15 @@ void BrowserCommandController::InitComma
+@@ -1546,6 +1561,15 @@ void BrowserCommandController::InitComma
    command_updater_.UpdateCommandEnabled(IDC_SHOW_SEARCH_TOOLS, true);
    command_updater_.UpdateCommandEnabled(IDC_SHOW_AI_MODE_OMNIBOX_BUTTON, true);
  

--- a/patches/helium/ui/layout/shortcuts.patch
+++ b/patches/helium/ui/layout/shortcuts.patch
@@ -76,7 +76,7 @@
  #if BUILDFLAG(ENABLE_PRINTING)
    profile_pref_registrar_.Add(
        prefs::kPrintingEnabled,
-@@ -1291,6 +1304,20 @@ bool BrowserCommandController::ExecuteCo
+@@ -1292,6 +1305,20 @@ bool BrowserCommandController::ExecuteCo
            copy ? IDC_COPY_URL : IDC_DEV_TOOLS_INSPECT,
            disposition, time_stamp);
      }
@@ -97,7 +97,7 @@
      // Hosted App commands
      case IDC_COPY_URL:
        CopyURL(browser_, browser_->tab_strip_model()->GetActiveWebContents());
-@@ -2312,7 +2339,11 @@ void BrowserCommandController::UpdateSav
+@@ -2330,7 +2357,11 @@ void BrowserCommandController::UpdateSav
      return;
    }
  


### PR DESCRIPTION
fixes the currently broken ctrl/cmd+shift+c shortcut that doesn't work unless you re-toggle `kCopyPageUrlShortcut`

should've done it this way long time ago