### PR TITLE
helium/zen: don't show new tab toast when tabs are visible

### DIFF
--- a/patches/helium/ui/experiments/zen-mode.patch
+++ b/patches/helium/ui/experiments/zen-mode.patch
@@ -2363,20 +2363,38 @@
  #include "chrome/browser/ui/incognito_allowed_url.h"
  #include "chrome/browser/ui/location_bar/location_bar.h"
  #include "chrome/browser/ui/singleton_tabs.h"
-@@ -41,6 +43,8 @@
+@@ -41,6 +43,9 @@
  #include "chrome/browser/ui/tabs/split_tab_metrics.h"
  #include "chrome/browser/ui/tabs/tab_strip_model.h"
  #include "chrome/browser/ui/tabs/tab_strip_user_gesture_details.h"
 +#include "chrome/browser/ui/toasts/api/toast_id.h"
 +#include "chrome/browser/ui/toasts/toast_controller.h"
++#include "chrome/browser/ui/views/frame/browser_view.h"
  #include "chrome/browser/ui/web_applications/app_browser_controller.h"
  #include "chrome/browser/ui/web_applications/web_app_tabbed_utils.h"
  #include "chrome/browser/web_applications/web_app_helpers.h"
-@@ -143,6 +147,43 @@ bool IncognitoModeForced(const Profile*
+@@ -143,6 +148,64 @@ bool IncognitoModeForced(const Profile*
           policy::IncognitoModeAvailability::kForced;
  }
  
-+bool IsNavigationOpeningNewTabInZenMode(const NavigateParams& params) {
++bool IsTabChromeRevealedInZenMode(
++    const HeliumLayoutStateController& layout_controller,
++    const NavigateParams& params) {
++  BrowserView* const browser_view =
++      BrowserView::GetBrowserViewForBrowser(params.browser);
++  if (!browser_view) {
++    return false;
++  }
++
++  // In vertical layout, tabs are in side chrome. In all other layouts,
++  // tabs are in top chrome.
++  if (layout_controller.IsVerticalLayout()) {
++    return browser_view->GetSideChromeRevealRatio() > 0.0f;
++  }
++  return browser_view->GetTopChromeRevealRatio() > 0.0f;
++}
++
++bool ShouldShowNewTabToastInZenMode(const NavigateParams& params) {
 +  // Only show the toast when a new browser tab is created.
 +  if (params.disposition != WindowOpenDisposition::NEW_FOREGROUND_TAB &&
 +      params.disposition != WindowOpenDisposition::NEW_BACKGROUND_TAB) {
@@ -2396,12 +2414,16 @@
 +    return false;
 +  }
 +
++  // Don't show the toast if zen mode is disabled or if chrome with tabs
++  // is revealed. The user can already see the tab strip update in either
++  // of those cases.
 +  auto* layout_controller = HeliumLayoutStateController::From(params.browser);
-+  return layout_controller && layout_controller->IsZenModeEnabled();
++  return layout_controller && layout_controller->IsZenModeEnabled() &&
++         !IsTabChromeRevealedInZenMode(*layout_controller, params);
 +}
 +
 +void MaybeShowZenModeNewTabCreatedToast(const NavigateParams& params) {
-+  if (!IsNavigationOpeningNewTabInZenMode(params)) {
++  if (!ShouldShowNewTabToastInZenMode(params)) {
 +    return;
 +  }
 +
@@ -2416,7 +2438,7 @@
  // Change some of the navigation parameters based on the particular URL.
  // Returns true on success. Otherwise, if changing params leads the browser
  // into an erroneous state, returns false.
-@@ -902,6 +943,7 @@ base::WeakPtr<content::NavigationHandle>
+@@ -902,6 +965,7 @@ base::WeakPtr<content::NavigationHandle>
      params->browser->GetBrowserForMigrationOnly()->tab_strip_model()->AddTab(
          std::move(tab_to_insert), params->tabstrip_index, params->transition,
          params->tabstrip_add_types, params->group);


### PR DESCRIPTION
the new tab toast no longer shows up when tabbed chrome is visible in zen mode, either on hover or when pinned

fixes #1684

https://github.com/user-attachments/assets/698ffb01-4499-4908-a9f6-376224424701