### PR TITLE
upstream-fixes: fix black flash on tab when leaving split view

### DIFF
--- a/patches/series
+++ b/patches/series
@@ -1,4 +1,5 @@
 upstream-fixes/missing-dependencies.patch
+upstream-fixes/vertical-tab-black-flash.patch
 
 inox-patchset/fix-building-without-safebrowsing.patch
 inox-patchset/disable-autofill-download-manager.patch

--- a/patches/upstream-fixes/vertical-tab-black-flash.patch
+++ b/patches/upstream-fixes/vertical-tab-black-flash.patch
@@ -1,0 +1,36 @@
+From 343f33947846544416ea566990b1c2cfc655cc73 Mon Sep 17 00:00:00 2001
+From: Yue Liu <yueliu1@microsoft.com>
+Date: Tue, 12 May 2026 01:56:22 -0700
+Subject: [PATCH] [Vertical Tabs] Fix black flash on tab when leaving split view
+
+When exiting a split view, one of the tabs briefly turns black for a
+single frame before snapping back to its normal background.
+
+AnimateAndReparentView calls SetPaintToLayer() on the reparented view
+but doesn't set fills_bounds_opaquely=false, unlike the sibling
+OnViewAdded and AnimateAndDestroyChildView paths. An inactive
+VerticalTabView paints no background of its own when the window is
+translucent (GlassFrame), so the freshly attached opaque layer
+composites uninitialized contents for one frame before the layer is
+destroyed at animation end.
+
+Bug: 510987458
+Change-Id: Ic2827f543f2e1d12271ebffc2a6a23276df4e52b
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7832567
+Commit-Queue: Yue Liu <yueliu1@microsoft.com>
+Reviewed-by: Chang Liu <changliu1@microsoft.com>
+Commit-Queue: Chang Liu <changliu1@microsoft.com>
+Reviewed-by: Eshwar Stalin <estalin@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1629152}
+---
+
+--- a/chrome/browser/ui/views/tabs/vertical/tab_collection_animating_layout_manager.cc
++++ b/chrome/browser/ui/views/tabs/vertical/tab_collection_animating_layout_manager.cc
+@@ -382,6 +382,7 @@ void TabCollectionAnimatingLayoutManager
+   if (!delegate_->IsViewDragging(*view_to_reparent) &&
+       !previous_bounds_in_screen.IsEmpty()) {
+     view_to_reparent->SetPaintToLayer();
++    view_to_reparent->layer()->SetFillsBoundsOpaquely(false);
+     view_to_reparent->SetProperty(kPreviousCollectionBounds,
+                                   previous_bounds_in_screen);
+   }


### PR DESCRIPTION
picked to M148 from https://crrev.com/c/7832567