### PR TITLE
helium/settings/clear-data: remove google link, always expand

### DIFF
--- a/patches/helium/settings/clear-browsing-data-popup.patch
+++ b/patches/helium/settings/clear-browsing-data-popup.patch
@@ -1,0 +1,52 @@
+--- a/chrome/browser/resources/settings/clear_browsing_data_dialog/clear_browsing_data_dialog_v2.html
++++ b/chrome/browser/resources/settings/clear_browsing_data_dialog/clear_browsing_data_dialog_v2.html
+@@ -47,16 +47,6 @@
+     position: fixed;
+   }
+ 
+-  #manageOtherGoogleDataRow {
+-    border-radius: var(--dbd-container-border-radius);
+-    color: var(--cr-primary-text-color);
+-    background: var(--dbd-container-color);
+-    margin-top: 12px;
+-    display: flex;
+-    align-items: center;
+-    font-weight: 500;
+-  }
+-
+   #showMoreButton {
+     --cr-button-background-color: var(--dbd-container-color);
+     --cr-button-height: auto;
+@@ -137,12 +127,6 @@
+       <cr-icon icon="cr:expand-more" aria-hidden="true" role="presentation">
+       </cr-icon>
+     </cr-button>
+-    <cr-link-row id="manageOtherGoogleDataRow"
+-        label="[[otherGoogleDataRowLabel_]]"
+-        sub-label="[[otherGoogleDataRowSubLabel_]]"
+-        on-click="onManageOtherGoogleDataRowClick_"
+-        role-description="$i18n{subpageArrowRoleDescription}">
+-    </cr-link-row>
+   </div>
+   <div slot="button-container" class="row-aligned">
+ <if expr="not is_chromeos">
+--- a/chrome/browser/resources/settings/clear_browsing_data_dialog/clear_browsing_data_dialog_v2.ts
++++ b/chrome/browser/resources/settings/clear_browsing_data_dialog/clear_browsing_data_dialog_v2.ts
+@@ -163,7 +163,7 @@ export class SettingsClearBrowsingDataDi
+     return {
+       dataTypesExpanded_: {
+         type: Boolean,
+-        value: false,
++        value: true,
+       },
+ 
+       deleteButtonLabel_: {
+@@ -520,8 +520,6 @@ export class SettingsClearBrowsingDataDi
+   private onOtherGoogleDataDialogClose_(e: Event) {
+     e.stopPropagation();
+     this.showOtherGoogleDataDialog_ = false;
+-    afterNextRender(
+-        this, () => focusWithoutInk(this.$.manageOtherGoogleDataRow));
+   }
+ 
+   private onCheckboxSubLabelLinkClick_(e: CustomEvent<{id: string}>) {

--- a/patches/series
+++ b/patches/series
@@ -211,6 +211,7 @@ helium/settings/reorder-settings-menu.patch
 helium/settings/add-search-engine-button.patch
 helium/settings/custom-profile-avatar-ui.patch
 helium/settings/custom-keyboard-shortcuts-page.patch
+helium/settings/clear-browsing-data-popup.patch
 
 helium/hop/setup.patch
 helium/hop/disable-password-manager.patch


### PR DESCRIPTION
removed the google data link, because it's not applicable in helium, and was likely added by google to cover their asses from legal issues. also flipped the `dataTypesExpanded_` bool to true by default, which eliminates an extra step needed to see all data types available for clearing.

fixes #1780

before:

<img width="551" height="596" alt="image" src="https://github.com/user-attachments/assets/00b94ab6-8ca4-4301-8aab-4e4901caf635" />

after:

<img width="552" height="602" alt="image" src="https://github.com/user-attachments/assets/3ee7f2fe-a91d-4347-bc49-cd887676929e" />

https://github.com/user-attachments/assets/cfed9fc0-cf43-4654-8c56-385447014a2e

