### PR TITLE
helium/zen: fix division-by-zero when collapsing vts

### DIFF
--- a/patches/helium/ui/experiments/zen-mode.patch
+++ b/patches/helium/ui/experiments/zen-mode.patch
@@ -1856,3 +1856,20 @@
    AddLayerToRegion(border_.layer(), views::LayerRegion::kBelow);
  
    views::AnimatingLayoutManager* animating_layout =
+--- a/chrome/browser/ui/views/tabs/vertical/vertical_pinned_tab_container_view.cc
++++ b/chrome/browser/ui/views/tabs/vertical/vertical_pinned_tab_container_view.cc
+@@ -94,11 +94,12 @@ views::ProposedLayout VerticalPinnedTabC
+     int available_width =
+         size_bounds.width().value() - region_horizontal_padding;
+ 
+-    children_on_row =
++    children_on_row = std::max(
++        1,
+         std::min(children_on_row,
+                  static_cast<int>(std::floor((available_width - child_width) /
+                                              (child_width + kTabPadding)) +
+-                                  1));
++                                  1)));
+ 
+     // Allocate extra space to the tabs.
+     available_width -=


### PR DESCRIPTION
fixes #1390
