### PR TITLE
helium/override-protocol: override protocol in tab search ui

### DIFF
--- a/patches/helium/core/override-chrome-protocol.patch
+++ b/patches/helium/core/override-chrome-protocol.patch
@@ -363,3 +363,16 @@
            base::UnescapeRule::NORMAL, nullptr, nullptr, nullptr);
      }
    }
+--- a/chrome/browser/resources/tab_search/tab_search_item.ts
++++ b/chrome/browser/resources/tab_search/tab_search_item.ts
+@@ -256,8 +256,8 @@ export class TabSearchItemElement extend
+ 
+     // Show chrome:// if it's a chrome internal url
+     const protocol = new URL(normalizeURL(data.tab.url)).protocol;
+-    if (protocol === 'chrome:') {
+-      this.$.secondaryText.prepend(document.createTextNode('chrome://'));
++    if (protocol === 'chrome:' || protocol === 'helium:') {
++      this.$.secondaryText.prepend(document.createTextNode('helium://'));
+     }
+   }
+ 


### PR DESCRIPTION
fixes #1574
