### PR TITLE
fix(zen-mode): respect vertical tab strip collapsed state on hover

### DIFF
--- a/patches/helium/ui/experiments/zen-mode.patch
+++ b/patches/helium/ui/experiments/zen-mode.patch
@@ -177,10 +177,6 @@
 +
 +  if (side_chrome_pinned) {
 +    zen_side_chrome_animation_.Reset(1);
-+  } else if (auto* controller =
-+                 tabs::VerticalTabStripStateController::From(browser_);
-+             controller && controller->IsCollapsed()) {
-+    controller->SetCollapsed(false);
 +  }
 +
 +  if (top_chrome_pinned) {
@@ -224,14 +220,6 @@
 +    }
 +  }
 +
-+  // Force the vertical tab strip expanded when not pinned.
-+  if (auto* controller =
-+          tabs::VerticalTabStripStateController::From(browser_)) {
-+    if (zen_mode_enabled_ && !IsZenModeSideChromePinned() &&
-+        controller->IsCollapsed()) {
-+      controller->SetCollapsed(false);
-+    }
-+  }
 +  UpdateZenCollapseButtonVisibility();
 +
 +  if (!zen_mode_enabled_) {


### PR DESCRIPTION
- Remove SetCollapsed(false) call in OnZenModePinnedChromePrefChanged()
- Remove SetCollapsed(false) block in UpdateZenModeState()

These calls were forcing the sidebar to expand when zen mode activated, defeating the hover-collapse mechanism that should keep the sidebar collapsed until explicitly interacted with. The hover-reveal system in vertical_tab_strip_region_view.cc already handles sidebar visibility based on mouse position, so forcing expansion is unnecessary.

Fixes: sidebar never collapses in zen mode despite collapse preference

Diagnosis and patch identification was AI-assisted. Human review recommended.

For your pull request to not get closed without review, please confirm that:

- [x] An issue exists where the maintainers agreed that this should be implemented
      (an approved feature request, or confirmed bug).
- [x] I tested that my contribution works locally, and does not break anything,
      otherwise I have marked my PR as draft.
- [ ] If my contribution is non-trivial, I did not use AI to write most of it.
- [x] I understand that I will be permanently banned from interacting with this
      organization if I lied by checking any of these checkboxes.
