### PR TITLE
helium/ui/layout: restore tab strip NTB in compact layout

### DIFF
--- a/patches/helium/ui/experiments/zen-mode.patch
+++ b/patches/helium/ui/experiments/zen-mode.patch
@@ -1142,7 +1142,7 @@
  bool ToolbarView::IsCompactLayout() const {
    auto* controller =
        HeliumLayoutStateController::From(browser_view_->browser());
-@@ -1904,8 +1914,11 @@ void ToolbarView::UpdateVerticalTabsColl
+@@ -1906,8 +1916,11 @@ void ToolbarView::UpdateVerticalTabsColl
  
    auto* controller =
        tabs::VerticalTabStripStateController::From(browser_view_->browser());

--- a/patches/helium/ui/layout/horizontal-tabs.patch
+++ b/patches/helium/ui/layout/horizontal-tabs.patch
@@ -1,6 +1,6 @@
 --- a/chrome/browser/ui/views/frame/horizontal_tab_strip_region_view.cc
 +++ b/chrome/browser/ui/views/frame/horizontal_tab_strip_region_view.cc
-@@ -130,16 +130,32 @@ class FrameGrabHandle : public views::Vi
+@@ -130,16 +130,38 @@ class FrameGrabHandle : public views::Vi
  BEGIN_METADATA(FrameGrabHandle)
  END_METADATA
  
@@ -32,7 +32,13 @@
 +  }
 +
 +  auto* const layout_controller = HeliumLayoutStateController::From(browser);
-+  return !layout_controller || layout_controller->IsClassicLayout();
++
++  if (!layout_controller) {
++    return true;
++  }
++
++  return layout_controller->IsClassicLayout() ||
++         layout_controller->IsCompactLayout();
 +}
 +
 +views::View* GetVisibleView(views::View* view) {
@@ -40,7 +46,7 @@
  }
  
  // Updates the border of `view` if the insets need to be updated.
-@@ -295,7 +311,7 @@ HorizontalTabStripRegionView::Horizontal
+@@ -295,7 +317,7 @@ HorizontalTabStripRegionView::Horizontal
                                 views::MaximumFlexSizeRule::kPreferred);
    tab_strip_->SetProperty(views::kFlexBehaviorKey, tab_strip_flex_spec);
  
@@ -49,7 +55,7 @@
      std::unique_ptr<TabStripControlButton> tab_strip_control_button =
          std::make_unique<NewTabButton>(
              base::BindRepeating(&TabStrip::NewTabButtonPressed,
-@@ -311,6 +327,7 @@ HorizontalTabStripRegionView::Horizontal
+@@ -311,6 +333,7 @@ HorizontalTabStripRegionView::Horizontal
      new_tab_button_->SetTriggerableEventFlags(
          new_tab_button_->GetTriggerableEventFlags() |
          ui::EF_MIDDLE_MOUSE_BUTTON);
@@ -57,7 +63,7 @@
    }
  
    reserved_grab_handle_space_ =
-@@ -432,6 +449,15 @@ void HorizontalTabStripRegionView::Layou
+@@ -432,6 +455,15 @@ void HorizontalTabStripRegionView::Layou
      return;
    }
  
@@ -73,7 +79,7 @@
    const bool tab_search_container_before_tab_strip =
        tab_search_container_ && render_tab_search_before_tab_strip_;
    if (tab_search_container_before_tab_strip ||
-@@ -458,7 +484,7 @@ void HorizontalTabStripRegionView::Layou
+@@ -458,7 +490,7 @@ void HorizontalTabStripRegionView::Layou
      AdjustViewBoundsRect(combo_button_, leading_offset);
    }
  
@@ -82,7 +88,7 @@
  
    if (button_to_paint_to_layer) {
      // The button needs to be layered on top of the tabstrip to achieve
-@@ -737,7 +763,7 @@ void HorizontalTabStripRegionView::Updat
+@@ -737,7 +769,7 @@ void HorizontalTabStripRegionView::Updat
    // The new tab button overlaps the tabstrip. Render it to a layer and adjust
    // the tabstrip right margin to reserve space for it.
    std::optional<int> tab_strip_right_margin;
@@ -91,7 +97,7 @@
  
    if (button_to_paint_to_layer) {
      button_to_paint_to_layer->SetPaintToLayer();
-@@ -791,12 +817,10 @@ void HorizontalTabStripRegionView::Updat
+@@ -791,12 +823,10 @@ void HorizontalTabStripRegionView::Updat
  
    UpdateButtonBorders();
  
@@ -126,7 +132,7 @@
  #include "chrome/grit/theme_resources.h"
  #include "components/tab_groups/tab_group_visual_data.h"
  #include "third_party/skia/include/core/SkPath.h"
-@@ -51,6 +53,25 @@
+@@ -51,6 +53,31 @@
  #include "ui/views/widget/widget.h"
  
  namespace {
@@ -146,13 +152,19 @@
 +
 +  auto* const layout_controller =
 +      HeliumLayoutStateController::From(browser_window_interface);
-+  return !layout_controller || layout_controller->IsClassicLayout();
++
++  if (!layout_controller) {
++    return true;
++  }
++
++  return layout_controller->IsClassicLayout() ||
++         layout_controller->IsCompactLayout();
 +}
 +
  class TabStyleViewsImpl : public TabStyleViews {
   public:
    explicit TabStyleViewsImpl(Tab* tab);
-@@ -735,6 +756,10 @@ float TabStyleViewsImpl::GetSeparatorOpa
+@@ -735,6 +762,10 @@ float TabStyleViewsImpl::GetSeparatorOpa
    // combo button with a non-transparent background in place of the new tab
    // button, we should not show the trailing separator.
    if (!adjacent_tab) {

--- a/patches/helium/ui/layout/toolbar-actions.patch
+++ b/patches/helium/ui/layout/toolbar-actions.patch
@@ -346,7 +346,7 @@
    if (location_bar_view_) {
      location_bar_view_->SetProperty(views::kFlexBehaviorKey,
                                      location_bar_flex_rule);
-@@ -1761,6 +1875,65 @@ bool ToolbarView::IsCompactLayout() cons
+@@ -1761,6 +1875,67 @@ bool ToolbarView::IsCompactLayout() cons
    return controller && controller->IsCompactLayout();
  }
  
@@ -369,7 +369,9 @@
 +}
 +
 +bool ToolbarView::ShouldShowToolbarNewTabButton() const {
-+  return IsCompactLayout() || IsDynamicLayout();
++  // TODO: Show the toolbar new tab button in Compact layout
++  // once we improve it.
++  return IsDynamicLayout();
 +}
 +
 +void ToolbarView::UpdateVerticalTabsCollapseButton() {


### PR DESCRIPTION
closes #1215

<img width="1226" height="831" alt="screenshot" src="https://github.com/user-attachments/assets/b1f7cf78-52ed-45c7-879a-5e558684cdf4" />

it's back!