### PR TITLE
Respect bookmark-bar-ntp flag and also "Always Show Bookmarks Bar" menu option

### DIFF
--- a/patches/helium/core/respect-bookmark-bar-visibility-pref.patch
+++ b/patches/helium/core/respect-bookmark-bar-visibility-pref.patch
@@ -1,0 +1,24 @@
+--- a/chrome/browser/ui/bookmarks/bookmark_bar_controller.cc
++++ b/chrome/browser/ui/bookmarks/bookmark_bar_controller.cc
+@@ -144,10 +144,6 @@
+ }
+ 
+ bool BookmarkBarController::ShouldShowBookmarkBar() const {
+-  if (base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII("bookmark-bar-ntp") == "never") {
+-    return false;
+-  }
+-
+   Profile* profile = browser_->GetProfile();
+   if (profile->IsGuestSession()) {
+     return false;
+@@ -200,6 +196,10 @@
+     return false;
+   }
+ 
++  if (base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII("bookmark-bar-ntp") == "never") {
++    return false;
++  }
++
+   return std::any_of(
+       tabs.begin(), tabs.end(), [](const tabs::TabInterface* tab) {
+         return tab->GetContents() && IsShowingNTP(tab->GetContents());

--- a/patches/series
+++ b/patches/series
@@ -127,6 +127,7 @@ helium/core/proxy-extension-downloads.patch
 helium/core/reenable-update-checks.patch
 helium/core/add-native-bangs.patch
 helium/core/disable-bookmarks-bar.patch
+helium/core/respect-bookmark-bar-visibility-pref.patch
 helium/core/reenable-spellcheck-downloads.patch
 helium/core/prefer-https-by-default.patch
 helium/core/enable-tab-hover-cards.patch


### PR DESCRIPTION
For your pull request to not get closed without review, please confirm that:

- [ ] An issue exists where the maintainers agreed that this should be implemented
      (an approved feature request, or confirmed bug).
- [x] I tested that my contribution works locally, and does not break anything,
      otherwise I have marked my PR as draft.
- [ ] If my contribution is non-trivial, I did not use AI to write most of it.
- [x] I understand that I will be permanently banned from interacting with this
      organization if I lied by checking any of these checkboxes.

Tested on (check one or more):
- [ ] Windows
- [x] macOS
- [ ] Linux

---

Allow completely toggling the bookmarks bar appearance in new tabs, respecting the ungoogled-chromium flag: `#bookmark-bar-ntp` and also "Always Show Bookmarks Bar". So it's basically a pull request to change behavior of upstream ungoogled-chromium's flag behavior, it doesn't kill the flag itself but expands to control the bookmarks bar better.

I used AI to debug and create this patch. To address this issue: https://github.com/imputnet/helium/issues/1349
Demo: Toggling Cmd+Shift+B on new tabs

Outcome matrix based on combination of flag `#bookmark-bar-ntp` and **View > Always Show Bookmarks Bar** option:

| flag: bookmark-bar-ntp | menu: Always Show Bookmarks Bar | regular tab | new tab |
|--------|--------|--------|--------|
| Default | ON | ✅ shown | ✅ shown |
| Default | OFF | ⭕ hidden | ✅ shown if bookmarks |
| Never | ON | ✅ shown | ✅ shown |
| Never | OFF | ⭕ hidden | ⭕ hidden |

Demos:

- When: bookmark-bar-ntp = default

https://github.com/user-attachments/assets/b5439b72-a7f2-4b3b-ac95-353303a25bd4

- When: bookmark-bar-ntp = never

https://github.com/user-attachments/assets/e1313fec-5aec-499e-a136-a00c9f6a23b7

Fixes #1349

