### PR TITLE
helium/ui/color-mixers: improve light mode element contrast

### DIFF
--- a/patches/helium/ui/helium-color-mixers.patch
+++ b/patches/helium/ui/helium-color-mixers.patch
@@ -94,8 +94,8 @@
  /* 16% opacity */
  constexpr SkAlpha kWebUiTabStripTabSeparatorAlpha = 0.16 * 255;
 +
-+/* 50% opacity */
-+constexpr SkAlpha kTabInactiveHoverAlpha = 0.5 * 255;
++/* 45% opacity */
++constexpr SkAlpha kTabInactiveHoverAlpha = 0.45 * 255;
 +
  }  // namespace
  
@@ -183,3 +183,43 @@
  
    mixer[kColorTabSearchButtonCRForegroundFrameActive] = {
        ui::kColorSysOnSurfacePrimary};
+--- a/ui/color/sys_color_mixer.cc
++++ b/ui/color/sys_color_mixer.cc
+@@ -66,7 +66,7 @@ void AddThemedSysColorOverrides(ColorMix
+ 
+   // Experimentation.
+   mixer[kColorSysOmniboxContainer] = {dark_mode ? kColorRefSecondary15
+-                                                : kColorSysSurface4};
++                                                : kColorSysSurface5};
+ }
+ 
+ // Overrides for the grayscale baseline case.
+@@ -95,6 +95,10 @@ void AddGrayscaleSysColorOverrides(Color
+   mixer[kColorSysOnHeaderPrimary] = {dark_mode ? kColorRefNeutral80
+                                                : kColorRefNeutral40};
+ 
++  // Toned divider.
++  mixer[kColorSysSurfaceVariant] = {dark_mode ? kColorRefNeutral40
++                                              : kColorRefNeutral92};
++
+   // States.
+   mixer[kColorSysStateInactiveRing] = {
+       dark_mode ? SetAlpha({kColorRefNeutral70}, 0x8C)
+@@ -106,7 +110,7 @@ void AddGrayscaleSysColorOverrides(Color
+ 
+   // Experimentation.
+   mixer[kColorSysOmniboxContainer] = {dark_mode ? kColorRefNeutral15
+-                                                : kColorRefNeutral94};
++                                                : kColorRefNeutral92};
+ }
+ 
+ }  // namespace
+@@ -367,7 +371,7 @@ void AddSysColorMixer(ColorProvider* pro
+ 
+   // Experimentation.
+   mixer[kColorSysOmniboxContainer] = {dark_mode ? kColorRefNeutral15
+-                                                : kColorSysSurface4};
++                                                : kColorSysSurface5};
+ 
+   // Deprecated.
+   // TODO(crbug.com/350783235): Remove remaining uses of these deprecated sys


### PR DESCRIPTION
increases contrast of tabs and location bar in light mode, both in greyscale (default) and tinted themes. also fixes the color of content separators in default light theme.

fixes #1532

before (top) and after (bottom):
<img width="2892" height="636" alt="comparison" src="https://github.com/user-attachments/assets/e27f68a4-5eeb-4c2f-b83a-dd512c7f1204" />