### PR TITLE
hide tab close buttons when vertical when flag is set

### DIFF
--- a/patches/helium/ui/layout/hide-tab-close-buttons-vertical.patch
+++ b/patches/helium/ui/layout/hide-tab-close-buttons-vertical.patch
@@ -1,0 +1,22 @@
+--- a/chrome/browser/ui/views/tabs/vertical/vertical_tab_view.cc
++++ b/chrome/browser/ui/views/tabs/vertical/vertical_tab_view.cc
+@@ -7,6 +7,7 @@
+ #include <optional>
+ #include <string>
+
++#include "base/command_line.h"
+ #include "base/functional/callback_helpers.h"
+ #include "base/metrics/histogram_functions.h"
+ #include "base/metrics/user_metrics.h"
+@@ -733,7 +734,11 @@
+     if (pinned_) {
+       return false;
+     }
+
++    if (base::CommandLine::ForCurrentProcess()->HasSwitch("hide-tab-close-buttons")) {
++      return false;
++    }
++
+     // When uncollapsing the tabstrip, intentionally start showing the close
+     // button on active non-hovered tabs a little bit sooner than reaching the
+     // uncollapsed min width, because otherwise the close buttons in a grouped

--- a/patches/series
+++ b/patches/series
@@ -295,6 +295,7 @@ helium/ui/layout/minimal-location-bar.patch
 helium/ui/layout/dynamic.patch
 helium/ui/layout/compact.patch
 helium/ui/layout/vertical.patch
+helium/ui/layout/hide-tab-close-buttons-vertical.patch
 helium/ui/layout/toolbar-actions.patch
 
 helium/ui/generate-standard-qr-codes.patch


### PR DESCRIPTION
For your pull request to not get closed without review, please confirm that:

- [ ] An issue exists where the maintainers agreed that this should be implemented
      (an approved feature request, or confirmed bug).
- [x] I tested that my contribution works locally, and does not break anything,
      otherwise I have marked my PR as draft.
- [x] If my contribution is non-trivial, I did not use AI to write most of it.
- [x] I understand that I will be permanently banned from interacting with this
      organization if I lied by checking any of these checkboxes.

Tested on (check one or more):
- [ ] Windows
- [ ] macOS
- [x] Linux

---

This is for #1694 - I have tested the patch locally and I would consider it trivial - it's just making sure the check for the close buttons flag is also used with vertical tabs. I did use AI figuring out the right change to make, but I've reviewed all the code, it's only meaningfully ~4 new lines, and those lines appear to be consistent with how this flag is checked else where as well how close buttons are hidden from pinned tabs, etc.