### PR TITLE
helium/ui/layout: fix centered address bar popup flicker

### DIFF
--- a/patches/helium/ui/experiments/zen-mode.patch
+++ b/patches/helium/ui/experiments/zen-mode.patch
@@ -1363,7 +1363,7 @@
 +}
 --- a/chrome/browser/ui/views/toolbar/toolbar_view.cc
 +++ b/chrome/browser/ui/views/toolbar/toolbar_view.cc
-@@ -1918,6 +1918,16 @@ void ToolbarView::UpdateToolbarLayout()
+@@ -1956,6 +1956,16 @@ void ToolbarView::UpdateToolbarLayout()
    InvalidateLayout();
  }
  
@@ -1380,7 +1380,7 @@
  bool ToolbarView::IsCompactLayout() const {
    auto* controller =
        HeliumLayoutStateController::From(browser_view_->browser());
-@@ -1955,8 +1965,11 @@ void ToolbarView::UpdateVerticalTabsColl
+@@ -1993,8 +2003,11 @@ void ToolbarView::UpdateVerticalTabsColl
  
    auto* controller =
        tabs::VerticalTabStripStateController::From(browser_view_->browser());

--- a/patches/helium/ui/layout/centered-address-bar.patch
+++ b/patches/helium/ui/layout/centered-address-bar.patch
@@ -25,18 +25,19 @@
    registry->RegisterBooleanPref(prefs::kShowHomeButton, false,
 --- a/chrome/browser/ui/views/toolbar/toolbar_view.h
 +++ b/chrome/browser/ui/views/toolbar/toolbar_view.h
-@@ -342,6 +342,10 @@ class ToolbarView : public views::Access
+@@ -342,6 +342,11 @@ class ToolbarView : public views::Access
  
    void OnShowMediaButtonChanged();
  
 +  void OnLocationBarCenteredChanged();
 +
-+  void MaybeCenterLocationBar();
++  gfx::Rect GetCenteredLocationBarBounds(gfx::Rect bounds,
++                                         int toolbar_width) const;
 +
    void OnTouchUiChanged();
  
    void NewTabButtonPressed(const ui::Event& event);
-@@ -457,6 +461,8 @@ class ToolbarView : public views::Access
+@@ -457,6 +462,8 @@ class ToolbarView : public views::Access
  
    BooleanPrefMember show_media_button_;
  
@@ -47,7 +48,15 @@
    // The display mode used when laying out the toolbar.
 --- a/chrome/browser/ui/views/toolbar/toolbar_view.cc
 +++ b/chrome/browser/ui/views/toolbar/toolbar_view.cc
-@@ -212,6 +212,27 @@ constexpr int kBrowserAppMenuRefreshColl
+@@ -12,6 +12,7 @@
+ #include "base/containers/fixed_flat_map.h"
+ #include "base/feature_list.h"
+ #include "base/functional/bind.h"
++#include "base/functional/callback.h"
+ #include "base/i18n/number_formatting.h"
+ #include "base/i18n/rtl.h"
+ #include "base/metrics/histogram_macros.h"
+@@ -212,6 +213,61 @@ constexpr int kBrowserAppMenuRefreshColl
  constexpr int kLargeSpaceBetweenButtons = 6;
  constexpr int kInsideBorderAroundGlicButtons = 2;
  constexpr int kOutsideBorderAroundGlicButtons = 11;
@@ -72,10 +81,44 @@
 +  }
 +  return 0;
 +}
++
++class CenteredLocationBarLayout : public views::FlexLayout {
++ public:
++  using GetCenteredBoundsCallback =
++      base::RepeatingCallback<gfx::Rect(gfx::Rect, int)>;
++
++  CenteredLocationBarLayout(views::View* location_bar,
++                            GetCenteredBoundsCallback callback)
++      : location_bar_(location_bar), callback_(std::move(callback)) {}
++
++  CenteredLocationBarLayout(const CenteredLocationBarLayout&) = delete;
++  CenteredLocationBarLayout& operator=(const CenteredLocationBarLayout&) =
++      delete;
++
++  ~CenteredLocationBarLayout() override = default;
++
++ protected:
++  views::ProposedLayout CalculateProposedLayout(
++      const views::SizeBounds& size_bounds) const override {
++    views::ProposedLayout layout =
++        views::FlexLayout::CalculateProposedLayout(size_bounds);
++    views::ChildLayout* const location_bar_layout =
++        layout.GetLayoutFor(location_bar_);
++    if (location_bar_layout && location_bar_layout->visible) {
++      location_bar_layout->bounds =
++          callback_.Run(location_bar_layout->bounds, layout.host_size.width());
++    }
++    return layout;
++  }
++
++ private:
++  const raw_ptr<views::View> location_bar_;
++  GetCenteredBoundsCallback callback_;
++};
  
  }  // namespace
  
-@@ -681,6 +702,11 @@ void ToolbarView::Init() {
+@@ -681,6 +737,11 @@ void ToolbarView::Init() {
      OnShowMediaButtonChanged();
    }
  
@@ -87,15 +130,20 @@
    InitLayout();
  
    for (auto* button : std::array<views::Button*, 5>{back_, forward_, reload_,
-@@ -1505,6 +1531,7 @@ void ToolbarView::Layout(PassKey) {
-   // Call super implementation to ensure layout manager and child layouts
-   // happen.
-   LayoutSuperclass<AccessiblePaneView>(this);
-+  MaybeCenterLocationBar();
- }
+@@ -1569,7 +1630,11 @@ void ToolbarView::InitLayout() {
+                                views::MaximumFlexSizeRule::kUnbounded)
+           .WithOrder(kLocationBarFlexOrder);
  
- void ToolbarView::OnThemeChanged() {
-@@ -1938,6 +1965,48 @@ void ToolbarView::OnShowMediaButtonChang
+-  layout_manager_ = SetLayoutManager(std::make_unique<views::FlexLayout>());
++  layout_manager_ =
++      SetLayoutManager(std::make_unique<CenteredLocationBarLayout>(
++          location_bar_view_,
++          base::BindRepeating(&ToolbarView::GetCenteredLocationBarBounds,
++                              base::Unretained(this))));
+ 
+   layout_manager_->SetOrientation(views::LayoutOrientation::kHorizontal)
+       .SetCrossAxisAlignment(views::LayoutAlignment::kCenter)
+@@ -1938,6 +2003,46 @@ void ToolbarView::OnShowMediaButtonChang
    InvalidateLayout();
  }
  
@@ -103,19 +151,18 @@
 +  InvalidateLayout();
 +}
 +
-+void ToolbarView::MaybeCenterLocationBar() {
++gfx::Rect ToolbarView::GetCenteredLocationBarBounds(gfx::Rect bounds,
++                                                    int toolbar_width) const {
 +  if (display_mode_ != DisplayMode::kNormal ||
 +      !location_bar_is_centered_.GetValue()) {
-+    return;
++    return bounds;
 +  }
 +
-+  const int toolbar_width = width();
 +  const int width_reduction = CenteredLocationBarWidthReduction(toolbar_width);
 +  if (width_reduction == 0) {
-+    return;
++    return bounds;
 +  }
 +
-+  gfx::Rect bounds = location_bar_view_->bounds();
 +  const int centered_width =
 +      std::clamp(bounds.width() - width_reduction,
 +                 location_bar_view_->GetMinimumSize().width(),
@@ -137,8 +184,7 @@
 +
 +  bounds.set_x(centered_x);
 +  bounds.set_width(centered_width);
-+
-+  location_bar_view_->SetBoundsRect(bounds);
++  return bounds;
 +}
 +
  void ToolbarView::OnTouchUiChanged() {

--- a/patches/helium/ui/layout/compact.patch
+++ b/patches/helium/ui/layout/compact.patch
@@ -175,7 +175,7 @@
    // TODO(pbos): Investigate whether the side panels should be creatable when
 --- a/chrome/browser/ui/views/toolbar/toolbar_view.cc
 +++ b/chrome/browser/ui/views/toolbar/toolbar_view.cc
-@@ -75,6 +75,7 @@
+@@ -76,6 +76,7 @@
  #include "chrome/browser/ui/views/extensions/extensions_toolbar_desktop.h"
  #include "chrome/browser/ui/views/frame/browser_view.h"
  #include "chrome/browser/ui/views/frame/custom_corners_background.h"
@@ -183,7 +183,7 @@
  #include "chrome/browser/ui/views/frame/top_container_view.h"
  #include "chrome/browser/ui/views/glic/glic_button_interface.h"
  #include "chrome/browser/ui/views/global_media_controls/media_toolbar_button_contextual_menu.h"
-@@ -182,6 +183,7 @@ DEFINE_UI_CLASS_PROPERTY_KEY(bool, kActi
+@@ -183,6 +184,7 @@ DEFINE_UI_CLASS_PROPERTY_KEY(bool, kActi
  
  namespace {
  
@@ -191,7 +191,7 @@
  constexpr int kToolbarFlexOrderOffset = 1000;
  constexpr int kLocationBarFlexOrder = kToolbarFlexOrderOffset + 1;
  constexpr int kToolbarActionsFlexOrder = kToolbarFlexOrderOffset + 2;
-@@ -1309,6 +1311,22 @@ bool ToolbarView::IsRectInWindowCaption(
+@@ -1344,6 +1346,22 @@ bool ToolbarView::IsRectInWindowCaption(
      return gfx::ToEnclosingRect(rect_in_target_coords_f);
    };
  
@@ -214,7 +214,7 @@
    // Check each child view to see if the rect intersects with
    // any clickable elements. If it does, check if the click is actually on that
    // element. False if on a clickable element, true if not on a clickable element.
-@@ -1697,6 +1715,30 @@ void ToolbarView::LayoutCommon() {
+@@ -1735,6 +1753,30 @@ void ToolbarView::LayoutCommon() {
    // Cast button visibility is controlled externally.
  }
  
@@ -245,7 +245,7 @@
  void ToolbarView::UpdateToolbarLayout() {
    if (!location_bar_) {
      return;
-@@ -1707,7 +1749,10 @@ void ToolbarView::UpdateToolbarLayout()
+@@ -1745,7 +1787,10 @@ void ToolbarView::UpdateToolbarLayout()
                                 views::MaximumFlexSizeRule::kPreferred);
    const int location_bar_margin =
        GetLayoutConstant(LayoutConstant::kLocationBarMargin);
@@ -257,14 +257,14 @@
    const views::FlexSpecification location_bar_flex_rule =
        views::FlexSpecification(min_location_bar_flex,
                                 views::MaximumFlexSizeRule::kUnbounded)
-@@ -2023,7 +2068,7 @@ void ToolbarView::OnLocationBarCenteredC
- }
+@@ -2062,7 +2107,7 @@ void ToolbarView::OnLocationBarCenteredC
  
- void ToolbarView::MaybeCenterLocationBar() {
+ gfx::Rect ToolbarView::GetCenteredLocationBarBounds(gfx::Rect bounds,
+                                                     int toolbar_width) const {
 -  if (display_mode_ != DisplayMode::kNormal ||
 +  if (IsCompactLayout() || display_mode_ != DisplayMode::kNormal ||
        !location_bar_is_centered_.GetValue()) {
-     return;
+     return bounds;
    }
 --- a/chrome/browser/ui/views/toolbar/toolbar_view.h
 +++ b/chrome/browser/ui/views/toolbar/toolbar_view.h
@@ -286,7 +286,7 @@
    // Accessors.
    Browser* browser() const { return browser_; }
    views::Button* GetChromeLabsButton() const;
-@@ -422,6 +426,7 @@ class ToolbarView : public views::Access
+@@ -423,6 +427,7 @@ class ToolbarView : public views::Access
    raw_ptr<BrowserAppMenuButton> app_menu_button_ = nullptr;
    raw_ptr<views::View> new_tab_button_ = nullptr;
    raw_ptr<PinnedActionToolbarButton> tab_search_button_ = nullptr;

--- a/patches/helium/ui/layout/toolbar-actions.patch
+++ b/patches/helium/ui/layout/toolbar-actions.patch
@@ -99,7 +99,7 @@
  #endif  // CHROME_BROWSER_UI_VIEW_IDS_H_
 --- a/chrome/browser/ui/views/toolbar/toolbar_view.cc
 +++ b/chrome/browser/ui/views/toolbar/toolbar_view.cc
-@@ -128,6 +128,7 @@
+@@ -129,6 +129,7 @@
  #include "components/send_tab_to_self/features.h"
  #include "components/signin/public/base/signin_buildflags.h"
  #include "components/strings/grit/components_strings.h"
@@ -107,7 +107,7 @@
  #include "content/public/browser/render_view_host.h"
  #include "content/public/browser/web_contents.h"
  #include "third_party/skia/include/core/SkPath.h"
-@@ -160,6 +161,7 @@
+@@ -161,6 +162,7 @@
  #include "ui/views/layout/proposed_layout.h"
  #include "ui/views/mouse_watcher.h"
  #include "ui/views/mouse_watcher_view_host.h"
@@ -115,7 +115,7 @@
  #include "ui/views/view.h"
  #include "ui/views/view_class_properties.h"
  #include "ui/views/view_utils.h"
-@@ -189,6 +191,18 @@ constexpr int kLocationBarFlexOrder = kT
+@@ -190,6 +192,18 @@ constexpr int kLocationBarFlexOrder = kT
  constexpr int kToolbarActionsFlexOrder = kToolbarFlexOrderOffset + 2;
  constexpr int kExtensionsFlexOrder = kToolbarFlexOrderOffset + 3;
  
@@ -134,7 +134,7 @@
  // Gets the display mode for a given browser.
  ToolbarView::DisplayMode GetDisplayMode(Browser* browser) {
    // Checked in this order because even tabbed PWAs use the CUSTOM_TAB
-@@ -211,7 +225,9 @@ auto& GetViewCommandMap() {
+@@ -212,7 +226,9 @@ auto& GetViewCommandMap() {
         {VIEW_ID_FORWARD_BUTTON, IDC_FORWARD},
         {VIEW_ID_HOME_BUTTON, IDC_HOME},
         {VIEW_ID_RELOAD_BUTTON, IDC_RELOAD},
@@ -145,7 +145,7 @@
    return kViewCommandMap;
  }
  
-@@ -406,6 +422,16 @@ void ToolbarView::Init() {
+@@ -441,6 +457,16 @@ void ToolbarView::Init() {
  #endif
  
    // Always add children in order from left to right, for accessibility.
@@ -162,7 +162,7 @@
    if (!features::IsWebUIBackForwardButtonEnabled()) {
      back_ = AddChildView(std::make_unique<BackForwardButton>(
          BackForwardButton::Direction::kBack,
-@@ -456,9 +482,22 @@ void ToolbarView::Init() {
+@@ -491,9 +517,22 @@ void ToolbarView::Init() {
      location_bar_ = toolbar_webview_->GetLocationBar();
    }
  
@@ -187,7 +187,7 @@
      if (base::FeatureList::IsEnabled(features::kGlicActorUi) &&
          features::kGlicActorUiTaskIcon.Get()) {
        glic_actor_button_container_ =
-@@ -476,17 +515,28 @@ void ToolbarView::Init() {
+@@ -511,17 +550,28 @@ void ToolbarView::Init() {
          views::kMarginsKey,
          gfx::Insets::VH(
              0, GetLayoutConstant(LayoutConstant::kToolbarDividerSpacing)));
@@ -224,7 +224,7 @@
    if (extensions_container) {
      extensions_container_ = AddChildView(std::move(extensions_container));
      extensions_toolbar_coordinator_ =
-@@ -673,6 +723,16 @@ void ToolbarView::Init() {
+@@ -708,6 +758,16 @@ void ToolbarView::Init() {
  
    reload_->SetVisible(show_reload_button_.GetValue());
  
@@ -241,7 +241,7 @@
    show_avatar_button_.Init(
        prefs::kShowAvatarButton, prefs,
        base::BindRepeating(&ToolbarView::OnShowAvatarButtonChanged,
-@@ -721,8 +781,9 @@ void ToolbarView::Init() {
+@@ -756,8 +816,9 @@ void ToolbarView::Init() {
        views::FlexSpecification(views::MinimumFlexSizeRule::kPreferred,
                                 views::MaximumFlexSizeRule::kPreferred);
  
@@ -253,7 +253,7 @@
      if (button) {
        button->set_tag(GetViewCommandMap().at(button->GetID()));
        button->SetProperty(views::kFlexBehaviorKey, flex_preferred);
-@@ -737,6 +798,12 @@ void ToolbarView::OnVerticalTabStripMode
+@@ -772,6 +833,12 @@ void ToolbarView::OnVerticalTabStripMode
    should_display_vertical_tabs_ = controller->ShouldDisplayVerticalTabs();
    UpdateGlicButtonVisibility();
    UpdateGlicActorVisibility();
@@ -266,7 +266,7 @@
  }
  
  std::unique_ptr<GlicAndActorButtonsContainer>
-@@ -1581,6 +1648,16 @@ void ToolbarView::NewTabButtonPressed(co
+@@ -1615,6 +1682,16 @@ void ToolbarView::NewTabButtonPressed(co
                   NewTabTypes::kNewTabButtonInToolbarForTouch);
  }
  
@@ -283,7 +283,7 @@
  bool ToolbarView::AcceleratorPressed(const ui::Accelerator& accelerator) {
    const views::View* focused_view = focus_manager()->GetFocusedView();
    if (focused_view && (focused_view->GetID() == VIEW_ID_OMNIBOX)) {
-@@ -1700,13 +1777,37 @@ void ToolbarView::LayoutCommon() {
+@@ -1738,13 +1815,37 @@ void ToolbarView::LayoutCommon() {
        browser_->window() &&
        (browser_->window()->IsMaximized() || browser_->window()->IsFullscreen());
    const int margin = extend_buttons_to_edge ? interior_margin.left() : 0;
@@ -326,7 +326,7 @@
  
    if (toolbar_divider_ && extensions_container_) {
      views::ManualLayoutUtil(layout_manager_)
-@@ -1766,6 +1867,19 @@ void ToolbarView::UpdateToolbarLayout()
+@@ -1804,6 +1905,19 @@ void ToolbarView::UpdateToolbarLayout()
                       .WithOrder(order);
    };
  
@@ -346,7 +346,7 @@
    if (location_bar_view_) {
      location_bar_view_->SetProperty(views::kFlexBehaviorKey,
                                      location_bar_flex_rule);
-@@ -1810,6 +1924,67 @@ bool ToolbarView::IsCompactLayout() cons
+@@ -1848,6 +1962,67 @@ bool ToolbarView::IsCompactLayout() cons
    return controller && controller->IsCompactLayout();
  }
  
@@ -437,7 +437,7 @@
  
    // AppMenuIconController::Delegate:
    void UpdateTypeAndSeverity(
-@@ -359,9 +366,12 @@ class ToolbarView : public views::Access
+@@ -360,9 +367,12 @@ class ToolbarView : public views::Access
    void OnTouchUiChanged();
  
    void NewTabButtonPressed(const ui::Event& event);
@@ -450,7 +450,7 @@
  
    void SetForwardButtonVisibility(bool visible);
  
-@@ -399,6 +409,7 @@ class ToolbarView : public views::Access
+@@ -400,6 +410,7 @@ class ToolbarView : public views::Access
    // Controls. Most of these can be null, e.g. in popup windows. Only
    // |location_bar_| is guaranteed to exist. These pointers are owned by the
    // view hierarchy.
@@ -458,7 +458,7 @@
    raw_ptr<ToolbarButton> back_ = nullptr;
    raw_ptr<ToolbarButton> forward_ = nullptr;
    raw_ptr<ReloadButton> reload_ = nullptr;
-@@ -422,6 +433,7 @@ class ToolbarView : public views::Access
+@@ -423,6 +434,7 @@ class ToolbarView : public views::Access
    // `toolbar_webview_->GetPinnedActionsContainer()`.
    raw_ptr<PinnedToolbarActions> pinned_toolbar_actions_ = nullptr;
    raw_ptr<AvatarToolbarButton> avatar_ = nullptr;
@@ -466,7 +466,7 @@
    raw_ptr<MediaToolbarButtonView> media_button_ = nullptr;
    raw_ptr<BrowserAppMenuButton> app_menu_button_ = nullptr;
    raw_ptr<views::View> new_tab_button_ = nullptr;
-@@ -464,6 +476,10 @@ class ToolbarView : public views::Access
+@@ -465,6 +477,10 @@ class ToolbarView : public views::Access
  
    BooleanPrefMember show_reload_button_;
  
@@ -477,7 +477,7 @@
    BooleanPrefMember show_avatar_button_;
  
    BooleanPrefMember show_extensions_button_;
-@@ -494,8 +510,8 @@ class ToolbarView : public views::Access
+@@ -495,8 +511,8 @@ class ToolbarView : public views::Access
    // `toolbar_controller_`.
    raw_ptr<OverflowButton> overflow_button_ = nullptr;
  

--- a/patches/helium/ui/layout/toolbar-layout.patch
+++ b/patches/helium/ui/layout/toolbar-layout.patch
@@ -60,7 +60,7 @@
                            params.visual_client_area.width(),
 --- a/chrome/browser/ui/views/toolbar/toolbar_view.cc
 +++ b/chrome/browser/ui/views/toolbar/toolbar_view.cc
-@@ -51,6 +51,7 @@
+@@ -52,6 +52,7 @@
  #include "chrome/browser/ui/global_error/global_error_service.h"
  #include "chrome/browser/ui/global_error/global_error_service_factory.h"
  #include "chrome/browser/ui/global_media_controls/media_toolbar_button_controller.h"
@@ -68,7 +68,7 @@
  #include "chrome/browser/ui/intent_picker_tab_helper.h"
  #include "chrome/browser/ui/layout_constants.h"
  #include "chrome/browser/ui/omnibox/omnibox_view.h"
-@@ -181,6 +182,11 @@ DEFINE_UI_CLASS_PROPERTY_KEY(bool, kActi
+@@ -182,6 +183,11 @@ DEFINE_UI_CLASS_PROPERTY_KEY(bool, kActi
  
  namespace {
  
@@ -80,7 +80,7 @@
  // Gets the display mode for a given browser.
  ToolbarView::DisplayMode GetDisplayMode(Browser* browser) {
    // Checked in this order because even tabbed PWAs use the CUSTOM_TAB
-@@ -709,10 +715,15 @@ void ToolbarView::Init() {
+@@ -744,10 +750,15 @@ void ToolbarView::Init() {
  
    InitLayout();
  
@@ -96,7 +96,7 @@
      }
    }
  
-@@ -1580,21 +1591,6 @@ views::View* ToolbarView::GetDefaultFocu
+@@ -1614,21 +1625,6 @@ views::View* ToolbarView::GetDefaultFocu
  void ToolbarView::InitLayout() {
    const int default_margin =
        GetLayoutConstant(LayoutConstant::kToolbarIconDefaultMargin);
@@ -116,9 +116,9 @@
 -                               views::MaximumFlexSizeRule::kUnbounded)
 -          .WithOrder(kLocationBarFlexOrder);
  
-   layout_manager_ = SetLayoutManager(std::make_unique<views::FlexLayout>());
- 
-@@ -1603,16 +1599,7 @@ void ToolbarView::InitLayout() {
+   layout_manager_ =
+       SetLayoutManager(std::make_unique<CenteredLocationBarLayout>(
+@@ -1641,16 +1637,7 @@ void ToolbarView::InitLayout() {
        .SetCollapseMargins(true)
        .SetDefault(views::kMarginsKey, gfx::Insets::VH(0, default_margin));
  
@@ -136,7 +136,7 @@
  
    if (extensions_container_) {
      const views::FlexSpecification extensions_flex_rule =
-@@ -1658,9 +1645,7 @@ void ToolbarView::LayoutCommon() {
+@@ -1696,9 +1683,7 @@ void ToolbarView::LayoutCommon() {
    DCHECK(display_mode_ == DisplayMode::kNormal);
  
    gfx::Insets interior_margin =
@@ -147,7 +147,7 @@
  
    if (!browser_view_->webui_tab_strip()) {
      if (app_menu_button_->IsLabelPresentAndVisible()) {
-@@ -1712,6 +1697,74 @@ void ToolbarView::LayoutCommon() {
+@@ -1750,6 +1735,74 @@ void ToolbarView::LayoutCommon() {
    // Cast button visibility is controlled externally.
  }
  


### PR DESCRIPTION
Apply centered address bar bounds as part of the toolbar FlexLayout
proposed layout instead of mutating the location bar after layout has
already applied.

https://github.com/user-attachments/assets/81f1713a-19f9-4173-90f8-e9c4f388211e

fixes https://github.com/imputnet/helium-linux/issues/250
