### PR TITLE
helium/zen: rephrase toast pref toggle in a11y settings

### DIFF
--- a/i18n/source.gen.json
+++ b/i18n/source.gen.json
@@ -864,6 +864,18 @@
     "message": "Minimal address bar"
   },
   {
+    "name": "IDS_SETTINGS_ACCESSIBILITY_TOAST_TOGGLE_TITLE",
+    "source": "chrome/app/settings_strings.grdp",
+    "context": "Title for a setting that allows you to toggle clipboard copy and new tab toast notifications.",
+    "message": "Background action confirmation toasts"
+  },
+  {
+    "name": "IDS_SETTINGS_ACCESSIBILITY_TOAST_TOGGLE_DESCRIPTION",
+    "source": "chrome/app/settings_strings.grdp",
+    "context": "Subtitle for a setting that allows you to toggle clipboard copy and new tab toast notifications.",
+    "message": "Shows a toast notification when you copy content, such as links and images, or open a new background tab in Zen mode"
+  },
+  {
     "name": "IDS_SETTINGS_BROWSER_ZEN_MODE",
     "source": "chrome/app/settings_strings.grdp",
     "context": "Label for the toggle that enables zen mode, hiding browser chrome until hover.",

--- a/patches/helium/ui/experiments/zen-mode-wiring.patch
+++ b/patches/helium/ui/experiments/zen-mode-wiring.patch
@@ -1,6 +1,19 @@
 --- a/chrome/app/settings_strings.grdp
 +++ b/chrome/app/settings_strings.grdp
-@@ -313,6 +313,18 @@
+@@ -189,6 +189,12 @@
+     <message name="IDS_SETTINGS_ACCESSIBILITY_TOAST_FREQUENCY_DESCRIPTION" desc="Subtitle for a setting that allows you to change the frequency of feedback messages.">
+       Shows a confirmation when you copy links, images, or videos
+     </message>
++    <message name="IDS_SETTINGS_ACCESSIBILITY_TOAST_TOGGLE_TITLE" desc="Title for a setting that allows you to toggle clipboard copy and new tab toast notifications.">
++      Background action confirmation toasts
++    </message>
++    <message name="IDS_SETTINGS_ACCESSIBILITY_TOAST_TOGGLE_DESCRIPTION" desc="Subtitle for a setting that allows you to toggle clipboard copy and new tab toast notifications.">
++      Shows a toast notification when you copy content, such as links and images, or open a new background tab in Zen mode
++    </message>
+   </if>
+   <if expr="is_macosx">
+     <message name="IDS_SETTINGS_ACCESSIBILITY_COPY_PAGE_URL_SHORTCUT" desc="Toggle in settings that allows you to enable the keyboard shortcut that copies the current page URL to the clipboard. It's enabled by default.">
+@@ -313,6 +319,18 @@
    <message name="IDS_SETTINGS_MINIMAL_LOCATION_BAR" desc="Label for the toggle that enables the minimal address bar.">
      Minimal address bar
    </message>
@@ -21,6 +34,18 @@
    </message>
 --- a/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
 +++ b/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
+@@ -278,9 +278,9 @@ void AddA11yStrings(content::WebUIDataSo
+       {"focusHighlightLabel",
+        IDS_SETTINGS_ACCESSIBILITY_FOCUS_HIGHLIGHT_DESCRIPTION},
+       {"toastAlertLevelTitle",
+-       IDS_SETTINGS_ACCESSIBILITY_TOAST_FREQUENCY_TITLE},
++       IDS_SETTINGS_ACCESSIBILITY_TOAST_TOGGLE_TITLE},
+       {"toastAlertLevelDescription",
+-       IDS_SETTINGS_ACCESSIBILITY_TOAST_FREQUENCY_DESCRIPTION},
++       IDS_SETTINGS_ACCESSIBILITY_TOAST_TOGGLE_DESCRIPTION},
+ #endif
+ #if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_MAC)
+       {"overscrollHistoryNavigationTitle",
 @@ -525,6 +525,10 @@ void AddAppearanceStrings(content::WebUI
        {"browserLayoutCompact", IDS_SETTINGS_BROWSER_LAYOUT_COMPACT},
        {"browserLayoutVertical", IDS_SETTINGS_BROWSER_LAYOUT_VERTICAL},


### PR DESCRIPTION
updates the toast pref toggle to clearly indicate what it toggles: clipboard copy and background new tab notifications

before:

<img width="728" height="92" alt="image" src="https://github.com/user-attachments/assets/d45a5d24-6e34-492b-be95-944cebb3bab8" />

after:

<img width="718" height="111" alt="image" src="https://github.com/user-attachments/assets/824ea9e3-77a2-429c-85ff-35ab1fab06ac" />
