### PR TITLE
Force Color Profile Flag

### DIFF
--- a/patches/helium/core/add-force-color-profile-flag.patch
+++ b/patches/helium/core/add-force-color-profile-flag.patch
@@ -1,0 +1,29 @@
+--- a/chrome/browser/helium_flag_choices.h
++++ b/chrome/browser/helium_flag_choices.h
+@@ -34,6 +34,13 @@ namespace helium {
+ 
+   constexpr const char kMiddleClickAutoscrollCommandLine[] = "middle-click-autoscroll";
+ 
++  constexpr const char kForceColorProfileCommandLine[] = "force-color-profile";
++  constexpr const FeatureEntry::Choice kForceColorProfileChoices[] = {
++    {flags_ui::kGenericExperimentChoiceAutomatic, "", ""},
++    {"sRGB", kForceColorProfileCommandLine, "srgb"},
++    {"Generic RGB", kForceColorProfileCommandLine, "generic-rgb"},
++  };
++
+ }  // namespace helium
+ 
+ #endif  /* CHROME_BROWSER_HELIUM_FLAG_CHOICES_H_ */
+--- a/chrome/browser/helium_flag_entries.h
++++ b/chrome/browser/helium_flag_entries.h
+@@ -33,5 +33,10 @@
+     {helium::kMiddleClickAutoscrollCommandLine,
+      "Middle Click Autoscroll",
+      "Enables autoscroll on middle click. Helium flag, Chromium feature.",
+      kOsDesktop, FEATURE_VALUE_TYPE(blink::features::kHeliumMiddleClickAutoscroll)},
++    {helium::kForceColorProfileCommandLine,
++     "Force display color profile",
++     "Overrides the detected display color profile. This can work around video color shifts on some"
++     " Windows wide-gamut displays. Helium flag.",
++     kOsWin, MULTI_VALUE_TYPE(helium::kForceColorProfileChoices)},
+ #endif  /* CHROME_BROWSER_HELIUM_FLAG_ENTRIES_H_ */

--- a/patches/series
+++ b/patches/series
@@ -177,6 +177,7 @@ helium/core/open-new-tabs-next-to-active-tab-option.patch
 helium/core/disable-update-toast.patch
 helium/core/disable-fedcm-bubble.patch
 helium/core/add-middle-click-autoscroll-flag.patch
+helium/core/add-force-color-profile-flag.patch
 helium/core/webrtc-default-handling-policy.patch
 helium/core/browser-window-context-menu.patch
 helium/core/disable-ntp-footer.patch


### PR DESCRIPTION
For your pull request to not get closed without review, please confirm that:

- [ ] An issue exists where the maintainers agreed that this should be implemented
      (an approved feature request, or confirmed bug).
- [x] I tested that my contribution works locally, and does not break anything,
      otherwise I have marked my PR as draft.
- [ ] If my contribution is non-trivial, I did not use AI to write most of it.
- [x] I understand that I will be permanently banned from interacting with this
      organization if I lied by checking any of these checkboxes.

Tested on (check one or more):
- [x] Windows
- [ ] macOS
- [ ] Linux

---

## Summary

Adds in Helium `chrome://flags` additional option to select display color profile.

The flag exposes:
- Automatic
- sRGB
- Generic RGB

## Why

For users who have problem with colors on video playback adding option `--force-color-profile` switch.

Related issue: imputnet/helium-windows#255
I tested this on Windows by building Helium locally and confirming the patch applies through the patch series.

## Testing

- Built Helium on Windows x64
- Verified the patch applies through the Helium patch series
- Verified the generated browser build completes successfully
