### PR TITLE
helium/core: remove macOS pinch zoom startup dead-zone (#1405)

### DIFF
--- a/patches/helium/core/fix-macos-pinch-zoom-threshold.patch
+++ b/patches/helium/core/fix-macos-pinch-zoom-threshold.patch
@@ -1,0 +1,30 @@
+--- a/content/browser/renderer_host/render_widget_host_view_mac.mm
++++ b/content/browser/renderer_host/render_widget_host_view_mac.mm
+@@ -1712,22 +1712,14 @@ void RenderWidgetHostViewMac::ForwardWheelEvent(
+ }
+ void RenderWidgetHostViewMac::PinchEvent(blink::WebGestureEvent event,
+-                                         bool is_synthetically_injected) {
++                                         bool /*is_synthetically_injected*/) {
+   switch (event.GetType()) {
+     case WebInputEvent::Type::kGesturePinchBegin:
+-      // Require a threshold be reached before the pinch has an effect.
+-      // Synthetic pinches are not subject to this threshold.
+-      pinch_has_reached_zoom_threshold_ = is_synthetically_injected;
++      // Start zooming as soon as the gesture begins for parity with Chromium.
++      // A dead-zone here makes trackpad and emulated pinch feel laggy.
++      pinch_has_reached_zoom_threshold_ = true;
+       pinch_unused_amount_ = 1;
+       break;
+     case WebInputEvent::Type::kGesturePinchUpdate:
+-      if (!pinch_has_reached_zoom_threshold_) {
+-        pinch_unused_amount_ *= event.data.pinch_update.scale;
+-        if (pinch_unused_amount_ < 0.667 || pinch_unused_amount_ > 1.5) {
+-          pinch_has_reached_zoom_threshold_ = true;
+-        }
+-      }
+-      event.data.pinch_update.zoom_disabled =
+-          !pinch_has_reached_zoom_threshold_;
++      event.data.pinch_update.zoom_disabled = false;
+       break;
+     case WebInputEvent::Type::kGesturePinchEnd:
+       // Expected; no special handling required, just send the event.

--- a/patches/series
+++ b/patches/series
@@ -146,6 +146,7 @@ helium/core/clean-context-menu.patch
 helium/core/split-view.patch
 helium/core/fix-tab-sync-unreached-error.patch
 helium/core/fix-instance-id-stuck.patch
+helium/core/fix-macos-pinch-zoom-threshold.patch
 
 helium/core/flags-setup.patch
 helium/core/add-low-power-framerate-flag.patch


### PR DESCRIPTION
This PR fixes a delayed page zoom response at the start of macOS pinch gestures.

Previously, zoom would only activate after a threshold of gesture progression was reached, creating a noticeable “dead zone” and making pinch and shortcut zoom interactions feel less responsive compared to other browsers.

This change removes the threshold-gated startup behavior in RenderWidgetHostViewMac::PinchEvent, allowing zooming to begin immediately when the gesture starts.

The update is intentionally scoped to the macOS pinch input path. A dedicated Helium core patch is introduced and wired through patches/series.

fix #1405 