### PR TITLE
helium/ui/zen: reapply fix for division-by-zero

### DIFF
--- a/patches/helium/ui/experiments/zen-mode.patch
+++ b/patches/helium/ui/experiments/zen-mode.patch
@@ -1961,15 +1961,26 @@
    views::AnimatingLayoutManager* animating_layout =
 --- a/chrome/browser/ui/views/tabs/vertical/vertical_pinned_tab_container_view.cc
 +++ b/chrome/browser/ui/views/tabs/vertical/vertical_pinned_tab_container_view.cc
-@@ -102,9 +102,8 @@ views::ProposedLayout VerticalPinnedTabC
+@@ -101,16 +101,12 @@ views::ProposedLayout VerticalPinnedTabC
+ 
      // When we are in collapsed state, only one child should be shown per row.
      // During collapse animation and other cases, fit as many as possible.
-     children_on_row =
+-    children_on_row =
 -        tabs::IsVerticalTabsExpandOnHoverFeatureEnabled() &&
 -                collapse_state ==
 -                    tabs::VerticalTabStripCollapseState::kCollapsed
-+            collapse_state ==
-+                tabs::VerticalTabStripCollapseState::kCollapsed
-             ? 1
-             : std::min(
-                   children_on_row,
+-            ? 1
+-            : std::min(
+-                  children_on_row,
+-                  static_cast<int>(std::floor((available_width - child_width) /
+-                                              (child_width + kTabPadding)) +
+-                                   1));
++    children_on_row = std::max(
++        1,
++        std::min(children_on_row,
++                 static_cast<int>(std::floor((available_width - child_width) /
++                                             (child_width + kTabPadding)) +
++                                  1)));
+ 
+     // Allocate extra space to the tabs.
+     available_width -=


### PR DESCRIPTION
we do not use the chromium collapse machinery (yet?) so the tab strip never becomes kCollapsed. add the fix from cdbece53a3 back.
