### PR TITLE
helium/ui: generate standard qr codes in toolbar action

### DIFF
--- a/patches/helium/ui/generate-standard-qr-codes.patch
+++ b/patches/helium/ui/generate-standard-qr-codes.patch
@@ -1,0 +1,28 @@
+--- a/components/qr_code_generator/bitmap_generator.cc
++++ b/components/qr_code_generator/bitmap_generator.cc
+@@ -334,7 +334,9 @@ base::expected<SkBitmap, Error> Generate
+     // The QR version (i.e. size) must be >= 5 because otherwise the dino
+     // painted over the middle covers too much of the code to be decodable.
+     constexpr int kMinimumQRVersion = 5;
+-    auto qr_result = GenerateCode(data, kMinimumQRVersion);
++    auto qr_result = center_image == CenterImage::kNoCenterImage
++                         ? GenerateCode(data)
++                         : GenerateCode(data, kMinimumQRVersion);
+     if (!qr_result.has_value()) {
+       return base::unexpected(qr_result.error());
+     }
+--- a/chrome/browser/ui/views/qrcode_generator/qrcode_generator_bubble.cc
++++ b/chrome/browser/ui/views/qrcode_generator/qrcode_generator_bubble.cc
+@@ -159,9 +159,9 @@ void QRCodeGeneratorBubble::UpdateQRCont
+     qr_code = base::unexpected(qrcode_error_override_.value());
+   } else {
+     qr_code = qr_code_generator::GenerateImage(
+-        base::as_byte_span(input), qr_code_generator::ModuleStyle::kCircles,
+-        qr_code_generator::LocatorStyle::kRounded,
+-        qr_code_generator::CenterImage::kDino,
++        base::as_byte_span(input), qr_code_generator::ModuleStyle::kSquares,
++        qr_code_generator::LocatorStyle::kSquare,
++        qr_code_generator::CenterImage::kNoCenterImage,
+         qr_code_generator::QuietZone::kIncluded);
+   }
+ 

--- a/patches/series
+++ b/patches/series
@@ -293,6 +293,7 @@ helium/ui/layout/compact.patch
 helium/ui/layout/vertical.patch
 helium/ui/layout/toolbar-actions.patch
 
+helium/ui/generate-standard-qr-codes.patch
 helium/ui/pdf-viewer.patch
 helium/ui/hide-pip-live-caption-button.patch
 helium/ui/disable-ink-ripple-effect.patch


### PR DESCRIPTION
makes the qr codes standard and efficient instead of the quirk chungus ones that chromium generates

before and after:
<img width="324" height="454" alt="Screenshot 2026-05-05 at 21 27 04" src="https://github.com/user-attachments/assets/945f9521-db1e-48c8-aea4-25a24f5fd534" />

<img width="395" height="485" alt="Screenshot 2026-05-05 at 21 26 09" src="https://github.com/user-attachments/assets/1c835a43-ead5-44e9-97f9-3ecd4e02bffe" />

fixes #1598
