### PR TITLE
helium/toolbar-actions: hide extension separator if it's last

### DIFF
--- a/patches/helium/ui/experiments/zen-mode.patch
+++ b/patches/helium/ui/experiments/zen-mode.patch
@@ -1363,7 +1363,7 @@
 +}
 --- a/chrome/browser/ui/views/toolbar/toolbar_view.cc
 +++ b/chrome/browser/ui/views/toolbar/toolbar_view.cc
-@@ -1956,6 +1956,16 @@ void ToolbarView::UpdateToolbarLayout()
+@@ -1984,6 +1984,16 @@ void ToolbarView::UpdateToolbarLayout()
    InvalidateLayout();
  }
  
@@ -1380,7 +1380,7 @@
  bool ToolbarView::IsCompactLayout() const {
    auto* controller =
        HeliumLayoutStateController::From(browser_view_->browser());
-@@ -1993,8 +2003,11 @@ void ToolbarView::UpdateVerticalTabsColl
+@@ -2021,8 +2031,11 @@ void ToolbarView::UpdateVerticalTabsColl
  
    auto* controller =
        tabs::VerticalTabStripStateController::From(browser_view_->browser());

--- a/patches/helium/ui/layout/toolbar-actions.patch
+++ b/patches/helium/ui/layout/toolbar-actions.patch
@@ -107,7 +107,15 @@
  #include "content/public/browser/render_view_host.h"
  #include "content/public/browser/web_contents.h"
  #include "third_party/skia/include/core/SkPath.h"
-@@ -161,6 +162,7 @@
+@@ -153,6 +154,7 @@
+ #include "ui/views/actions/action_view_controller.h"
+ #include "ui/views/background.h"
+ #include "ui/views/cascading_property.h"
++#include "ui/views/controls/button/button.h"
+ #include "ui/views/controls/button/label_button.h"
+ #include "ui/views/controls/separator.h"
+ #include "ui/views/layout/fill_layout.h"
+@@ -161,6 +163,7 @@
  #include "ui/views/layout/proposed_layout.h"
  #include "ui/views/mouse_watcher.h"
  #include "ui/views/mouse_watcher_view_host.h"
@@ -115,7 +123,7 @@
  #include "ui/views/view.h"
  #include "ui/views/view_class_properties.h"
  #include "ui/views/view_utils.h"
-@@ -190,6 +192,18 @@ constexpr int kLocationBarFlexOrder = kT
+@@ -190,6 +193,18 @@ constexpr int kLocationBarFlexOrder = kT
  constexpr int kToolbarActionsFlexOrder = kToolbarFlexOrderOffset + 2;
  constexpr int kExtensionsFlexOrder = kToolbarFlexOrderOffset + 3;
  
@@ -134,7 +142,7 @@
  // Gets the display mode for a given browser.
  ToolbarView::DisplayMode GetDisplayMode(Browser* browser) {
    // Checked in this order because even tabbed PWAs use the CUSTOM_TAB
-@@ -212,7 +226,9 @@ auto& GetViewCommandMap() {
+@@ -212,7 +227,9 @@ auto& GetViewCommandMap() {
         {VIEW_ID_FORWARD_BUTTON, IDC_FORWARD},
         {VIEW_ID_HOME_BUTTON, IDC_HOME},
         {VIEW_ID_RELOAD_BUTTON, IDC_RELOAD},
@@ -145,7 +153,7 @@
    return kViewCommandMap;
  }
  
-@@ -441,6 +457,16 @@ void ToolbarView::Init() {
+@@ -441,6 +458,16 @@ void ToolbarView::Init() {
  #endif
  
    // Always add children in order from left to right, for accessibility.
@@ -162,7 +170,7 @@
    if (!features::IsWebUIBackForwardButtonEnabled()) {
      back_ = AddChildView(std::make_unique<BackForwardButton>(
          BackForwardButton::Direction::kBack,
-@@ -491,9 +517,22 @@ void ToolbarView::Init() {
+@@ -491,9 +518,22 @@ void ToolbarView::Init() {
      location_bar_ = toolbar_webview_->GetLocationBar();
    }
  
@@ -187,7 +195,7 @@
      if (base::FeatureList::IsEnabled(features::kGlicActorUi) &&
          features::kGlicActorUiTaskIcon.Get()) {
        glic_actor_button_container_ =
-@@ -511,17 +550,28 @@ void ToolbarView::Init() {
+@@ -511,17 +551,28 @@ void ToolbarView::Init() {
          views::kMarginsKey,
          gfx::Insets::VH(
              0, GetLayoutConstant(LayoutConstant::kToolbarDividerSpacing)));
@@ -224,7 +232,7 @@
    if (extensions_container) {
      extensions_container_ = AddChildView(std::move(extensions_container));
      extensions_toolbar_coordinator_ =
-@@ -708,6 +758,16 @@ void ToolbarView::Init() {
+@@ -708,6 +759,16 @@ void ToolbarView::Init() {
  
    reload_->SetVisible(show_reload_button_.GetValue());
  
@@ -241,7 +249,7 @@
    show_avatar_button_.Init(
        prefs::kShowAvatarButton, prefs,
        base::BindRepeating(&ToolbarView::OnShowAvatarButtonChanged,
-@@ -756,8 +816,9 @@ void ToolbarView::Init() {
+@@ -756,8 +817,9 @@ void ToolbarView::Init() {
        views::FlexSpecification(views::MinimumFlexSizeRule::kPreferred,
                                 views::MaximumFlexSizeRule::kPreferred);
  
@@ -253,7 +261,7 @@
      if (button) {
        button->set_tag(GetViewCommandMap().at(button->GetID()));
        button->SetProperty(views::kFlexBehaviorKey, flex_preferred);
-@@ -772,6 +833,12 @@ void ToolbarView::OnVerticalTabStripMode
+@@ -772,6 +834,12 @@ void ToolbarView::OnVerticalTabStripMode
    should_display_vertical_tabs_ = controller->ShouldDisplayVerticalTabs();
    UpdateGlicButtonVisibility();
    UpdateGlicActorVisibility();
@@ -266,7 +274,7 @@
  }
  
  std::unique_ptr<GlicAndActorButtonsContainer>
-@@ -1615,6 +1682,16 @@ void ToolbarView::NewTabButtonPressed(co
+@@ -1615,6 +1683,16 @@ void ToolbarView::NewTabButtonPressed(co
                   NewTabTypes::kNewTabButtonInToolbarForTouch);
  }
  
@@ -283,7 +291,7 @@
  bool ToolbarView::AcceleratorPressed(const ui::Accelerator& accelerator) {
    const views::View* focused_view = focus_manager()->GetFocusedView();
    if (focused_view && (focused_view->GetID() == VIEW_ID_OMNIBOX)) {
-@@ -1738,13 +1815,37 @@ void ToolbarView::LayoutCommon() {
+@@ -1738,21 +1816,72 @@ void ToolbarView::LayoutCommon() {
        browser_->window() &&
        (browser_->window()->IsMaximized() || browser_->window()->IsFullscreen());
    const int margin = extend_buttons_to_edge ? interior_margin.left() : 0;
@@ -326,7 +334,43 @@
  
    if (toolbar_divider_ && extensions_container_) {
      views::ManualLayoutUtil(layout_manager_)
-@@ -1804,6 +1905,19 @@ void ToolbarView::UpdateToolbarLayout()
+-        .SetViewHidden(toolbar_divider_, !extensions_container_->GetVisible());
++        .SetViewHidden(toolbar_divider_, !ShouldShowExtensionsToolbarDivider());
+   }
+   // Cast button visibility is controlled externally.
+ }
+ 
++bool ToolbarView::ShouldShowExtensionsToolbarDivider() const {
++  CHECK(toolbar_divider_);
++  CHECK(extensions_container_);
++
++  if (!extensions_container_->GetVisible()) {
++    return false;
++  }
++
++  const std::optional<size_t> divider_index = GetIndexOf(toolbar_divider_);
++  CHECK(divider_index);
++
++  for (size_t i = *divider_index + 1; i < children().size(); ++i) {
++    const views::View* child = children()[i];
++    if (child != pinned_toolbar_actions_container_ && child->GetVisible()) {
++      return true;
++    }
++  }
++
++  return pinned_toolbar_actions_container_ &&
++         pinned_toolbar_actions_container_->GetVisible() &&
++         std::ranges::any_of(pinned_toolbar_actions_container_->children(),
++                             [](const views::View* child) {
++                               return child->GetVisible() &&
++                                      views::Button::AsButton(child);
++                             });
++}
++
+ void ToolbarView::AttachTabStripRegionView(HorizontalTabStripRegionView* view) {
+   if (!view) {
+     return;
+@@ -1804,6 +1933,19 @@ void ToolbarView::UpdateToolbarLayout()
                       .WithOrder(order);
    };
  
@@ -346,7 +390,7 @@
    if (location_bar_view_) {
      location_bar_view_->SetProperty(views::kFlexBehaviorKey,
                                      location_bar_flex_rule);
-@@ -1848,6 +1962,67 @@ bool ToolbarView::IsCompactLayout() cons
+@@ -1848,6 +1990,67 @@ bool ToolbarView::IsCompactLayout() cons
    return controller && controller->IsCompactLayout();
  }
  
@@ -437,7 +481,16 @@
  
    // AppMenuIconController::Delegate:
    void UpdateTypeAndSeverity(
-@@ -360,9 +367,12 @@ class ToolbarView : public views::Access
+@@ -352,6 +359,8 @@ class ToolbarView : public views::Access
+ 
+   void OnShowMediaButtonChanged();
+ 
++  bool ShouldShowExtensionsToolbarDivider() const;
++
+   void OnLocationBarCenteredChanged();
+ 
+   gfx::Rect GetCenteredLocationBarBounds(gfx::Rect bounds,
+@@ -360,9 +369,12 @@ class ToolbarView : public views::Access
    void OnTouchUiChanged();
  
    void NewTabButtonPressed(const ui::Event& event);
@@ -450,7 +503,7 @@
  
    void SetForwardButtonVisibility(bool visible);
  
-@@ -400,6 +410,7 @@ class ToolbarView : public views::Access
+@@ -400,6 +412,7 @@ class ToolbarView : public views::Access
    // Controls. Most of these can be null, e.g. in popup windows. Only
    // |location_bar_| is guaranteed to exist. These pointers are owned by the
    // view hierarchy.
@@ -458,7 +511,7 @@
    raw_ptr<ToolbarButton> back_ = nullptr;
    raw_ptr<ToolbarButton> forward_ = nullptr;
    raw_ptr<ReloadButton> reload_ = nullptr;
-@@ -423,6 +434,7 @@ class ToolbarView : public views::Access
+@@ -423,6 +436,7 @@ class ToolbarView : public views::Access
    // `toolbar_webview_->GetPinnedActionsContainer()`.
    raw_ptr<PinnedToolbarActions> pinned_toolbar_actions_ = nullptr;
    raw_ptr<AvatarToolbarButton> avatar_ = nullptr;
@@ -466,7 +519,7 @@
    raw_ptr<MediaToolbarButtonView> media_button_ = nullptr;
    raw_ptr<BrowserAppMenuButton> app_menu_button_ = nullptr;
    raw_ptr<views::View> new_tab_button_ = nullptr;
-@@ -465,6 +477,10 @@ class ToolbarView : public views::Access
+@@ -465,6 +479,10 @@ class ToolbarView : public views::Access
  
    BooleanPrefMember show_reload_button_;
  
@@ -477,7 +530,7 @@
    BooleanPrefMember show_avatar_button_;
  
    BooleanPrefMember show_extensions_button_;
-@@ -495,8 +511,8 @@ class ToolbarView : public views::Access
+@@ -495,8 +513,8 @@ class ToolbarView : public views::Access
    // `toolbar_controller_`.
    raw_ptr<OverflowButton> overflow_button_ = nullptr;
  


### PR DESCRIPTION
fixes #1116
