### PR TITLE
helium/core/kb-shortcuts: open downloads bubble when available

### DIFF
--- a/patches/helium/core/keyboard-shortcuts.patch
+++ b/patches/helium/core/keyboard-shortcuts.patch
@@ -52,7 +52,15 @@
  
 --- a/chrome/browser/ui/browser_command_controller.cc
 +++ b/chrome/browser/ui/browser_command_controller.cc
-@@ -324,6 +324,11 @@ BrowserCommandController::BrowserCommand
+@@ -85,6 +85,7 @@
+ #include "chrome/browser/ui/tabs/tab_strip_user_gesture_details.h"
+ #include "chrome/browser/ui/toolbar/chrome_labs/chrome_labs_utils.h"
+ #include "chrome/browser/ui/ui_features.h"
++#include "chrome/browser/ui/views/download/bubble/download_toolbar_ui_controller.h"
+ #include "chrome/browser/ui/views/frame/browser_view.h"
+ #include "chrome/browser/ui/web_applications/app_browser_controller.h"
+ #include "chrome/browser/ui/web_applications/web_app_dialog_utils.h"
+@@ -324,6 +325,11 @@ BrowserCommandController::BrowserCommand
                            base::Unretained(this)));
  #endif  // BUILDFLAG(ENABLE_PRINTING)
    profile_pref_registrar_.Add(
@@ -64,7 +72,7 @@
        policy::policy_prefs::kDownloadRestrictions,
        base::BindRepeating(&BrowserCommandController::UpdateSaveAsState,
                            base::Unretained(this)));
-@@ -456,7 +461,9 @@ bool BrowserCommandController::IsReserve
+@@ -456,7 +462,9 @@ bool BrowserCommandController::IsReserve
           command_id == IDC_NEW_INCOGNITO_WINDOW || command_id == IDC_NEW_TAB ||
           command_id == IDC_NEW_WINDOW || command_id == IDC_RESTORE_TAB ||
           command_id == IDC_SELECT_NEXT_TAB ||
@@ -75,7 +83,20 @@
  }
  
  void BrowserCommandController::TabStateChanged() {
-@@ -1283,6 +1290,14 @@ bool BrowserCommandController::ExecuteCo
+@@ -1103,6 +1111,12 @@ bool BrowserCommandController::ExecuteCo
+           SidePanelEntryId::kHistoryClusters, SidePanelOpenTrigger::kAppMenu);
+       break;
+     case IDC_SHOW_DOWNLOADS:
++      if (auto* download_controller =
++              browser_->GetFeatures().download_toolbar_ui_controller();
++          download_controller && download_controller->IsShowing()) {
++        download_controller->InvokeUI();
++        break;
++      }
+       ShowDownloads(browser_->GetBrowserForOpeningWebUi());
+       break;
+     case IDC_SHOW_COMMENTS_SIDE_PANEL:
+@@ -1283,6 +1297,14 @@ bool BrowserCommandController::ExecuteCo
      case IDC_DUPLICATE_TARGET_TAB:
        DuplicateKeyboardFocusedTab(browser_);
        break;
@@ -90,7 +111,7 @@
      // Hosted App commands
      case IDC_COPY_URL:
        CopyURL(browser_, browser_->tab_strip_model()->GetActiveWebContents());
-@@ -1751,6 +1766,7 @@ void BrowserCommandController::InitComma
+@@ -1751,6 +1773,7 @@ void BrowserCommandController::InitComma
                                          is_web_app_or_custom_tab);
    command_updater_.UpdateCommandEnabled(IDC_WEB_APP_MENU_APP_INFO,
                                          is_web_app_or_custom_tab);
@@ -98,7 +119,7 @@
  
    // Tab management commands
    const bool supports_tabs =
-@@ -2056,6 +2072,25 @@ void BrowserCommandController::UpdateCom
+@@ -2056,6 +2079,25 @@ void BrowserCommandController::UpdateCom
    UpdatePrintingState();
  }
  
@@ -124,7 +145,7 @@
  // TODO(crbug.com/442892562): Remove this function once the feature is launched.
  void BrowserCommandController::UpdateCommandsForDevTools() {
    if (is_locked_fullscreen_) {
-@@ -2064,6 +2099,9 @@ void BrowserCommandController::UpdateCom
+@@ -2064,6 +2106,9 @@ void BrowserCommandController::UpdateCom
  
    bool dev_tools_enabled = DevToolsWindow::AllowDevToolsFor(
        profile(), browser_->tab_strip_model()->GetActiveWebContents());

--- a/patches/helium/ui/experiments/zen-mode-wiring.patch
+++ b/patches/helium/ui/experiments/zen-mode-wiring.patch
@@ -303,7 +303,7 @@
      {ui::VKEY_R, ui::EF_PLATFORM_ACCELERATOR, IDC_RELOAD},
 --- a/chrome/browser/ui/browser_command_controller.cc
 +++ b/chrome/browser/ui/browser_command_controller.cc
-@@ -1840,6 +1840,8 @@ void BrowserCommandController::InitComma
+@@ -1847,6 +1847,8 @@ void BrowserCommandController::InitComma
    // These are always enabled; the menu determines their menu item visibility.
    command_updater_.UpdateCommandEnabled(IDC_UPGRADE_DIALOG, true);
    command_updater_.UpdateCommandEnabled(IDC_HELIUM_SERVICES_OPEN, true);

--- a/patches/helium/ui/experiments/zen-mode.patch
+++ b/patches/helium/ui/experiments/zen-mode.patch
@@ -1419,7 +1419,7 @@
    // AppMenuIconController::Delegate:
 --- a/chrome/browser/ui/browser_command_controller.cc
 +++ b/chrome/browser/ui/browser_command_controller.cc
-@@ -1327,6 +1327,15 @@ bool BrowserCommandController::ExecuteCo
+@@ -1334,6 +1334,15 @@ bool BrowserCommandController::ExecuteCo
            disposition, time_stamp);
      }
      case IDC_CTRL_S_SHORTCUT: {
@@ -1435,7 +1435,7 @@
        PrefService* prefs = profile()->GetPrefs();
        if (ShouldToggleVerticalCollapse(prefs)) {
          auto* controller =
-@@ -1340,6 +1349,14 @@ bool BrowserCommandController::ExecuteCo
+@@ -1347,6 +1356,14 @@ bool BrowserCommandController::ExecuteCo
        return ExecuteCommandWithDisposition(IDC_SAVE_PAGE, disposition,
                                             time_stamp);
      }

--- a/patches/helium/ui/layout/context-menu.patch
+++ b/patches/helium/ui/layout/context-menu.patch
@@ -128,7 +128,7 @@
    if (!current_tab) {
 --- a/chrome/browser/ui/browser_command_controller.cc
 +++ b/chrome/browser/ui/browser_command_controller.cc
-@@ -746,6 +746,21 @@ bool BrowserCommandController::ExecuteCo
+@@ -747,6 +747,21 @@ bool BrowserCommandController::ExecuteCo
      case IDC_NAME_WINDOW:
        PromptToNameWindow(browser_);
        break;
@@ -150,7 +150,7 @@
  
  #if BUILDFLAG(IS_CHROMEOS)
      case IDC_TAKE_SCREENSHOT:
-@@ -1573,6 +1588,15 @@ void BrowserCommandController::InitComma
+@@ -1580,6 +1595,15 @@ void BrowserCommandController::InitComma
    command_updater_.UpdateCommandEnabled(IDC_SHOW_SEARCH_TOOLS, true);
    command_updater_.UpdateCommandEnabled(IDC_SHOW_AI_MODE_OMNIBOX_BUTTON, true);
  

--- a/patches/helium/ui/layout/shortcuts.patch
+++ b/patches/helium/ui/layout/shortcuts.patch
@@ -50,8 +50,8 @@
 +#include "chrome/browser/ui/tabs/vertical_tab_strip_state_controller.h"
  #include "chrome/browser/ui/toolbar/chrome_labs/chrome_labs_utils.h"
  #include "chrome/browser/ui/ui_features.h"
- #include "chrome/browser/ui/views/frame/browser_view.h"
-@@ -232,6 +234,13 @@ void InvokeAction(actions::ActionId id,
+ #include "chrome/browser/ui/views/download/bubble/download_toolbar_ui_controller.h"
+@@ -233,6 +235,13 @@ void InvokeAction(actions::ActionId id,
    actions::ActionManager::Get().FindAction(id, scope)->InvokeAction();
  }
  
@@ -65,7 +65,7 @@
  }  // namespace
  
  ///////////////////////////////////////////////////////////////////////////////
-@@ -317,6 +326,10 @@ BrowserCommandController::BrowserCommand
+@@ -318,6 +327,10 @@ BrowserCommandController::BrowserCommand
        base::BindRepeating(
            &BrowserCommandController::UpdateCommandsForIncognitoAvailability,
            base::Unretained(this)));
@@ -76,7 +76,7 @@
  #if BUILDFLAG(ENABLE_PRINTING)
    profile_pref_registrar_.Add(
        prefs::kPrintingEnabled,
-@@ -1313,6 +1326,20 @@ bool BrowserCommandController::ExecuteCo
+@@ -1320,6 +1333,20 @@ bool BrowserCommandController::ExecuteCo
            copy ? IDC_COPY_URL : IDC_DEV_TOOLS_INSPECT,
            disposition, time_stamp);
      }
@@ -97,7 +97,7 @@
      // Hosted App commands
      case IDC_COPY_URL:
        CopyURL(browser_, browser_->tab_strip_model()->GetActiveWebContents());
-@@ -2366,7 +2393,11 @@ void BrowserCommandController::UpdateSav
+@@ -2373,7 +2400,11 @@ void BrowserCommandController::UpdateSav
      return;
    }
  


### PR DESCRIPTION
when the download toolbar ui is available (e.g. if something was downloaded), open the bubble instead of the webui page, and fall back otherwise

https://github.com/user-attachments/assets/1b4d308d-5d19-485f-9c2d-21783efa42e4

fixes #1149