### PR TITLE
fix: derive content separator from toolbar for custom themes in light mode

### DIFF
--- a/patches/helium/ui/helium-color-mixers.patch
+++ b/patches/helium/ui/helium-color-mixers.patch
@@ -20,19 +20,20 @@
    mixer[kColorToolbarButtonBackgroundHighlightedDefault] = {
        ui::kColorSysStateHoverOnSubtle};
    mixer[kColorToolbarButtonBorder] = {ui::kColorSysOutline};
-@@ -412,7 +416,10 @@ void AddMaterialChromeColorMixer(ui::Col
+@@ -412,7 +416,11 @@ void AddMaterialChromeColorMixer(ui::Col
        {ui::kColorSysStateDisabled}, {kColorToolbar})};
    mixer[kColorToolbarButtonIconPressed] = {kColorToolbarButtonIconHovered};
    mixer[kColorToolbarButtonText] = {ui::kColorSysOnSurfaceSecondary};
 -  mixer[kColorToolbarContentAreaSeparator] = {ui::kColorSysSurfaceVariant};
 +  mixer[kColorToolbarContentAreaSeparator] = {
-+      dark_mode ? ui::GetResultingPaintColor({ui::kColorSysStateHoverOnSubtle},
-+                                             {kColorToolbar})
-+                : ui::kColorSysSurfaceVariant};
++      (dark_mode || key.custom_theme)
++          ? ui::GetResultingPaintColor({ui::kColorSysStateHoverOnSubtle},
++                                       {kColorToolbar})
++          : ui::kColorSysSurfaceVariant};
    mixer[kColorToolbarFeaturePromoHighlight] = {ui::kColorSysPrimary};
    mixer[kColorToolbarIconContainerBorder] = {ui::kColorSysNeutralOutline};
    mixer[kColorToolbarInkDropHover] = {ui::kColorSysStateHoverOnSubtle};
-@@ -424,8 +431,11 @@ void AddMaterialChromeColorMixer(ui::Col
+@@ -424,8 +432,11 @@ void AddMaterialChromeColorMixer(ui::Col
    mixer[kColorToolbarExtensionSeparatorDisabled] = {
        kColorToolbarButtonIconInactive};
    mixer[kColorToolbarSeparator] = {kColorToolbarSeparatorDefault};
@@ -62,16 +63,17 @@
      mixer[kColorLocationBarBackgroundHovered] =
          ui::GetResultingPaintColor(ui::kColorSysStateHoverBrightBlendProtection,
                                     kColorLocationBarBackground);
-@@ -810,8 +814,10 @@ void AddChromeColorMixer(ui::ColorProvid
+@@ -810,8 +814,11 @@ void AddChromeColorMixer(ui::ColorProvid
        ui::SetAlpha(kColorToolbarButtonIcon, gfx::kGoogleGreyAlpha500)};
    mixer[kColorToolbarButtonIconPressed] = {kColorToolbarButtonIconHovered};
    mixer[kColorToolbarButtonText] = ui::GetColorWithMaxContrast(kColorToolbar);
 -  mixer[kColorToolbarContentAreaSeparator] =
 -      ui::AlphaBlend(kColorToolbarButtonIcon, kColorToolbar, 0x3A);
 +  mixer[kColorToolbarContentAreaSeparator] = {
-+      dark_mode ? ui::GetResultingPaintColor({ui::kColorSysStateHoverOnSubtle},
-+                                             {kColorToolbar})
-+                : ui::kColorSysSurfaceVariant};
++      (dark_mode || key.custom_theme)
++          ? ui::GetResultingPaintColor({ui::kColorSysStateHoverOnSubtle},
++                                       {kColorToolbar})
++          : ui::kColorSysSurfaceVariant};
    mixer[kColorToolbarFeaturePromoHighlight] =
        ui::PickGoogleColor(ui::kColorAccent, kColorToolbar,
                            color_utils::kMinimumVisibleContrastRatio);


### PR DESCRIPTION
## Problem

With a custom theme that sets a dark `toolbar` color, the **content-area separator** renders light/white in **light mode**, standing out against the dark chrome. This includes:

- the rounded webview frame **outline** on normal (non-split) windows, and
- the **top / leading content separators** that remain when the rounded frame pref is off.

All three are painted with `kColorToolbarContentAreaSeparator`. Switching the browser to dark mode makes them dark, but light mode ignores the theme.

## Cause

In `helium-color-mixers.patch`, the separator recipe is:

```cpp
mixer[kColorToolbarContentAreaSeparator] = {
    dark_mode ? ui::GetResultingPaintColor({ui::kColorSysStateHoverOnSubtle},
                                           {kColorToolbar})
              : ui::kColorSysSurfaceVariant};
```

Dark mode derives the color from `kColorToolbar`, but light mode hardcodes `ui::kColorSysSurfaceVariant` (a fixed light grey from the grayscale sys palette), so a custom theme's `toolbar` color has no effect on it in light mode.

## Change

Derive the separator from the toolbar for **custom themes** too (`key.custom_theme`), matching the dark-mode treatment, in both `material_chrome_color_mixer.cc` and `chrome_color_mixer.cc`:

```cpp
mixer[kColorToolbarContentAreaSeparator] = {
    (dark_mode || key.custom_theme)
        ? ui::GetResultingPaintColor({ui::kColorSysStateHoverOnSubtle},
                                     {kColorToolbar})
        : ui::kColorSysSurfaceVariant};
```

Default (non-themed) light UI is unchanged. Toolbar **icon** color is unaffected (separate token).

## Notes / open questions

- **Draft / not yet built.** I don't have a local Chromium build set up; the patch hunks are hand-edited and verified for context/offset consistency, but this needs a build + visual check before merge. Help verifying is welcome.
- Behavior change for existing custom-theme users in light mode: their content separator now follows the toolbar color (same as dark mode) instead of the fixed grey. If you'd prefer this gated behind a flag/pref instead of applying to all custom themes, I'm happy to rework it that way.
- Only the `key.custom_theme` path is touched; the high-contrast and default paths are left as-is.