### PR TITLE
helium/ui: remove toolbar dividers

### DIFF
--- a/patches/helium/ui/experiments/zen-mode.patch
+++ b/patches/helium/ui/experiments/zen-mode.patch
@@ -1363,7 +1363,7 @@
 +}
 --- a/chrome/browser/ui/views/toolbar/toolbar_view.cc
 +++ b/chrome/browser/ui/views/toolbar/toolbar_view.cc
-@@ -1956,6 +1956,16 @@ void ToolbarView::UpdateToolbarLayout()
+@@ -1935,6 +1935,16 @@ void ToolbarView::UpdateToolbarLayout()
    InvalidateLayout();
  }
  
@@ -1380,7 +1380,7 @@
  bool ToolbarView::IsCompactLayout() const {
    auto* controller =
        HeliumLayoutStateController::From(browser_view_->browser());
-@@ -1993,8 +2003,11 @@ void ToolbarView::UpdateVerticalTabsColl
+@@ -1972,8 +1982,11 @@ void ToolbarView::UpdateVerticalTabsColl
  
    auto* controller =
        tabs::VerticalTabStripStateController::From(browser_view_->browser());

--- a/patches/helium/ui/find-bar.patch
+++ b/patches/helium/ui/find-bar.patch
@@ -1,6 +1,6 @@
 --- a/chrome/browser/ui/views/toolbar/toolbar_view.cc
 +++ b/chrome/browser/ui/views/toolbar/toolbar_view.cc
-@@ -1757,8 +1757,7 @@ AppMenuButton* ToolbarView::GetAppMenuBu
+@@ -1738,8 +1738,7 @@ AppMenuButton* ToolbarView::GetAppMenuBu
  }
  
  gfx::Rect ToolbarView::GetFindBarBoundingBox(int contents_bottom) {

--- a/patches/helium/ui/layout/centered-address-bar.patch
+++ b/patches/helium/ui/layout/centered-address-bar.patch
@@ -118,7 +118,7 @@
  
  }  // namespace
  
-@@ -681,6 +737,11 @@ void ToolbarView::Init() {
+@@ -674,6 +730,11 @@ void ToolbarView::Init() {
      OnShowMediaButtonChanged();
    }
  
@@ -130,7 +130,7 @@
    InitLayout();
  
    for (auto* button : std::array<views::Button*, 5>{back_, forward_, reload_,
-@@ -1569,7 +1630,11 @@ void ToolbarView::InitLayout() {
+@@ -1562,7 +1623,11 @@ void ToolbarView::InitLayout() {
                                 views::MaximumFlexSizeRule::kUnbounded)
            .WithOrder(kLocationBarFlexOrder);
  
@@ -143,7 +143,7 @@
  
    layout_manager_->SetOrientation(views::LayoutOrientation::kHorizontal)
        .SetCrossAxisAlignment(views::LayoutAlignment::kCenter)
-@@ -1938,6 +2003,46 @@ void ToolbarView::OnShowMediaButtonChang
+@@ -1919,6 +1984,46 @@ void ToolbarView::OnShowMediaButtonChang
    InvalidateLayout();
  }
  

--- a/patches/helium/ui/layout/compact.patch
+++ b/patches/helium/ui/layout/compact.patch
@@ -191,7 +191,7 @@
  constexpr int kToolbarFlexOrderOffset = 1000;
  constexpr int kLocationBarFlexOrder = kToolbarFlexOrderOffset + 1;
  constexpr int kToolbarActionsFlexOrder = kToolbarFlexOrderOffset + 2;
-@@ -1344,6 +1346,22 @@ bool ToolbarView::IsRectInWindowCaption(
+@@ -1337,6 +1339,22 @@ bool ToolbarView::IsRectInWindowCaption(
      return gfx::ToEnclosingRect(rect_in_target_coords_f);
    };
  
@@ -214,7 +214,7 @@
    // Check each child view to see if the rect intersects with
    // any clickable elements. If it does, check if the click is actually on that
    // element. False if on a clickable element, true if not on a clickable element.
-@@ -1735,6 +1753,30 @@ void ToolbarView::LayoutCommon() {
+@@ -1716,6 +1734,30 @@ void ToolbarView::LayoutCommon() {
    // Cast button visibility is controlled externally.
  }
  
@@ -245,7 +245,7 @@
  void ToolbarView::UpdateToolbarLayout() {
    if (!location_bar_) {
      return;
-@@ -1745,7 +1787,10 @@ void ToolbarView::UpdateToolbarLayout()
+@@ -1726,7 +1768,10 @@ void ToolbarView::UpdateToolbarLayout()
                                 views::MaximumFlexSizeRule::kPreferred);
    const int location_bar_margin =
        GetLayoutConstant(LayoutConstant::kLocationBarMargin);
@@ -257,7 +257,7 @@
    const views::FlexSpecification location_bar_flex_rule =
        views::FlexSpecification(min_location_bar_flex,
                                 views::MaximumFlexSizeRule::kUnbounded)
-@@ -2062,7 +2107,7 @@ void ToolbarView::OnLocationBarCenteredC
+@@ -2043,7 +2088,7 @@ void ToolbarView::OnLocationBarCenteredC
  
  gfx::Rect ToolbarView::GetCenteredLocationBarBounds(gfx::Rect bounds,
                                                      int toolbar_width) const {

--- a/patches/helium/ui/layout/toolbar-actions.patch
+++ b/patches/helium/ui/layout/toolbar-actions.patch
@@ -145,7 +145,7 @@
    return kViewCommandMap;
  }
  
-@@ -441,6 +457,16 @@ void ToolbarView::Init() {
+@@ -438,6 +454,16 @@ void ToolbarView::Init() {
  #endif
  
    // Always add children in order from left to right, for accessibility.
@@ -162,7 +162,7 @@
    if (!features::IsWebUIBackForwardButtonEnabled()) {
      back_ = AddChildView(std::make_unique<BackForwardButton>(
          BackForwardButton::Direction::kBack,
-@@ -491,9 +517,22 @@ void ToolbarView::Init() {
+@@ -488,9 +514,22 @@ void ToolbarView::Init() {
      location_bar_ = toolbar_webview_->GetLocationBar();
    }
  
@@ -187,7 +187,7 @@
      if (base::FeatureList::IsEnabled(features::kGlicActorUi) &&
          features::kGlicActorUiTaskIcon.Get()) {
        glic_actor_button_container_ =
-@@ -511,17 +550,28 @@ void ToolbarView::Init() {
+@@ -508,17 +547,28 @@ void ToolbarView::Init() {
          views::kMarginsKey,
          gfx::Insets::VH(
              0, GetLayoutConstant(LayoutConstant::kToolbarDividerSpacing)));
@@ -224,7 +224,7 @@
    if (extensions_container) {
      extensions_container_ = AddChildView(std::move(extensions_container));
      extensions_toolbar_coordinator_ =
-@@ -708,6 +758,16 @@ void ToolbarView::Init() {
+@@ -701,6 +751,16 @@ void ToolbarView::Init() {
  
    reload_->SetVisible(show_reload_button_.GetValue());
  
@@ -241,7 +241,7 @@
    show_avatar_button_.Init(
        prefs::kShowAvatarButton, prefs,
        base::BindRepeating(&ToolbarView::OnShowAvatarButtonChanged,
-@@ -756,8 +816,9 @@ void ToolbarView::Init() {
+@@ -749,8 +809,9 @@ void ToolbarView::Init() {
        views::FlexSpecification(views::MinimumFlexSizeRule::kPreferred,
                                 views::MaximumFlexSizeRule::kPreferred);
  
@@ -253,7 +253,7 @@
      if (button) {
        button->set_tag(GetViewCommandMap().at(button->GetID()));
        button->SetProperty(views::kFlexBehaviorKey, flex_preferred);
-@@ -772,6 +833,12 @@ void ToolbarView::OnVerticalTabStripMode
+@@ -765,6 +826,12 @@ void ToolbarView::OnVerticalTabStripMode
    should_display_vertical_tabs_ = controller->ShouldDisplayVerticalTabs();
    UpdateGlicButtonVisibility();
    UpdateGlicActorVisibility();
@@ -266,7 +266,7 @@
  }
  
  std::unique_ptr<GlicAndActorButtonsContainer>
-@@ -1615,6 +1682,16 @@ void ToolbarView::NewTabButtonPressed(co
+@@ -1608,6 +1675,16 @@ void ToolbarView::NewTabButtonPressed(co
                   NewTabTypes::kNewTabButtonInToolbarForTouch);
  }
  
@@ -283,7 +283,7 @@
  bool ToolbarView::AcceleratorPressed(const ui::Accelerator& accelerator) {
    const views::View* focused_view = focus_manager()->GetFocusedView();
    if (focused_view && (focused_view->GetID() == VIEW_ID_OMNIBOX)) {
-@@ -1738,13 +1815,37 @@ void ToolbarView::LayoutCommon() {
+@@ -1724,13 +1801,35 @@ void ToolbarView::LayoutCommon() {
        browser_->window() &&
        (browser_->window()->IsMaximized() || browser_->window()->IsFullscreen());
    const int margin = extend_buttons_to_edge ? interior_margin.left() : 0;
@@ -291,7 +291,6 @@
 -    toolbar_webview_->SetBackButtonLeadingMargin(margin);
 -  } else {
 -    back_->SetLeadingMargin(margin);
-+
 +  const bool collapse_button_on_trailing_edge =
 +      vertical_tabs_collapse_button_ &&
 +      vertical_tabs_collapse_button_->GetVisible() && IsVerticalLayout() &&
@@ -307,11 +306,10 @@
 +  leading_button->SetLeadingMargin(margin);
 +  if (leading_button != back_.get()) {
 +    back_->SetLeadingMargin(0);
-   }
++  }
 +  if (vertical_tabs_collapse_button_.get() != leading_button) {
 +    vertical_tabs_collapse_button_->SetLeadingMargin(0);
-+  }
-+
+   }
    app_menu_button_->SetTrailingMargin(
 -      extend_buttons_to_edge ? interior_margin.right() : 0);
 +      extend_buttons_to_edge && !collapse_button_on_trailing_edge
@@ -323,10 +321,10 @@
 +            ? interior_margin.right()
 +            : 0);
 +  }
+   // Cast button visibility is controlled externally.
+ }
  
-   if (toolbar_divider_ && extensions_container_) {
-     views::ManualLayoutUtil(layout_manager_)
-@@ -1804,6 +1905,19 @@ void ToolbarView::UpdateToolbarLayout()
+@@ -1785,6 +1884,19 @@ void ToolbarView::UpdateToolbarLayout()
                       .WithOrder(order);
    };
  
@@ -346,7 +344,7 @@
    if (location_bar_view_) {
      location_bar_view_->SetProperty(views::kFlexBehaviorKey,
                                      location_bar_flex_rule);
-@@ -1848,6 +1962,67 @@ bool ToolbarView::IsCompactLayout() cons
+@@ -1829,6 +1941,67 @@ bool ToolbarView::IsCompactLayout() cons
    return controller && controller->IsCompactLayout();
  }
  

--- a/patches/helium/ui/layout/toolbar-layout.patch
+++ b/patches/helium/ui/layout/toolbar-layout.patch
@@ -80,7 +80,7 @@
  // Gets the display mode for a given browser.
  ToolbarView::DisplayMode GetDisplayMode(Browser* browser) {
    // Checked in this order because even tabbed PWAs use the CUSTOM_TAB
-@@ -744,10 +750,15 @@ void ToolbarView::Init() {
+@@ -737,10 +743,15 @@ void ToolbarView::Init() {
  
    InitLayout();
  
@@ -96,7 +96,7 @@
      }
    }
  
-@@ -1614,21 +1625,6 @@ views::View* ToolbarView::GetDefaultFocu
+@@ -1607,21 +1618,6 @@ views::View* ToolbarView::GetDefaultFocu
  void ToolbarView::InitLayout() {
    const int default_margin =
        GetLayoutConstant(LayoutConstant::kToolbarIconDefaultMargin);
@@ -118,7 +118,7 @@
  
    layout_manager_ =
        SetLayoutManager(std::make_unique<CenteredLocationBarLayout>(
-@@ -1641,16 +1637,7 @@ void ToolbarView::InitLayout() {
+@@ -1634,16 +1630,7 @@ void ToolbarView::InitLayout() {
        .SetCollapseMargins(true)
        .SetDefault(views::kMarginsKey, gfx::Insets::VH(0, default_margin));
  
@@ -136,7 +136,7 @@
  
    if (extensions_container_) {
      const views::FlexSpecification extensions_flex_rule =
-@@ -1696,9 +1683,7 @@ void ToolbarView::LayoutCommon() {
+@@ -1682,9 +1669,7 @@ void ToolbarView::LayoutCommon() {
    DCHECK(display_mode_ == DisplayMode::kNormal);
  
    gfx::Insets interior_margin =
@@ -147,7 +147,7 @@
  
    if (!browser_view_->webui_tab_strip()) {
      if (app_menu_button_->IsLabelPresentAndVisible()) {
-@@ -1750,6 +1735,74 @@ void ToolbarView::LayoutCommon() {
+@@ -1731,6 +1716,74 @@ void ToolbarView::LayoutCommon() {
    // Cast button visibility is controlled externally.
  }
  

--- a/patches/helium/ui/remove-toolbar-dividers.patch
+++ b/patches/helium/ui/remove-toolbar-dividers.patch
@@ -1,0 +1,64 @@
+--- a/chrome/browser/ui/views/toolbar/toolbar_view.cc
++++ b/chrome/browser/ui/views/toolbar/toolbar_view.cc
+@@ -390,14 +390,11 @@ void ToolbarView::Init() {
+   PrefService* const prefs = browser_->profile()->GetPrefs();
+ 
+   std::unique_ptr<ExtensionsToolbarDesktop> extensions_container;
+-  std::unique_ptr<ToolbarDivider> toolbar_divider;
+ 
+   // Do not create the extensions or browser actions container if it is a guest
+   // profile (only regular and incognito profiles host extensions).
+   if (!browser_->profile()->IsGuestSession()) {
+     extensions_container = std::make_unique<ExtensionsToolbarDesktop>(browser_);
+-
+-    toolbar_divider = std::make_unique<ToolbarDivider>();
+   }
+ 
+   std::unique_ptr<MediaToolbarButtonView> media_button;
+@@ -496,10 +493,6 @@ void ToolbarView::Init() {
+                                                        extensions_container_);
+   }
+ 
+-  if (toolbar_divider) {
+-    toolbar_divider_ = AddChildView(std::move(toolbar_divider));
+-  }
+-
+   if (!features::IsWebUIPinnedToolbarActionsEnabled()) {
+     pinned_toolbar_actions_container_ = AddChildView(
+         std::make_unique<PinnedToolbarActionsContainer>(browser_view_, this));
+@@ -1555,13 +1548,6 @@ void ToolbarView::InitLayout() {
+             .WithOrder(kToolbarActionsFlexOrder));
+   }
+ 
+-  if (toolbar_divider_) {
+-    toolbar_divider_->SetProperty(
+-        views::kMarginsKey,
+-        gfx::Insets::VH(
+-            0, GetLayoutConstant(LayoutConstant::kToolbarDividerSpacing)));
+-  }
+-
+   constexpr int kToolbarFlexOrderStart = 1;
+ 
+   // TODO(crbug.com/40929989): Ignore containers till issue addressed.
+@@ -1625,11 +1611,6 @@ void ToolbarView::LayoutCommon() {
+   }
+   app_menu_button_->SetTrailingMargin(
+       extend_buttons_to_edge ? interior_margin.right() : 0);
+-
+-  if (toolbar_divider_ && extensions_container_) {
+-    views::ManualLayoutUtil(layout_manager_)
+-        .SetViewHidden(toolbar_divider_, !extensions_container_->GetVisible());
+-  }
+   // Cast button visibility is controlled externally.
+ }
+ 
+--- a/chrome/browser/ui/views/toolbar/pinned_toolbar_actions_container.cc
++++ b/chrome/browser/ui/views/toolbar/pinned_toolbar_actions_container.cc
+@@ -167,6 +167,7 @@ PinnedToolbarActionsContainer::PinnedToo
+               GetLayoutConstant(LayoutConstant::kToolbarIconDefaultMargin),
+           0, GetLayoutConstant(LayoutConstant::kToolbarDividerSpacing)));
+   toolbar_divider_ = AddChildView(std::move(toolbar_divider));
++  toolbar_divider_->SetVisible(false);
+ 
+   // Initialize the pinned action buttons.
+   action_view_controller_ = std::make_unique<views::ActionViewController>();

--- a/patches/helium/ui/toolbar-button-prefs.patch
+++ b/patches/helium/ui/toolbar-button-prefs.patch
@@ -172,7 +172,7 @@
  #include "chrome/browser/ui/intent_picker_tab_helper.h"
  #include "chrome/browser/ui/layout_constants.h"
  #include "chrome/browser/ui/omnibox/omnibox_view.h"
-@@ -554,8 +555,7 @@ void ToolbarView::Init() {
+@@ -547,8 +548,7 @@ void ToolbarView::Init() {
  #else
    // DevTools profiles are OffTheRecord, so hide it there.
    show_avatar_toolbar_button = browser_->profile()->IsIncognitoProfile() ||
@@ -182,7 +182,7 @@
  #endif
  
    const std::string sab_value = base::CommandLine::ForCurrentProcess()->
-@@ -630,6 +630,57 @@ void ToolbarView::Init() {
+@@ -623,6 +623,57 @@ void ToolbarView::Init() {
      home_->SetVisible(show_home_button_.GetValue());
    }
  
@@ -240,7 +240,7 @@
    InitLayout();
  
    for (auto* button : std::array<views::Button*, 5>{back_, forward_, reload_,
-@@ -1859,6 +1910,35 @@ void ToolbarView::OnShowHomeButtonChange
+@@ -1840,6 +1891,35 @@ void ToolbarView::OnShowHomeButtonChange
    }
  }
  

--- a/patches/helium/ui/toolbar-window-frame-hit-test.patch
+++ b/patches/helium/ui/toolbar-window-frame-hit-test.patch
@@ -60,7 +60,7 @@
  }  // namespace
  
  ////////////////////////////////////////////////////////////////////////////////
-@@ -1240,6 +1208,44 @@ bool ToolbarView::GetAppMenuFocused() co
+@@ -1233,6 +1201,44 @@ bool ToolbarView::GetAppMenuFocused() co
    return app_menu_button_ && app_menu_button_->HasFocus();
  }
  
@@ -105,7 +105,7 @@
  void ToolbarView::ShowIntentPickerBubble(
      std::vector<IntentPickerBubbleView::AppInfo> app_info,
      bool show_stay_in_chrome,
-@@ -1276,11 +1282,6 @@ void ToolbarView::ShowBookmarkBubble(con
+@@ -1269,11 +1275,6 @@ void ToolbarView::ShowBookmarkBubble(con
                                   already_bookmarked);
  }
  

--- a/patches/series
+++ b/patches/series
@@ -224,6 +224,7 @@ helium/ui/location-bar-page-action.patch
 helium/ui/tabs.patch
 helium/ui/tab-strip-controls.patch
 helium/ui/toolbar.patch
+helium/ui/remove-toolbar-dividers.patch
 helium/ui/toolbar-window-frame-hit-test.patch
 helium/ui/toolbar-button-prefs.patch
 helium/ui/omnibox.patch


### PR DESCRIPTION
fixes #1116 
supersedes #1654

<img width="234" height="110" alt="image" src="https://github.com/user-attachments/assets/63e762c3-3fd6-46e1-b312-476bcb30dcfc" />
