### PR TITLE
helium/kb-shortcuts: don't modify close tab/window actions

### DIFF
--- a/patches/helium/core/custom-keyboard-shortcuts.patch
+++ b/patches/helium/core/custom-keyboard-shortcuts.patch
@@ -1824,7 +1824,7 @@
 +#endif  // CHROME_BROWSER_UI_BROWSER_SHORTCUTS_BROWSER_SHORTCUT_PLATFORM_MAC_H_
 --- /dev/null
 +++ b/chrome/browser/ui/browser_shortcuts/browser_shortcut_platform_mac.mm
-@@ -0,0 +1,250 @@
+@@ -0,0 +1,265 @@
 +// Copyright 2026 The Helium Authors
 +// You can use, redistribute, and/or modify this source code under
 +// the terms of the GPL-3.0 license that can be found in the LICENSE file.
@@ -1924,9 +1924,20 @@
 +  return *command_ids;
 +}
 +
++bool IsDynamicCloseCommand(int command_id) {
++  // AppController swaps Cmd+W/Cmd+Shift+W between Close Tab and Close Window at
++  // runtime based on the active window. Helium can expose these commands for
++  // additional shortcuts, but should not rewrite their menu-owned defaults.
++  return command_id == IDC_CLOSE_TAB || command_id == IDC_CLOSE_WINDOW;
++}
++
 +bool IsMenuCommandHeliumModifiable(
 +    int command_id,
 +    const std::optional<ui::Accelerator>& accelerator) {
++  if (IsDynamicCloseCommand(command_id)) {
++    return false;
++  }
++
 +  const ui::Accelerator* default_accelerator =
 +      AcceleratorsCocoa::GetInstance()->GetAcceleratorForCommand(command_id);
 +  if (!default_accelerator) {
@@ -1987,6 +1998,10 @@
 +}
 +
 +bool ShouldManageMenuItem(NSMenuItem* item, int command_id) {
++  if (IsDynamicCloseCommand(command_id)) {
++    return false;
++  }
++
 +  if (HeliumManagedMenuCommandIds().contains(command_id)) {
 +    return true;
 +  }


### PR DESCRIPTION
⌘W maps to different commands depending on whether we have tabs or not. somehow the mac shortcut handler persists the mapping "close window" command. let's just avoid that altogether

fixes imputnet/helium-macos#241
