### PR TITLE
helium/layout/vertical: remove leftover tab context menu option

### DIFF
--- a/patches/helium/ui/layout/vertical.patch
+++ b/patches/helium/ui/layout/vertical.patch
@@ -1580,3 +1580,38 @@
    views::FocusRing::Get(this)->SetColorId(kColorNewTabButtonFocusRing);
    ConfigureInkDropForToolbar(this);
  }
+--- a/chrome/browser/ui/tabs/tab_menu_model.cc
++++ b/chrome/browser/ui/tabs/tab_menu_model.cc
+@@ -297,32 +297,6 @@ void TabMenuModel::Build(TabStripModel*
+ #endif
+   }
+ 
+-  if (tabs::kVerticalTabsToggleInTabContextMenu.Get() && controller) {
+-    // TODO(crbug.com/475222200): When in immersive, swapping between tab
+-    // strip types create duplicate tab strips. Until that is resolved,
+-    // disable the ability to swap between tab strips while in immersive.
+-    BrowserWindowInterface* bwi =
+-        tab_strip->delegate()->GetBrowserWindowInterface();
+-    if (bwi && !bwi->GetFeatures().immersive_mode_controller()->IsEnabled()) {
+-      AddSeparator(ui::NORMAL_SEPARATOR);
+-      if (controller->ShouldDisplayVerticalTabs()) {
+-        AddItemWithStringId(TabStripModel::CommandToggleVertical,
+-                            IDS_SWITCH_TO_HORIZONTAL_TAB);
+-      } else {
+-        AddItemWithStringId(TabStripModel::CommandToggleVertical,
+-                            IDS_SWITCH_TO_VERTICAL_TAB);
+-        const bool use_preview_badge =
+-            base::FeatureList::IsEnabled(tabs::kVerticalTabsPreviewBadge);
+-        const user_education::DisplayNewBadge show_badge =
+-            UserEducationService::MaybeShowNewBadge(
+-                tab_strip->profile(), use_preview_badge
+-                                          ? tabs::kVerticalTabsPreviewBadge
+-                                          : tabs::kVerticalTabsNewBadge);
+-        SetIsNewFeatureAt(GetItemCount() - 1, show_badge);
+-      }
+-    }
+-  }
+-
+   AddSeparator(ui::NORMAL_SEPARATOR);
+ 
+   AddItemWithStringId(TabStripModel::CommandDiscard, IDS_TAB_CXMENU_HIBERNATE);


### PR DESCRIPTION
accidentally left around

fixes #1260