### PR TITLE
helium/ui/app-menu: remove vertical tabs & exit options

### DIFF
--- a/patches/helium/ui/app-menu-model.patch
+++ b/patches/helium/ui/app-menu-model.patch
@@ -1,6 +1,15 @@
 --- a/chrome/browser/ui/toolbar/app_menu_model.cc
 +++ b/chrome/browser/ui/toolbar/app_menu_model.cc
-@@ -779,9 +779,6 @@ SaveAndShareSubMenuModel::SaveAndShareSu
+@@ -75,8 +75,6 @@
+ #include "chrome/browser/ui/tabs/features.h"
+ #include "chrome/browser/ui/tabs/recent_tabs_sub_menu_model.h"
+ #include "chrome/browser/ui/tabs/tab_strip_model.h"
+-#include "chrome/browser/ui/tabs/vertical_tab_strip_metrics.h"
+-#include "chrome/browser/ui/tabs/vertical_tab_strip_state_controller.h"
+ #include "chrome/browser/ui/toolbar/app_menu_icon_controller.h"
+ #include "chrome/browser/ui/toolbar/bookmark_sub_menu_model.h"
+ #include "chrome/browser/ui/toolbar/chrome_labs/chrome_labs_prefs.h"
+@@ -779,9 +777,6 @@ SaveAndShareSubMenuModel::SaveAndShareSu
      if (!sharing_hub::SharingIsDisabledByPolicy(browser->profile())) {
        AddItemWithStringIdAndVectorIcon(
            this, IDC_COPY_URL, IDS_APP_MENU_COPY_LINK, kLinkChromeRefreshIcon);
@@ -10,7 +19,7 @@
        AddItemWithStringIdAndVectorIcon(this, IDC_QRCODE_GENERATOR,
                                         IDS_APP_MENU_CREATE_QR_CODE,
                                         kQrCodeChromeRefreshIcon);
-@@ -794,11 +791,6 @@ SaveAndShareSubMenuModel::SaveAndShareSu
+@@ -794,11 +789,6 @@ SaveAndShareSubMenuModel::SaveAndShareSu
    }
  }
  
@@ -22,10 +31,39 @@
  }  // namespace
  
  ////////////////////////////////////////////////////////////////////////////////
-@@ -939,23 +931,6 @@ void ToolsMenuModel::Build(Browser* brow
-     }
-   }
+@@ -910,52 +900,6 @@ void ToolsMenuModel::Build(Browser* brow
+   AddItemWithStringIdAndVectorIcon(this, IDC_NAME_WINDOW, IDS_NAME_WINDOW,
+                                    kNameWindowIcon);
  
+-  if (auto* controller = tabs::VerticalTabStripStateController::From(browser)) {
+-    // TODO(crbug.com/475222200): When in immersive, swapping between tab
+-    // strip types create duplicate tab strips. Until that is resolved,
+-    // disable the ability to swap between tab strips while in immersive.
+-    if (!ImmersiveModeController::From(browser)->IsEnabled()) {
+-      if (controller->ShouldDisplayVerticalTabs()) {
+-        AddItemWithStringIdAndVectorIcon(this, IDC_TOGGLE_VERTICAL_TABS,
+-                                         IDS_SWITCH_TO_HORIZONTAL_TAB,
+-                                         kToolbarIcon);
+-      } else {
+-        AddItemWithStringIdAndVectorIcon(
+-            this, IDC_TOGGLE_VERTICAL_TABS, IDS_SWITCH_TO_VERTICAL_TAB,
+-            base::i18n::IsRTL() ? kDockToRightIcon : kDockToLeftIcon);
+-        const bool use_preview_badge =
+-            base::FeatureList::IsEnabled(tabs::kVerticalTabsPreviewBadge);
+-        const ui::NewBadgeType badge_type = use_preview_badge
+-                                                ? ui::NewBadgeType::kPreview
+-                                                : ui::NewBadgeType::kNew;
+-        const user_education::DisplayNewBadge show_badge =
+-            UserEducationService::MaybeShowNewBadge(
+-                browser->GetProfile(), use_preview_badge
+-                                           ? tabs::kVerticalTabsPreviewBadge
+-                                           : tabs::kVerticalTabsNewBadge);
+-        SetIsNewFeatureAt(GetIndexOfCommandId(IDC_TOGGLE_VERTICAL_TABS).value(),
+-                          show_badge, badge_type);
+-      }
+-    }
+-  }
+-
 -  if (CustomizeChromePageHandler::IsSupported(
 -          NtpCustomBackgroundServiceFactory::GetForProfile(browser->profile()),
 -          browser->profile())) {
@@ -46,7 +84,35 @@
    AddSeparator(ui::NORMAL_SEPARATOR);
  
    AddItemWithStringIdAndVectorIcon(this, IDC_PERFORMANCE, IDS_SHOW_PERFORMANCE,
-@@ -1821,22 +1796,8 @@ void AppMenuModel::Build() {
+@@ -1532,12 +1476,6 @@ void AppMenuModel::LogMenuMetrics(int co
+       }
+       LogMenuAction(MENU_ACTION_TOGGLE_REQUEST_TABLET_SITE);
+       break;
+-    case IDC_EXIT:
+-      if (!uma_action_recorded_) {
+-        base::UmaHistogramMediumTimes("WrenchMenu.TimeToAction.Exit", delta);
+-      }
+-      LogMenuAction(MENU_ACTION_EXIT);
+-      break;
+ 
+     // Hosted App menu.
+     case IDC_OPEN_IN_CHROME:
+@@ -1732,14 +1670,6 @@ void AppMenuModel::LogMenuMetrics(int co
+       }
+       LogMenuAction(MENU_ACTION_SAFETY_HUB_MANAGE_EXTENSIONS);
+       break;
+-    case IDC_TOGGLE_VERTICAL_TABS:
+-      if (auto* controller =
+-              tabs::VerticalTabStripStateController::From(browser_)) {
+-        const bool is_vertical = !controller->ShouldDisplayVerticalTabs();
+-        tabs::RecordVerticalTabStripModeChanged(
+-            is_vertical, tabs::VerticalTabStripEntryPoint::kAppMenu);
+-      }
+-      break;
+     default: {
+       if (IsOtherProfileCommand(command_id)) {
+         if (!uma_action_recorded_) {
+@@ -1821,22 +1751,8 @@ void AppMenuModel::Build() {
    // Build (and, by extension, Init) should only be called once.
    DCHECK_EQ(0u, GetItemCount());
  
@@ -71,7 +137,7 @@
      AddSeparator(ui::NORMAL_SEPARATOR);
    }
  
-@@ -1873,32 +1834,6 @@ void AppMenuModel::Build() {
+@@ -1873,32 +1789,6 @@ void AppMenuModel::Build() {
  
    AddSeparator(ui::NORMAL_SEPARATOR);
  
@@ -104,7 +170,7 @@
    if (!browser_->profile()->IsOffTheRecord()) {
      auto recent_tabs_sub_menu =
          std::make_unique<RecentTabsSubMenuModel>(provider_, browser_);
-@@ -1920,7 +1855,7 @@ void AppMenuModel::Build() {
+@@ -1920,7 +1810,7 @@ void AppMenuModel::Build() {
          std::make_unique<BookmarkSubMenuModel>(this, browser_);
  
      AddSubMenuWithStringIdAndVectorIcon(
@@ -113,7 +179,7 @@
          bookmark_sub_menu_model_.get(), kBookmarksListsMenuIcon);
      SetElementIdentifierAt(GetIndexOfCommandId(IDC_BOOKMARKS_MENU).value(),
                             kBookmarksMenuItem);
-@@ -1937,23 +1872,10 @@ void AppMenuModel::Build() {
+@@ -1937,23 +1827,10 @@ void AppMenuModel::Build() {
          kTabGroupsMenuItem);
    }
  
@@ -141,7 +207,7 @@
  
    AddItemWithStringIdAndVectorIcon(this, IDC_CLEAR_BROWSING_DATA,
                                     IDS_CLEAR_BROWSING_DATA,
-@@ -2000,9 +1922,6 @@ void AppMenuModel::Build() {
+@@ -2000,9 +1877,6 @@ void AppMenuModel::Build() {
              lens::features::kLensOverlay));
    }
  
@@ -151,7 +217,7 @@
    CreateFindAndEditSubMenu();
  
    sub_menus_.push_back(
-@@ -2053,6 +1972,12 @@ void AppMenuModel::Build() {
+@@ -2053,13 +1927,15 @@ void AppMenuModel::Build() {
  #endif
  #endif
  
@@ -164,7 +230,14 @@
    AddItemWithStringIdAndVectorIcon(this, IDC_OPTIONS, IDS_SETTINGS,
                                     kSettingsMenuIcon);
  
-@@ -2149,34 +2074,21 @@ bool AppMenuModel::AddDefaultBrowserMenu
+-  if (browser_defaults::kShowExitMenuItem) {
+-    AddItemWithStringIdAndVectorIcon(this, IDC_EXIT, IDS_EXIT, kExitMenuIcon);
+-  }
+-
+   // On Chrome OS, similar UI is displayed in the system tray menu, instead of
+   // this menu.
+ #if !BUILDFLAG(IS_CHROMEOS)
+@@ -2149,34 +2025,21 @@ bool AppMenuModel::AddDefaultBrowserMenu
    return false;
  }
  


### PR DESCRIPTION
- vertical tabs are managed via other means, we don't need the chromium option here
- the exit option makes no sense and elongates the menu for 0 benefit. linux and windows have other means to close the app (such as the close button in window controls)
