### PR TITLE
utils/clone: clone latest depot_tools instead of relying on DEPS

### DIFF
--- a/utils/clone.py
+++ b/utils/clone.py
@@ -86,12 +86,7 @@ def clone(args): # pylint: disable=too-many-branches, too-many-locals, too-many-
     # Set up staging directory
     ucstaging.mkdir(exist_ok=True)
 
-    get_logger().info('Cloning depot_tools')
-    dt_commit = re.search(r"depot_tools\.git'\s*\+\s*'@'\s*\+\s*'([^']+)',",
-                          Path(args.output / 'DEPS').read_text(encoding=ENCODING)).group(1)
-    if not dt_commit:
-        get_logger().error('Unable to obtain commit for depot_tools checkout')
-        sys.exit(1)
+    get_logger().info('Cloning latest depot_tools')
     if not dtpath.exists():
         dtpath.mkdir()
         run(['git', 'init', '-q'], cwd=dtpath, check=True)
@@ -101,8 +96,8 @@ def clone(args): # pylint: disable=too-many-branches, too-many-locals, too-many-
         ],
             cwd=dtpath,
             check=True)
-    run(['git', 'fetch', '--depth=1', 'origin', dt_commit], cwd=dtpath, check=True)
-    run(['git', 'reset', '--hard', dt_commit], cwd=dtpath, check=True)
+    run(['git', 'fetch', '--depth=1', 'origin', 'HEAD'], cwd=dtpath, check=True)
+    run(['git', 'reset', '--hard', 'FETCH_HEAD'], cwd=dtpath, check=True)
     run(['git', 'clean', '-ffdx'], cwd=dtpath, check=True)
     if iswin:
         (dtpath / 'git.bat').write_text('git')


### PR DESCRIPTION
this is a fix for an outdated depot_tools version in DEPS in the current chromium tag. it fixes the android orderfiles error caused by https://crrev.com/c/7683270, which breaks builds that use cloning.

generally speaking, this is *probably* a bad idea, but i refuse to pin a specific commit and then update it every time google breaks DEPS.