### PR TITLE
feat: add native profile switching shortcut

### DIFF
--- a/patches/helium/core/profile-switching-shortcut.patch
+++ b/patches/helium/core/profile-switching-shortcut.patch
@@ -1,0 +1,126 @@
+--- a/chrome/app/chrome_command_ids.h
++++ b/chrome/app/chrome_command_ids.h
+@@ -96,6 +96,7 @@
+ 
+ // Helium commands
+ #define IDC_COPY_OR_INSPECT_SHORTCUT    34080
++#define IDC_SWITCH_TO_NEXT_PROFILE      34090
+ 
+ #if BUILDFLAG(IS_CHROMEOS)
+ // Move window to other user commands
+--- a/chrome/browser/ui/browser_command_controller.cc
++++ b/chrome/browser/ui/browser_command_controller.cc
+@@ -8,6 +8,7 @@
+ 
+ #include <algorithm>
+ #include <string>
++#include <vector>
+ 
+ #include "base/check_deref.h"
+ #include "base/command_line.h"
+@@ -33,6 +34,9 @@
+ #include "chrome/browser/lifetime/application_lifetime.h"
+ #include "chrome/browser/prefs/incognito_mode_prefs.h"
+ #include "chrome/browser/profiles/profile.h"
++#include "chrome/browser/profiles/profile_attributes_entry.h"
++#include "chrome/browser/profiles/profile_attributes_storage.h"
++#include "chrome/browser/profiles/profile_manager.h"
+ #include "chrome/browser/profiles/profile_window.h"
+ #include "chrome/browser/sessions/tab_restore_service_factory.h"
+ #include "chrome/browser/sharing_hub/sharing_hub_features.h"
+@@ -225,6 +229,43 @@
+   actions::ActionManager::Get().FindAction(id, scope)->InvokeAction();
+ }
+ 
++void SwitchToNextProfile(Profile* profile) {
++  if (!profile || !g_browser_process ||
++      !g_browser_process->profile_manager()) {
++    return;
++  }
++
++  ProfileManager* profile_manager = g_browser_process->profile_manager();
++  std::vector<ProfileAttributesEntry*> profiles =
++      profile_manager->GetProfileAttributesStorage()
++          .GetAllProfilesAttributesSortedForDisplay();
++
++  std::erase_if(profiles, [](ProfileAttributesEntry* entry) {
++    return !entry || entry->IsOmitted() || entry->IsSigninRequired();
++  });
++
++  if (profiles.size() < 2) {
++    return;
++  }
++
++  const base::FilePath current_path = profile->GetOriginalProfile()->GetPath();
++  auto current = std::ranges::find_if(
++      profiles, [&current_path](ProfileAttributesEntry* entry) {
++        return entry->GetPath() == current_path;
++      });
++
++  size_t next_index = 0;
++  if (current != profiles.end()) {
++    next_index = (std::distance(profiles.begin(), current) + 1) %
++                 profiles.size();
++  }
++
++  const base::FilePath next_profile_path = profiles[next_index]->GetPath();
++  if (next_profile_path != current_path) {
++    profiles::SwitchToProfile(next_profile_path, /*always_create=*/false);
++  }
++}
++
+ }  // namespace
+ 
+ ///////////////////////////////////////////////////////////////////////////////
+@@ -459,8 +497,9 @@ bool BrowserCommandController::IsReserve
+          command_id == IDC_NEW_WINDOW || command_id == IDC_RESTORE_TAB ||
+          command_id == IDC_SELECT_NEXT_TAB ||
+          command_id == IDC_SELECT_PREVIOUS_TAB || command_id == IDC_EXIT ||
+          command_id == IDC_COPY_OR_INSPECT_SHORTCUT || command_id == IDC_DEV_TOOLS ||
+-         command_id == IDC_DEV_TOOLS_TOGGLE || command_id == IDC_TAB_SEARCH;
++         command_id == IDC_DEV_TOOLS_TOGGLE || command_id == IDC_TAB_SEARCH ||
++         command_id == IDC_SWITCH_TO_NEXT_PROFILE;
+ }
+ 
+ void BrowserCommandController::TabStateChanged() {
+@@ -1269,6 +1308,9 @@ bool BrowserCommandController::ExecuteCo
+           copy ? IDC_COPY_URL : IDC_DEV_TOOLS_INSPECT,
+           disposition, time_stamp);
+     }
++    case IDC_SWITCH_TO_NEXT_PROFILE:
++      SwitchToNextProfile(profile());
++      break;
+     // Hosted App commands
+     case IDC_COPY_URL:
+       CopyURL(browser_, browser_->tab_strip_model()->GetActiveWebContents());
+@@ -1738,6 +1780,8 @@ void BrowserCommandController::InitComma
+   command_updater_.UpdateCommandEnabled(IDC_WEB_APP_MENU_APP_INFO,
+                                         is_web_app_or_custom_tab);
+   UpdateCommandForCopyInspect();
++  command_updater_.UpdateCommandEnabled(IDC_SWITCH_TO_NEXT_PROFILE,
++                                        normal_window);
+ 
+   // Tab management commands
+   const bool supports_tabs =
+--- a/chrome/browser/global_keyboard_shortcuts_mac.mm
++++ b/chrome/browser/global_keyboard_shortcuts_mac.mm
+@@ -154,6 +154,8 @@ const std::vector<KeyboardShortcutData>&
+       {true,  false, false, false, kVK_ANSI_Keypad9,      IDC_SELECT_LAST_TAB},
+ 
+       {true,  true,  false, false, kVK_ANSI_M,            IDC_SHOW_AVATAR_MENU},
++      {true,  false, true,  false, kVK_Tab,
++       IDC_SWITCH_TO_NEXT_PROFILE},
+       {true,  false, false, true,  kVK_ANSI_L,            IDC_SHOW_DOWNLOADS},
+       {true,  true,  false, false, kVK_ANSI_I,            IDC_DEV_TOOLS},
+       {true,  true,  false, false, kVK_ANSI_E,            IDC_DEV_TOOLS_INSPECT},
+--- a/chrome/browser/ui/cocoa/accelerators_cocoa.mm
++++ b/chrome/browser/ui/cocoa/accelerators_cocoa.mm
+@@ -50,6 +50,8 @@ const struct AcceleratorMapping {
+     {IDC_SAVE_PAGE, ui::EF_COMMAND_DOWN, ui::VKEY_S},
+     {IDC_SHOW_BOOKMARK_BAR, ui::EF_COMMAND_DOWN | ui::EF_SHIFT_DOWN,
+      ui::VKEY_B},
++    {IDC_SWITCH_TO_NEXT_PROFILE, ui::EF_COMMAND_DOWN | ui::EF_CONTROL_DOWN,
++     ui::VKEY_TAB},
+     {IDC_SHOW_BOOKMARK_MANAGER, ui::EF_COMMAND_DOWN | ui::EF_ALT_DOWN,
+      ui::VKEY_B},
+     {IDC_BOOKMARK_THIS_TAB, ui::EF_COMMAND_DOWN, ui::VKEY_D},

--- a/patches/series
+++ b/patches/series
@@ -182,6 +182,7 @@ helium/core/webrtc-default-handling-policy.patch
 helium/core/browser-window-context-menu.patch
 helium/core/disable-ntp-footer.patch
 helium/core/tab-cycling-mru.patch
+helium/core/profile-switching-shortcut.patch
 helium/core/component-updates.patch
 helium/core/fixups-component-setup.patch
 helium/core/fixups-chrome-webstore-script.patch


### PR DESCRIPTION
## Summary
- add a native Cmd+Ctrl+Tab command to switch to the next available browser profile
- reuse Chromium profile attributes and SwitchToProfile instead of adding a parallel profile model
- wire the patch into the Helium core patch series

## Checks
- python3 devutils/check_patch_files.py
- git diff --check -- patches/series patches/helium/core/profile-switching-shortcut.patch
- cd devutils && python3 -m pytest -o addopts='' tests

Note: utils tests were also run with coverage flags disabled; they hit the existing macOS assumption that /bin/false exists.