### PR TITLE
helium/ui: add "Copy link" action to downloads context menu

### DIFF
--- a/i18n/source.gen.json
+++ b/i18n/source.gen.json
@@ -402,12 +402,6 @@
     "message": "Extension downloads are disabled"
   },
   {
-    "name": "IDS_DOWNLOAD_MENU_COPY_LINK",
-    "source": "chrome/app/generated_resources.grd",
-    "context": "Download context menu: Copy the download source URL to the clipboard",
-    "message": "Copy link"
-  },
-  {
     "name": "IDS_NTP_CUSTOMIZE_CHROME_CHANGE_WALLPAPER_LABEL",
     "source": "chrome/app/generated_resources.grd",
     "context": "The label for the action button for changing Helium wallpaper in the New Tab Page customize chrome side panel.",

--- a/i18n/source.gen.json
+++ b/i18n/source.gen.json
@@ -402,6 +402,12 @@
     "message": "Extension downloads are disabled"
   },
   {
+    "name": "IDS_DOWNLOAD_MENU_COPY_LINK",
+    "source": "chrome/app/generated_resources.grd",
+    "context": "Download context menu: Copy the download source URL to the clipboard",
+    "message": "Copy link"
+  },
+  {
     "name": "IDS_NTP_CUSTOMIZE_CHROME_CHANGE_WALLPAPER_LABEL",
     "source": "chrome/app/generated_resources.grd",
     "context": "The label for the action button for changing Helium wallpaper in the New Tab Page customize chrome side panel.",

--- a/patches/helium/ui/add-copy-download-link-context-menu.patch
+++ b/patches/helium/ui/add-copy-download-link-context-menu.patch
@@ -1,0 +1,169 @@
+--- a/chrome/browser/download/download_commands.h
++++ b/chrome/browser/download/download_commands.h
+@@ -48,6 +48,7 @@
+     EDIT_WITH_MEDIA_APP = 22,  // Open file using the ChromeOS media app with
+                                // an editing hint.
+     OPEN_HELIUM_SERVICES = 23,  // Open the Services page in settings.
++    COPY_DOWNLOAD_LINK = 24,  // Copy the download source URL to the clipboard.
+
+-    kMaxValue = OPEN_HELIUM_SERVICES,  // Keep last.
++    kMaxValue = COPY_DOWNLOAD_LINK,  // Keep last.
+   };
+--- a/chrome/browser/download/download_ui_model.cc
++++ b/chrome/browser/download/download_ui_model.cc
+@@ -40,5 +40,6 @@
+ #include "net/base/mime_util.h"
+ #include "third_party/blink/public/common/mime_util/mime_util.h"
++#include "ui/base/clipboard/scoped_clipboard_writer.h"
+ #include "ui/base/l10n/l10n_util.h"
+ #include "ui/base/l10n/time_format.h"
+ #include "ui/base/text/bytes_formatting.h"
+@@ -640,4 +641,5 @@
+     case DownloadCommands::RETRY:
+     case DownloadCommands::CANCEL_DEEP_SCAN:
+     case DownloadCommands::OPEN_HELIUM_SERVICES:
++    case DownloadCommands::COPY_DOWNLOAD_LINK:
+       return true;
+@@ -683,4 +685,5 @@
+     case DownloadCommands::OPEN_WITH_MEDIA_APP:
+     case DownloadCommands::EDIT_WITH_MEDIA_APP:
+     case DownloadCommands::OPEN_HELIUM_SERVICES:
++    case DownloadCommands::COPY_DOWNLOAD_LINK:
+       return false;
+@@ -741,4 +744,9 @@
+           ui::PAGE_TRANSITION_LINK, false),
+           /*navigation_handle_callback=*/{});
+       break;
++    case DownloadCommands::COPY_DOWNLOAD_LINK: {
++      ui::ScopedClipboardWriter scw(ui::ClipboardBuffer::kCopyPaste);
++      scw.WriteText(base::UTF8ToUTF16(GetURL().spec()));
++      break;
++    }
+     case DownloadCommands::OPEN_SAFE_BROWSING_SETTING:
+--- a/chrome/browser/download/download_item_model.cc
++++ b/chrome/browser/download/download_item_model.cc
+@@ -713,4 +713,5 @@
+     case DownloadCommands::RETRY:
+     case DownloadCommands::CANCEL_DEEP_SCAN:
+     case DownloadCommands::OPEN_HELIUM_SERVICES:
++    case DownloadCommands::COPY_DOWNLOAD_LINK:
+       return DownloadUIModel::IsCommandEnabled(download_commands, command);
+@@ -757,4 +758,5 @@
+     case DownloadCommands::OPEN_WITH_MEDIA_APP:
+     case DownloadCommands::EDIT_WITH_MEDIA_APP:
+     case DownloadCommands::OPEN_HELIUM_SERVICES:
++    case DownloadCommands::COPY_DOWNLOAD_LINK:
+       return false;
+@@ -865,5 +866,6 @@
+     case DownloadCommands::OPEN_WITH_MEDIA_APP:
+     case DownloadCommands::EDIT_WITH_MEDIA_APP:
+     case DownloadCommands::OPEN_HELIUM_SERVICES:
++    case DownloadCommands::COPY_DOWNLOAD_LINK:
+       DownloadUIModel::ExecuteCommand(download_commands, command);
+       break;
+--- a/chrome/browser/download/offline_item_model.cc
++++ b/chrome/browser/download/offline_item_model.cc
+@@ -334,4 +334,5 @@
+     case DownloadCommands::RETRY:
+     case DownloadCommands::CANCEL_DEEP_SCAN:
+     case DownloadCommands::OPEN_HELIUM_SERVICES:
++    case DownloadCommands::COPY_DOWNLOAD_LINK:
+       return DownloadUIModel::IsCommandEnabled(download_commands, command);
+@@ -370,4 +371,5 @@
+     case DownloadCommands::OPEN_WITH_MEDIA_APP:
+     case DownloadCommands::EDIT_WITH_MEDIA_APP:
+     case DownloadCommands::OPEN_HELIUM_SERVICES:
++    case DownloadCommands::COPY_DOWNLOAD_LINK:
+       return false;
+@@ -404,5 +405,6 @@
+     case DownloadCommands::OPEN_WITH_MEDIA_APP:
+     case DownloadCommands::EDIT_WITH_MEDIA_APP:
+     case DownloadCommands::OPEN_HELIUM_SERVICES:
++    case DownloadCommands::COPY_DOWNLOAD_LINK:
+       DownloadUIModel::ExecuteCommand(download_commands, command);
+       break;
+--- a/chrome/browser/download/download_stats.h
++++ b/chrome/browser/download/download_stats.h
+@@ -196,5 +196,7 @@
+   // kReviewEnabled = 34,
+   // kReviewClicked = 35,
+   kNotReached = 36,  // Should not be possible to hit
+-  kMaxValue = kNotReached
++  kCopyDownloadLinkEnabled = 37,
++  kCopyDownloadLinkClicked = 38,
++  kMaxValue = kCopyDownloadLinkClicked
+ };
+--- a/chrome/browser/download/download_stats.cc
++++ b/chrome/browser/download/download_stats.cc
+@@ -162,5 +162,8 @@
+     case DownloadCommands::BYPASS_DEEP_SCANNING_AND_OPEN:
+       return clicked ? DownloadUiContextMenuAction::kBypassDeepScanningClicked
+                      : DownloadUiContextMenuAction::kBypassDeepScanningEnabled;
++    case DownloadCommands::Command::COPY_DOWNLOAD_LINK:
++      return clicked ? DownloadUiContextMenuAction::kCopyDownloadLinkClicked
++                     : DownloadUiContextMenuAction::kCopyDownloadLinkEnabled;
+ 
+     // The following are not actually visible in the context menu so should
+--- a/chrome/browser/download/bubble/download_bubble_ui_controller.cc
++++ b/chrome/browser/download/bubble/download_bubble_ui_controller.cc
+@@ -334,5 +334,6 @@
+     case DownloadCommands::CANCEL_DEEP_SCAN:
+     case DownloadCommands::OPEN_SAFE_BROWSING_SETTING:
+     case DownloadCommands::OPEN_HELIUM_SERVICES:
++    case DownloadCommands::COPY_DOWNLOAD_LINK:
+       commands.ExecuteCommand(command);
+       break;
+--- a/chrome/browser/download/download_ui_context_menu.cc
++++ b/chrome/browser/download/download_ui_context_menu.cc
+@@ -192,4 +192,7 @@
+     case DownloadCommands::BYPASS_DEEP_SCANNING_AND_OPEN:
+       id = IDS_OPEN_DOWNLOAD_NOW;
+       break;
++    case DownloadCommands::COPY_DOWNLOAD_LINK:
++      id = IDS_DOWNLOAD_MENU_COPY_LINK;
++      break;
+     // These commands are not supported on the context menu.
+@@ -240,4 +243,7 @@
+   in_progress_download_menu_model_->AddItem(
+       DownloadCommands::PAUSE, GetLabelForCommandId(DownloadCommands::PAUSE));
+
++  in_progress_download_menu_model_->AddItem(
++      DownloadCommands::COPY_DOWNLOAD_LINK,
++      GetLabelForCommandId(DownloadCommands::COPY_DOWNLOAD_LINK));
+   if (is_download) {
+@@ -273,4 +279,7 @@
+   in_progress_download_paused_menu_model_->AddItem(
+       DownloadCommands::RESUME, GetLabelForCommandId(DownloadCommands::RESUME));
+
++  in_progress_download_paused_menu_model_->AddItem(
++      DownloadCommands::COPY_DOWNLOAD_LINK,
++      GetLabelForCommandId(DownloadCommands::COPY_DOWNLOAD_LINK));
+   if (is_download) {
+@@ -313,4 +322,7 @@
+     finished_download_menu_model_->AddItem(
+         DownloadCommands::SHOW_IN_FOLDER,
+         GetLabelForCommandId(DownloadCommands::SHOW_IN_FOLDER));
++    finished_download_menu_model_->AddItem(
++        DownloadCommands::COPY_DOWNLOAD_LINK,
++        GetLabelForCommandId(DownloadCommands::COPY_DOWNLOAD_LINK));
+     finished_download_menu_model_->AddSeparator(ui::NORMAL_SEPARATOR);
+@@ -334,3 +346,6 @@
+   interrupted_download_menu_model_->AddItem(
+       DownloadCommands::RESUME, GetLabelForCommandId(DownloadCommands::RESUME));
++  interrupted_download_menu_model_->AddItem(
++      DownloadCommands::COPY_DOWNLOAD_LINK,
++      GetLabelForCommandId(DownloadCommands::COPY_DOWNLOAD_LINK));
+ #if BUILDFLAG(IS_WIN)
+--- a/chrome/app/generated_resources.grd
++++ b/chrome/app/generated_resources.grd
+@@ -2745,6 +2745,10 @@
+                    desc="Download context menu: Resume download">
+             &amp;Resume
+           </message>
++          <message name="IDS_DOWNLOAD_MENU_COPY_LINK"
++                   desc="Download context menu: Copy the download source URL to the clipboard">
++            Copy link
++          </message>
+           <message name="IDS_DOWNLOAD_MENU_DISCARD"
+                    desc="Download context menu: Discard malicious download">
+             &amp;Discard

--- a/patches/helium/ui/add-copy-download-link-context-menu.patch
+++ b/patches/helium/ui/add-copy-download-link-context-menu.patch
@@ -18,20 +18,20 @@
  #include "ui/base/l10n/l10n_util.h"
  #include "ui/base/l10n/time_format.h"
  #include "ui/base/text/bytes_formatting.h"
-@@ -640,4 +641,5 @@
+@@ -639,4 +641,5 @@
      case DownloadCommands::RETRY:
      case DownloadCommands::CANCEL_DEEP_SCAN:
      case DownloadCommands::OPEN_HELIUM_SERVICES:
 +    case DownloadCommands::COPY_DOWNLOAD_LINK:
        return true;
-@@ -683,4 +685,5 @@
+@@ -682,4 +685,5 @@
      case DownloadCommands::OPEN_WITH_MEDIA_APP:
      case DownloadCommands::EDIT_WITH_MEDIA_APP:
      case DownloadCommands::OPEN_HELIUM_SERVICES:
 +    case DownloadCommands::COPY_DOWNLOAD_LINK:
        return false;
-@@ -741,4 +744,9 @@
-           ui::PAGE_TRANSITION_LINK, false),
+@@ -730,4 +744,9 @@
+                                  ui::PAGE_TRANSITION_LINK, false),
            /*navigation_handle_callback=*/{});
        break;
 +    case DownloadCommands::COPY_DOWNLOAD_LINK: {
@@ -54,7 +54,7 @@
      case DownloadCommands::OPEN_HELIUM_SERVICES:
 +    case DownloadCommands::COPY_DOWNLOAD_LINK:
        return false;
-@@ -865,5 +866,6 @@
+@@ -865,5 +867,6 @@
      case DownloadCommands::OPEN_WITH_MEDIA_APP:
      case DownloadCommands::EDIT_WITH_MEDIA_APP:
      case DownloadCommands::OPEN_HELIUM_SERVICES:
@@ -75,7 +75,7 @@
      case DownloadCommands::OPEN_HELIUM_SERVICES:
 +    case DownloadCommands::COPY_DOWNLOAD_LINK:
        return false;
-@@ -404,5 +405,6 @@
+@@ -404,5 +406,6 @@
      case DownloadCommands::OPEN_WITH_MEDIA_APP:
      case DownloadCommands::EDIT_WITH_MEDIA_APP:
      case DownloadCommands::OPEN_HELIUM_SERVICES:
@@ -156,7 +156,7 @@
  #if BUILDFLAG(IS_WIN)
 --- a/chrome/app/generated_resources.grd
 +++ b/chrome/app/generated_resources.grd
-@@ -2745,6 +2745,10 @@
+@@ -2767,6 +2767,10 @@
                     desc="Download context menu: Resume download">
              &amp;Resume
            </message>

--- a/patches/helium/ui/add-copy-download-link-context-menu.patch
+++ b/patches/helium/ui/add-copy-download-link-context-menu.patch
@@ -18,19 +18,19 @@
  #include "ui/base/l10n/l10n_util.h"
  #include "ui/base/l10n/time_format.h"
  #include "ui/base/text/bytes_formatting.h"
-@@ -639,4 +641,5 @@
+@@ -640,4 +641,5 @@
      case DownloadCommands::RETRY:
      case DownloadCommands::CANCEL_DEEP_SCAN:
      case DownloadCommands::OPEN_HELIUM_SERVICES:
 +    case DownloadCommands::COPY_DOWNLOAD_LINK:
        return true;
-@@ -682,4 +685,5 @@
+@@ -683,4 +685,5 @@
      case DownloadCommands::OPEN_WITH_MEDIA_APP:
      case DownloadCommands::EDIT_WITH_MEDIA_APP:
      case DownloadCommands::OPEN_HELIUM_SERVICES:
 +    case DownloadCommands::COPY_DOWNLOAD_LINK:
        return false;
-@@ -730,4 +744,9 @@
+@@ -741,4 +744,9 @@
                                   ui::PAGE_TRANSITION_LINK, false),
            /*navigation_handle_callback=*/{});
        break;
@@ -120,7 +120,7 @@
        id = IDS_OPEN_DOWNLOAD_NOW;
        break;
 +    case DownloadCommands::COPY_DOWNLOAD_LINK:
-+      id = IDS_DOWNLOAD_MENU_COPY_LINK;
++      id = IDS_DOWNLOAD_COPY_DOWNLOAD_LINK;
 +      break;
      // These commands are not supported on the context menu.
 @@ -240,4 +243,7 @@
@@ -154,16 +154,3 @@
 +      DownloadCommands::COPY_DOWNLOAD_LINK,
 +      GetLabelForCommandId(DownloadCommands::COPY_DOWNLOAD_LINK));
  #if BUILDFLAG(IS_WIN)
---- a/chrome/app/generated_resources.grd
-+++ b/chrome/app/generated_resources.grd
-@@ -2767,6 +2767,10 @@
-                    desc="Download context menu: Resume download">
-             &amp;Resume
-           </message>
-+          <message name="IDS_DOWNLOAD_MENU_COPY_LINK"
-+                   desc="Download context menu: Copy the download source URL to the clipboard">
-+            Copy link
-+          </message>
-           <message name="IDS_DOWNLOAD_MENU_DISCARD"
-                    desc="Download context menu: Discard malicious download">
-             &amp;Discard

--- a/patches/helium/ui/add-copy-download-link-context-menu.patch
+++ b/patches/helium/ui/add-copy-download-link-context-menu.patch
@@ -5,7 +5,7 @@
                                 // an editing hint.
      OPEN_HELIUM_SERVICES = 23,  // Open the Services page in settings.
 +    COPY_DOWNLOAD_LINK = 24,  // Copy the download source URL to the clipboard.
-
+ 
 -    kMaxValue = OPEN_HELIUM_SERVICES,  // Keep last.
 +    kMaxValue = COPY_DOWNLOAD_LINK,  // Keep last.
    };
@@ -126,7 +126,7 @@
 @@ -240,4 +243,7 @@
    in_progress_download_menu_model_->AddItem(
        DownloadCommands::PAUSE, GetLabelForCommandId(DownloadCommands::PAUSE));
-
+ 
 +  in_progress_download_menu_model_->AddItem(
 +      DownloadCommands::COPY_DOWNLOAD_LINK,
 +      GetLabelForCommandId(DownloadCommands::COPY_DOWNLOAD_LINK));
@@ -134,7 +134,7 @@
 @@ -273,4 +279,7 @@
    in_progress_download_paused_menu_model_->AddItem(
        DownloadCommands::RESUME, GetLabelForCommandId(DownloadCommands::RESUME));
-
+ 
 +  in_progress_download_paused_menu_model_->AddItem(
 +      DownloadCommands::COPY_DOWNLOAD_LINK,
 +      GetLabelForCommandId(DownloadCommands::COPY_DOWNLOAD_LINK));

--- a/patches/series
+++ b/patches/series
@@ -244,6 +244,7 @@ helium/ui/remove-dead-toolbar-actions.patch
 helium/ui/remove-dead-profile-actions.patch
 helium/ui/clean-up-installed-extension-bubble.patch
 helium/ui/add-specific-error-for-disabled-extension-downloads.patch
+helium/ui/add-copy-download-link-context-menu.patch
 helium/ui/selected-keyword-view.patch
 helium/ui/bookmark-button-bg-fix.patch
 helium/ui/restyle-ntp-tiles.patch

--- a/patches/series
+++ b/patches/series
@@ -244,7 +244,6 @@ helium/ui/remove-dead-toolbar-actions.patch
 helium/ui/remove-dead-profile-actions.patch
 helium/ui/clean-up-installed-extension-bubble.patch
 helium/ui/add-specific-error-for-disabled-extension-downloads.patch
-helium/ui/add-copy-download-link-context-menu.patch
 helium/ui/selected-keyword-view.patch
 helium/ui/bookmark-button-bg-fix.patch
 helium/ui/restyle-ntp-tiles.patch
@@ -281,6 +280,7 @@ helium/ui/remove-zoom-action.patch
 helium/ui/layout/core.patch
 helium/ui/layout/settings.patch
 helium/ui/layout/context-menu.patch
+helium/ui/add-copy-download-link-context-menu.patch
 helium/ui/layout/shortcuts.patch
 helium/ui/layout/centered-address-bar.patch
 helium/ui/layout/frame-grab-handle.patch

--- a/patches/series
+++ b/patches/series
@@ -280,7 +280,12 @@ helium/ui/remove-zoom-action.patch
 helium/ui/layout/core.patch
 helium/ui/layout/settings.patch
 helium/ui/layout/context-menu.patch
+helium/ui/remove-zoom-action.patch
 helium/ui/add-copy-download-link-context-menu.patch
+
+helium/ui/layout/core.patch
+helium/ui/layout/settings.patch
+helium/ui/layout/context-menu.patch
 helium/ui/layout/shortcuts.patch
 helium/ui/layout/centered-address-bar.patch
 helium/ui/layout/frame-grab-handle.patch


### PR DESCRIPTION
For your pull request to not get closed without review, please confirm that:

- [x] An issue exists where the maintainers agreed that this should be implemented
      (an approved feature request, or confirmed bug).
- [x] I tested that my contribution works locally, and does not break anything,
      otherwise I have marked my PR as draft.
- [ ] If my contribution is non-trivial, I did not use AI to write most of it.
- [x] I understand that I will be permanently banned from interacting with this
      organization if I lied by checking any of these checkboxes.

Tested on (check one or more):
- [x] Windows
- [ ] macOS
- [x] Linux

---
I tested my PR only on Linux at the moment, leaving this as a draft until I test on Windows, I'm building helium there at this moment

Edit : Tested also on Windows
Video of manual test below :

[Screencast from 2026-04-29 00-09-03.webm](https://github.com/user-attachments/assets/4777dce5-9d98-4750-b835-d23fcb20a30b)

Closes #897

Adds a "Copy link" option to the download context menu that copies the original download source URL to the clipboard. Available on in-progress, paused, finished, and interrupted downloads.

## Changes
- New `COPY_DOWNLOAD_LINK` command wired through all model/controller layers
- Clipboard write implemented via `ScopedClipboardWriter` in `DownloadUIModel::ExecuteCommand`
- Menu item added to all four context menu states in `download_ui_context_menu.cc`
- Stats tracking added (`kCopyDownloadLinkEnabled`, `kCopyDownloadLinkClicked`)
- New `IDS_DOWNLOAD_MENU_COPY_LINK` string ("Copy link") in `generated_resources.grd`
