### PR TITLE
helium/ui/app-menu: restore exit option under "more tools"

### DIFF
--- a/patches/helium/ui/app-menu-model.patch
+++ b/patches/helium/ui/app-menu-model.patch
@@ -84,20 +84,18 @@
    AddSeparator(ui::NORMAL_SEPARATOR);
  
    AddItemWithStringIdAndVectorIcon(this, IDC_PERFORMANCE, IDS_SHOW_PERFORMANCE,
-@@ -1532,12 +1476,6 @@ void AppMenuModel::LogMenuMetrics(int co
+@@ -996,6 +940,10 @@ void ToolsMenuModel::Build(Browser* brow
        }
-       LogMenuAction(MENU_ACTION_TOGGLE_REQUEST_TABLET_SITE);
-       break;
--    case IDC_EXIT:
--      if (!uma_action_recorded_) {
--        base::UmaHistogramMediumTimes("WrenchMenu.TimeToAction.Exit", delta);
--      }
--      LogMenuAction(MENU_ACTION_EXIT);
--      break;
+     }
+   }
++  if (browser_defaults::kShowExitMenuItem) {
++    AddSeparator(ui::NORMAL_SEPARATOR);
++    AddItemWithStringIdAndVectorIcon(this, IDC_EXIT, IDS_EXIT, kExitMenuIcon);
++  }
+ }
  
-     // Hosted App menu.
-     case IDC_OPEN_IN_CHROME:
-@@ -1732,14 +1670,6 @@ void AppMenuModel::LogMenuMetrics(int co
+ ////////////////////////////////////////////////////////////////////////////////
+@@ -1732,14 +1680,6 @@ void AppMenuModel::LogMenuMetrics(int co
        }
        LogMenuAction(MENU_ACTION_SAFETY_HUB_MANAGE_EXTENSIONS);
        break;
@@ -112,7 +110,7 @@
      default: {
        if (IsOtherProfileCommand(command_id)) {
          if (!uma_action_recorded_) {
-@@ -1821,22 +1751,8 @@ void AppMenuModel::Build() {
+@@ -1821,22 +1761,8 @@ void AppMenuModel::Build() {
    // Build (and, by extension, Init) should only be called once.
    DCHECK_EQ(0u, GetItemCount());
  
@@ -137,7 +135,7 @@
      AddSeparator(ui::NORMAL_SEPARATOR);
    }
  
-@@ -1873,32 +1789,6 @@ void AppMenuModel::Build() {
+@@ -1873,32 +1799,6 @@ void AppMenuModel::Build() {
  
    AddSeparator(ui::NORMAL_SEPARATOR);
  
@@ -170,7 +168,7 @@
    if (!browser_->profile()->IsOffTheRecord()) {
      auto recent_tabs_sub_menu =
          std::make_unique<RecentTabsSubMenuModel>(provider_, browser_);
-@@ -1920,7 +1810,7 @@ void AppMenuModel::Build() {
+@@ -1920,7 +1820,7 @@ void AppMenuModel::Build() {
          std::make_unique<BookmarkSubMenuModel>(this, browser_);
  
      AddSubMenuWithStringIdAndVectorIcon(
@@ -179,7 +177,7 @@
          bookmark_sub_menu_model_.get(), kBookmarksListsMenuIcon);
      SetElementIdentifierAt(GetIndexOfCommandId(IDC_BOOKMARKS_MENU).value(),
                             kBookmarksMenuItem);
-@@ -1937,23 +1827,10 @@ void AppMenuModel::Build() {
+@@ -1937,23 +1837,10 @@ void AppMenuModel::Build() {
          kTabGroupsMenuItem);
    }
  
@@ -207,7 +205,7 @@
  
    AddItemWithStringIdAndVectorIcon(this, IDC_CLEAR_BROWSING_DATA,
                                     IDS_CLEAR_BROWSING_DATA,
-@@ -2000,9 +1877,6 @@ void AppMenuModel::Build() {
+@@ -2000,9 +1887,6 @@ void AppMenuModel::Build() {
              lens::features::kLensOverlay));
    }
  
@@ -217,7 +215,7 @@
    CreateFindAndEditSubMenu();
  
    sub_menus_.push_back(
-@@ -2053,13 +1927,15 @@ void AppMenuModel::Build() {
+@@ -2053,13 +1937,15 @@ void AppMenuModel::Build() {
  #endif
  #endif
  
@@ -237,7 +235,7 @@
    // On Chrome OS, similar UI is displayed in the system tray menu, instead of
    // this menu.
  #if !BUILDFLAG(IS_CHROMEOS)
-@@ -2149,34 +2025,21 @@ bool AppMenuModel::AddDefaultBrowserMenu
+@@ -2149,34 +2035,21 @@ bool AppMenuModel::AddDefaultBrowserMenu
    return false;
  }
  


### PR DESCRIPTION
closes #1612

<img width="553" height="277" alt="image" src="https://github.com/user-attachments/assets/9c307cfe-588c-415a-9eb8-a0d3f627577b" />

(forced to show on macos, but it's only visible on windows/linux, like before)