### PR TITLE
helium/core: add "mute tab" action to tab context menu

### DIFF
--- a/i18n/source.gen.json
+++ b/i18n/source.gen.json
@@ -288,6 +288,30 @@
     "message": "Hibernate"
   },
   {
+    "name": "IDS_TAB_CXMENU_SOUND_MUTE_TAB",
+    "source": "chrome/app/generated_resources.grd",
+    "context": "The label of the tab context menu item for muting the current tab.",
+    "message": "{NUM_TABS, plural, =1 {Mute tab} other {Mute tabs}}"
+  },
+  {
+    "name": "IDS_TAB_CXMENU_SOUND_UNMUTE_TAB",
+    "source": "chrome/app/generated_resources.grd",
+    "context": "The label of the tab context menu item for unmuting the current tab.",
+    "message": "{NUM_TABS, plural, =1 {Unmute tab} other {Unmute tabs}}"
+  },
+  {
+    "name": "IDS_TAB_CXMENU_SOUND_MUTE_TAB",
+    "source": "chrome/app/generated_resources.grd",
+    "context": "In Title Case: The label of the tab context menu item for muting the current tab.",
+    "message": "{NUM_TABS, plural, =1 {Mute Tab} other {Mute Tabs}}"
+  },
+  {
+    "name": "IDS_TAB_CXMENU_SOUND_UNMUTE_TAB",
+    "source": "chrome/app/generated_resources.grd",
+    "context": "In Title Case: The label of the tab context menu item for unmuting the current tab.",
+    "message": "{NUM_TABS, plural, =1 {Unmute Tab} other {Unmute Tabs}}"
+  },
+  {
     "name": "IDS_SETTINGS_PERMISSIONS_DESCRIPTION_NORMAL",
     "source": "chrome/app/settings_strings.grdp",
     "context": "Description of the controls available on the permissions and site content settings page",

--- a/i18n/source.gen.json
+++ b/i18n/source.gen.json
@@ -288,30 +288,6 @@
     "message": "Hibernate"
   },
   {
-    "name": "IDS_TAB_CXMENU_SOUND_MUTE_TAB",
-    "source": "chrome/app/generated_resources.grd",
-    "context": "The label of the tab context menu item for muting the current tab.",
-    "message": "{NUM_TABS, plural, =1 {Mute tab} other {Mute tabs}}"
-  },
-  {
-    "name": "IDS_TAB_CXMENU_SOUND_UNMUTE_TAB",
-    "source": "chrome/app/generated_resources.grd",
-    "context": "The label of the tab context menu item for unmuting the current tab.",
-    "message": "{NUM_TABS, plural, =1 {Unmute tab} other {Unmute tabs}}"
-  },
-  {
-    "name": "IDS_TAB_CXMENU_SOUND_MUTE_TAB",
-    "source": "chrome/app/generated_resources.grd",
-    "context": "In Title Case: The label of the tab context menu item for muting the current tab.",
-    "message": "{NUM_TABS, plural, =1 {Mute Tab} other {Mute Tabs}}"
-  },
-  {
-    "name": "IDS_TAB_CXMENU_SOUND_UNMUTE_TAB",
-    "source": "chrome/app/generated_resources.grd",
-    "context": "In Title Case: The label of the tab context menu item for unmuting the current tab.",
-    "message": "{NUM_TABS, plural, =1 {Unmute Tab} other {Unmute Tabs}}"
-  },
-  {
     "name": "IDS_SETTINGS_PERMISSIONS_DESCRIPTION_NORMAL",
     "source": "chrome/app/settings_strings.grdp",
     "context": "Description of the controls available on the permissions and site content settings page",
@@ -574,6 +550,30 @@
     "source": "chrome/app/settings_strings.grdp",
     "context": "Label for the toggle that enables the minimal address bar.",
     "message": "Minimal address bar"
+  },
+  {
+    "name": "IDS_TAB_CXMENU_SOUND_MUTE_TAB",
+    "source": "chrome/app/generated_resources.grd",
+    "context": "The label of the tab context menu item for muting the current tab.",
+    "message": "{NUM_TABS, plural, =1 {Mute tab} other {Mute tabs}}"
+  },
+  {
+    "name": "IDS_TAB_CXMENU_SOUND_UNMUTE_TAB",
+    "source": "chrome/app/generated_resources.grd",
+    "context": "The label of the tab context menu item for unmuting the current tab.",
+    "message": "{NUM_TABS, plural, =1 {Unmute tab} other {Unmute tabs}}"
+  },
+  {
+    "name": "IDS_TAB_CXMENU_SOUND_MUTE_TAB",
+    "source": "chrome/app/generated_resources.grd",
+    "context": "In Title Case: The label of the tab context menu item for muting the current tab.",
+    "message": "{NUM_TABS, plural, =1 {Mute Tab} other {Mute Tabs}}"
+  },
+  {
+    "name": "IDS_TAB_CXMENU_SOUND_UNMUTE_TAB",
+    "source": "chrome/app/generated_resources.grd",
+    "context": "In Title Case: The label of the tab context menu item for unmuting the current tab.",
+    "message": "{NUM_TABS, plural, =1 {Unmute Tab} other {Unmute Tabs}}"
   },
   {
     "name": "IDS_SETTINGS_BROWSER_ZEN_MODE",

--- a/patches/helium/core/mute-tab-context-menu.patch
+++ b/patches/helium/core/mute-tab-context-menu.patch
@@ -1,6 +1,6 @@
 --- a/chrome/app/generated_resources.grd
 +++ b/chrome/app/generated_resources.grd
-@@ -11781,6 +11781,12 @@
+@@ -12097,6 +12097,12 @@
          <message name="IDS_TAB_CXMENU_SOUND_UNMUTE_SITE" desc="The label of the tab context menu item for unmuting one or more sites. NOTE: If having no explicit # makes the phrasing awkward, feel free to add a # as necessary. [ICU Syntax]">
            {NUM_TABS, plural, =1 {Unmute site} other {Unmute sites}}
          </message>
@@ -13,7 +13,7 @@
          <message name="IDS_TAB_CXMENU_READ_LATER" desc="The label of the tab context menu item for adding one or more tabs to Read later.">
            {NUM_TABS, plural,
            =1 {Add tab to reading list}
-@@ -11903,6 +11909,12 @@
+@@ -12219,6 +12225,12 @@
          <message name="IDS_TAB_CXMENU_SOUND_UNMUTE_SITE" desc="In Title Case: The label of the tab context menu item for unmuting one or more sites. NOTE: If having no explicit # makes the phrasing awkward, feel free to add a # as necessary. [ICU Syntax]">
            {NUM_TABS, plural, =1 {Unmute Site} other {Unmute Sites}}
          </message>

--- a/patches/helium/core/mute-tab-context-menu.patch
+++ b/patches/helium/core/mute-tab-context-menu.patch
@@ -1,0 +1,129 @@
+--- a/chrome/app/generated_resources.grd
++++ b/chrome/app/generated_resources.grd
+@@ -11781,6 +11781,12 @@
+         <message name="IDS_TAB_CXMENU_SOUND_UNMUTE_SITE" desc="The label of the tab context menu item for unmuting one or more sites. NOTE: If having no explicit # makes the phrasing awkward, feel free to add a # as necessary. [ICU Syntax]">
+           {NUM_TABS, plural, =1 {Unmute site} other {Unmute sites}}
+         </message>
++        <message name="IDS_TAB_CXMENU_SOUND_MUTE_TAB" desc="The label of the tab context menu item for muting the current tab.">
++          {NUM_TABS, plural, =1 {Mute tab} other {Mute tabs}}
++        </message>
++        <message name="IDS_TAB_CXMENU_SOUND_UNMUTE_TAB" desc="The label of the tab context menu item for unmuting the current tab.">
++          {NUM_TABS, plural, =1 {Unmute tab} other {Unmute tabs}}
++        </message>
+         <message name="IDS_TAB_CXMENU_READ_LATER" desc="The label of the tab context menu item for adding one or more tabs to Read later.">
+           {NUM_TABS, plural,
+           =1 {Add tab to reading list}
+@@ -11903,6 +11909,12 @@
+         <message name="IDS_TAB_CXMENU_SOUND_UNMUTE_SITE" desc="In Title Case: The label of the tab context menu item for unmuting one or more sites. NOTE: If having no explicit # makes the phrasing awkward, feel free to add a # as necessary. [ICU Syntax]">
+           {NUM_TABS, plural, =1 {Unmute Site} other {Unmute Sites}}
+         </message>
++        <message name="IDS_TAB_CXMENU_SOUND_MUTE_TAB" desc="In Title Case: The label of the tab context menu item for muting the current tab.">
++          {NUM_TABS, plural, =1 {Mute Tab} other {Mute Tabs}}
++        </message>
++        <message name="IDS_TAB_CXMENU_SOUND_UNMUTE_TAB" desc="In Title Case: The label of the tab context menu item for unmuting the current tab.">
++          {NUM_TABS, plural, =1 {Unmute Tab} other {Unmute Tabs}}
++        </message>
+         <message name="IDS_TAB_CXMENU_READ_LATER" desc="In Title Case: The label of the tab context menu item for adding one or more tabs to Read later.">
+           {NUM_TABS, plural,
+           =1 {Add Tab to Reading List}
+--- a/chrome/browser/ui/tabs/tab_strip_model.h
++++ b/chrome/browser/ui/tabs/tab_strip_model.h
+@@ -786,6 +786,7 @@
+     CommandGlicSwitchToRecentConversation,
+     CommandGlicUnshare,
+     CommandDiscard,
++    CommandToggleTabAudioMuted,
+     CommandLast
+   };
+   // LINT.ThenChange(//tools/metrics/histograms/metadata/tab/histograms.xml:TabContextMenuCommand)
+@@ -841,6 +842,9 @@
+   // Returns true if 'CommandToggleSiteMuted' will mute. |index| is the
+   // index supplied to |ExecuteContextMenuCommand|.
+   bool WillContextMenuMuteSites(int index);
++  // Returns true if 'CommandToggleTabAudioMuted' will mute. |index| is the
++  // index supplied to |ExecuteContextMenuCommand|.
++  bool WillContextMenuMuteTab(int index);
+ 
+   // Returns true if 'CommandTogglePinned' will pin. |index| is the index
+   // supplied to |ExecuteContextMenuCommand|.
+--- a/chrome/browser/ui/tabs/tab_strip_model.cc
++++ b/chrome/browser/ui/tabs/tab_strip_model.cc
+@@ -2503,6 +2503,9 @@
+       return false;
+     }
+ 
++    case CommandToggleTabAudioMuted:
++      return true;
++
+     case CommandTogglePinned:
+       return true;
+ 
+@@ -2798,6 +2801,22 @@
+       SetSitesMuted(GetIndicesForCommand(context_index), mute);
+       break;
+     }
++
++    case CommandToggleTabAudioMuted: {
++      base::UmaHistogramCounts1000(
++          "Tab.ContextMenu.ToggleTabAudioMuted.SelectedTabsCount",
++          selection_model_.size());
++      const bool mute = WillContextMenuMuteTab(context_index);
++      const std::vector<int> indices = GetIndicesForCommand(context_index);
++      for (int index : indices) {
++        content::WebContents* const contents = GetWebContentsAt(index);
++        if (contents) {
++          SetTabAudioMuted(contents, mute, TabMutedReason::kAudioIndicator,
++                           /*extension_id=*/"");
++        }
++      }
++      break;
++    }
+ 
+     case CommandAddToReadLater: {
+       base::UmaHistogramCounts1000(
+@@ -3306,6 +3325,17 @@
+ bool TabStripModel::WillContextMenuMuteSites(int index) {
+   return !AreAllSitesMuted(*this, GetIndicesForCommand(index));
+ }
++
++bool TabStripModel::WillContextMenuMuteTab(int index) {
++  const std::vector<int> indices = GetIndicesForCommand(index);
++  for (int i : indices) {
++    content::WebContents* const contents = GetWebContentsAt(i);
++    if (contents && !contents->IsAudioMuted()) {
++      return true;
++    }
++  }
++  return false;
++}
+ 
+ bool TabStripModel::WillContextMenuPin(int index) {
+   std::vector<int> indices = GetIndicesForCommand(index);
+--- a/chrome/browser/ui/tabs/tab_menu_model.cc
++++ b/chrome/browser/ui/tabs/tab_menu_model.cc
+@@ -244,6 +244,11 @@
+   AddItem(TabStripModel::CommandToggleSiteMuted,
+           will_mute ? l10n_util::GetPluralStringFUTF16(
+                           IDS_TAB_CXMENU_SOUND_MUTE_SITE, num_tabs)
+                     : l10n_util::GetPluralStringFUTF16(
+                           IDS_TAB_CXMENU_SOUND_UNMUTE_SITE, num_tabs));
++  const bool will_mute_tab = tab_strip->WillContextMenuMuteTab(index);
++  AddItem(TabStripModel::CommandToggleTabAudioMuted,
++          will_mute_tab ? l10n_util::GetPluralStringFUTF16(
++                              IDS_TAB_CXMENU_SOUND_MUTE_TAB, num_tabs)
++                        : l10n_util::GetPluralStringFUTF16(
++                              IDS_TAB_CXMENU_SOUND_UNMUTE_TAB, num_tabs));
+ 
+   const bool display_read_later = tab_strip->delegate()->SupportsReadLater();
+   const bool display_send_to_self = send_tab_to_self::ShouldDisplayEntryPoint(
+--- a/tools/metrics/histograms/metadata/tab/histograms.xml
++++ b/tools/metrics/histograms/metadata/tab/histograms.xml
+@@ -91,6 +91,8 @@
+   <variant name="ToggleMuted" summary="the Toggle muted command"/>
+   <variant name="TogglePinned" summary="the Toggle Pinned command"/>
+   <variant name="ToggleVertical" summary="the Toggle Vertical tabs command"/>
++  <variant name="ToggleTabAudioMuted"
++      summary="the Toggle Tab Audio Muted command"/>
+ </variants>
+ 
+ <!-- LINT.ThenChange(//chrome/browser/ui/tabs/tab_strip_model.h:TabContextMenuCommand) -->

--- a/patches/helium/core/mute-tab-context-menu.patch
+++ b/patches/helium/core/mute-tab-context-menu.patch
@@ -1,6 +1,6 @@
 --- a/chrome/app/generated_resources.grd
 +++ b/chrome/app/generated_resources.grd
-@@ -12097,6 +12097,12 @@
+@@ -12111,6 +12111,12 @@
          <message name="IDS_TAB_CXMENU_SOUND_UNMUTE_SITE" desc="The label of the tab context menu item for unmuting one or more sites. NOTE: If having no explicit # makes the phrasing awkward, feel free to add a # as necessary. [ICU Syntax]">
            {NUM_TABS, plural, =1 {Unmute site} other {Unmute sites}}
          </message>
@@ -13,7 +13,7 @@
          <message name="IDS_TAB_CXMENU_READ_LATER" desc="The label of the tab context menu item for adding one or more tabs to Read later.">
            {NUM_TABS, plural,
            =1 {Add tab to reading list}
-@@ -12219,6 +12225,12 @@
+@@ -12233,6 +12239,12 @@
          <message name="IDS_TAB_CXMENU_SOUND_UNMUTE_SITE" desc="In Title Case: The label of the tab context menu item for unmuting one or more sites. NOTE: If having no explicit # makes the phrasing awkward, feel free to add a # as necessary. [ICU Syntax]">
            {NUM_TABS, plural, =1 {Unmute Site} other {Unmute Sites}}
          </message>

--- a/patches/helium/core/mute-tab-context-menu.patch
+++ b/patches/helium/core/mute-tab-context-menu.patch
@@ -101,7 +101,7 @@
    std::vector<int> indices = GetIndicesForCommand(index);
 --- a/chrome/browser/ui/tabs/tab_menu_model.cc
 +++ b/chrome/browser/ui/tabs/tab_menu_model.cc
-@@ -244,6 +244,11 @@
+@@ -244,8 +244,14 @@
    AddItem(TabStripModel::CommandToggleSiteMuted,
            will_mute ? l10n_util::GetPluralStringFUTF16(
                            IDS_TAB_CXMENU_SOUND_MUTE_SITE, num_tabs)

--- a/patches/helium/core/mute-tab-context-menu.patch
+++ b/patches/helium/core/mute-tab-context-menu.patch
@@ -1,6 +1,6 @@
 --- a/chrome/app/generated_resources.grd
 +++ b/chrome/app/generated_resources.grd
-@@ -12111,6 +12111,12 @@
+@@ -12156,6 +12156,12 @@
          <message name="IDS_TAB_CXMENU_SOUND_UNMUTE_SITE" desc="The label of the tab context menu item for unmuting one or more sites. NOTE: If having no explicit # makes the phrasing awkward, feel free to add a # as necessary. [ICU Syntax]">
            {NUM_TABS, plural, =1 {Unmute site} other {Unmute sites}}
          </message>
@@ -13,7 +13,7 @@
          <message name="IDS_TAB_CXMENU_READ_LATER" desc="The label of the tab context menu item for adding one or more tabs to Read later.">
            {NUM_TABS, plural,
            =1 {Add tab to reading list}
-@@ -12233,6 +12239,12 @@
+@@ -12278,6 +12284,12 @@
          <message name="IDS_TAB_CXMENU_SOUND_UNMUTE_SITE" desc="In Title Case: The label of the tab context menu item for unmuting one or more sites. NOTE: If having no explicit # makes the phrasing awkward, feel free to add a # as necessary. [ICU Syntax]">
            {NUM_TABS, plural, =1 {Unmute Site} other {Unmute Sites}}
          </message>

--- a/patches/series
+++ b/patches/series
@@ -186,6 +186,7 @@ helium/core/component-updates.patch
 helium/core/fixups-component-setup.patch
 helium/core/fixups-chrome-webstore-script.patch
 helium/core/hibernate-tab-context-menu.patch
+helium/core/mute-tab-context-menu.patch
 helium/core/disable-side-panel-flyover.patch
 helium/core/custom-profile-avatar.patch
 

--- a/patches/series
+++ b/patches/series
@@ -186,7 +186,6 @@ helium/core/component-updates.patch
 helium/core/fixups-component-setup.patch
 helium/core/fixups-chrome-webstore-script.patch
 helium/core/hibernate-tab-context-menu.patch
-helium/core/mute-tab-context-menu.patch
 helium/core/disable-side-panel-flyover.patch
 helium/core/custom-profile-avatar.patch
 
@@ -272,6 +271,7 @@ helium/ui/enable-fluent-scrollbar.patch
 helium/ui/helium-color-scheme.patch
 helium/ui/improve-flags-webui.patch
 helium/ui/ublock-show-in-settings.patch
+helium/core/mute-tab-context-menu.patch
 helium/ui/licenses-in-credits.patch
 helium/ui/remove-autofill-link-to-password-manager.patch
 helium/ui/fix-caption-button-bounds.patch

--- a/patches/series
+++ b/patches/series
@@ -271,7 +271,6 @@ helium/ui/enable-fluent-scrollbar.patch
 helium/ui/helium-color-scheme.patch
 helium/ui/improve-flags-webui.patch
 helium/ui/ublock-show-in-settings.patch
-helium/core/mute-tab-context-menu.patch
 helium/ui/licenses-in-credits.patch
 helium/ui/remove-autofill-link-to-password-manager.patch
 helium/ui/fix-caption-button-bounds.patch
@@ -290,6 +289,7 @@ helium/ui/layout/minimal-location-bar.patch
 helium/ui/layout/dynamic.patch
 helium/ui/layout/compact.patch
 helium/ui/layout/vertical.patch
+helium/core/mute-tab-context-menu.patch
 helium/ui/layout/toolbar-actions.patch
 
 helium/ui/pdf-viewer.patch


### PR DESCRIPTION
For your pull request to not get closed without review, please confirm that:

- [x] An issue exists where the maintainers agreed that this should be implemented (an approved feature request, or confirmed bug).
- [x] I tested that my contribution works locally, and does not break anything, otherwise I have marked my PR as draft.
- [x] If my contribution is non-trivial, I did not use AI to write most of it.
- [x] I understand that I will be permanently banned from interacting with this organization if I lied by checking any of these checkboxes.

Tested on (check one or more):

- [x] Windows
- [ ] macOS
- [x] Linux

---

Closes #974

Adds a "Mute tab" / "Unmute tab" toggle to the tab context menu, placed next to the existing "Mute site" item. Operates on the individual tab's audio mute state independently of site-level muting.

- New `CommandToggleTabAudioMuted` command added to `TabStripModelCommand` enum
- `WillContextMenuMuteTab()` added to `TabStripModel` to drive the label toggle
- `IDS_TAB_CXMENU_SOUND_MUTE_TAB` / `IDS_TAB_CXMENU_SOUND_UNMUTE_TAB` strings added to `generated_resources.grd`
- Menu item wired through `tab_menu_model.cc`
- `ToggleTabAudioMuted` histogram variant added to `histograms.xml`

Video of the manual test on Windows below :

https://github.com/user-attachments/assets/58e9a91f-da58-450a-9bbe-e6b33db8110f

I'll be testing this also on Linux and update the description if it goes fine

Edit :

Works also on Linux, video of the manual testing below :

[Screencast from 2026-05-23 23-24-10.webm](https://github.com/user-attachments/assets/3e62f110-335b-4ccc-9061-4b0f70f14182)

