### PR TITLE
helium/updates: decouple update url from helium services + reformat

### DIFF
--- a/patches/helium/core/add-disable-ech-flag.patch
+++ b/patches/helium/core/add-disable-ech-flag.patch
@@ -1,8 +1,8 @@
 --- a/chrome/browser/helium_flag_choices.h
 +++ b/chrome/browser/helium_flag_choices.h
-@@ -26,6 +26,8 @@ namespace helium {
-     {kChannelBeta, kChannelCommandLine, kChannelBeta},
-   };
+@@ -29,6 +29,8 @@ namespace helium {
+   constexpr const char kUpdateServerUrlCommandLine[] =
+       "custom-update-server-url";
  
 +  constexpr const char kDisableEchCommandLine[] = "disable-ech";
 +
@@ -11,10 +11,10 @@
  #endif  /* CHROME_BROWSER_HELIUM_FLAG_CHOICES_H_ */
 --- a/chrome/browser/helium_flag_entries.h
 +++ b/chrome/browser/helium_flag_entries.h
-@@ -11,4 +11,9 @@
-      "Maximum frame rate for Energy Saver",
-      "Configures the frame rate the browser is throttled to when Energy Saver is enabled. Helium flag.",
-      kOsDesktop, MULTI_VALUE_TYPE(helium::kEnergySaverFrameRateChoices)},
+@@ -14,4 +14,9 @@
+     {helium::kUpdateServerUrlCommandLine, "Update server URL",
+      "Overrides the default URL for fetching updates. Helium flag.", kOsDesktop,
+      STRING_VALUE_TYPE(helium::kUpdateServerUrlCommandLine, "")},
 +    {helium::kDisableEchCommandLine,
 +     "Disable ECH (Encrypted Client Hello)",
 +     "Disables TLS Encrypted Client Hello. Not recommended unless you live in an area with heavy Internet"

--- a/patches/helium/core/add-disable-ech-flag.patch
+++ b/patches/helium/core/add-disable-ech-flag.patch
@@ -13,7 +13,7 @@
 +++ b/chrome/browser/helium_flag_entries.h
 @@ -14,4 +14,9 @@
      {helium::kUpdateServerUrlCommandLine, "Update server URL",
-      "Overrides the default URL for fetching updates. Helium flag.", kOsDesktop,
+      "Overrides the default URL for fetching updates. Should be used only for testing. Helium flag.", kOsDesktop,
       STRING_VALUE_TYPE(helium::kUpdateServerUrlCommandLine, "")},
 +    {helium::kDisableEchCommandLine,
 +     "Disable ECH (Encrypted Client Hello)",

--- a/patches/helium/core/add-middle-click-autoscroll-flag.patch
+++ b/patches/helium/core/add-middle-click-autoscroll-flag.patch
@@ -1,6 +1,6 @@
 --- a/chrome/browser/helium_flag_choices.h
 +++ b/chrome/browser/helium_flag_choices.h
-@@ -34,6 +34,8 @@ namespace helium {
+@@ -37,6 +37,8 @@ namespace helium {
    constexpr const char kHeliumNoiseCpuCoresCommandLine[] =
        "helium-noise-hw-concurrency";
  
@@ -11,7 +11,7 @@
  #endif  /* CHROME_BROWSER_HELIUM_FLAG_CHOICES_H_ */
 --- a/chrome/browser/helium_flag_entries.h
 +++ b/chrome/browser/helium_flag_entries.h
-@@ -33,4 +33,8 @@
+@@ -36,4 +36,8 @@
       "Randomizes the number of cores returned by "
       "`navigator.hardwareConcurrency` in a reasonable range. Helium flag.",
       kOsAll, FEATURE_VALUE_TYPE(blink::features::kHeliumNoiseCpuCores)},

--- a/patches/helium/core/add-updater-preference.patch
+++ b/patches/helium/core/add-updater-preference.patch
@@ -181,6 +181,6 @@
       "Configures the frame rate the browser is throttled to when Energy Saver is enabled. Helium flag.",
       kOsDesktop, MULTI_VALUE_TYPE(helium::kEnergySaverFrameRateChoices)},
 +    {helium::kUpdateServerUrlCommandLine, "Update server URL",
-+     "Overrides the default URL for fetching updates. Helium flag.", kOsDesktop,
++     "Overrides the default URL for fetching updates. Should be used only for testing. Helium flag.", kOsDesktop,
 +     STRING_VALUE_TYPE(helium::kUpdateServerUrlCommandLine, "")},
  #endif  /* CHROME_BROWSER_HELIUM_FLAG_ENTRIES_H_ */

--- a/patches/helium/core/add-updater-preference.patch
+++ b/patches/helium/core/add-updater-preference.patch
@@ -28,48 +28,65 @@
                              PrefChangeRegistrar& registrar, const base::RepeatingClosure& observer);
 --- a/components/helium_services/helium_services_helpers.cc
 +++ b/components/helium_services/helium_services_helpers.cc
-@@ -16,6 +16,14 @@
+@@ -6,6 +6,7 @@
+ 
+ #include <optional>
+ 
++#include "base/command_line.h"
+ #include "base/functional/bind.h"
+ #include "base/strings/stringprintf.h"
+ #include "components/helium_services/pref_names.h"
+@@ -15,6 +16,19 @@
+ #include "url/url_constants.h"
  
  namespace helium {
- 
-+#if BUILDFLAG(IS_MAC)
 +#if defined(ARCH_CPU_ARM_FAMILY)
-+constexpr std::string cpu_arch = "arm64";
++#define CPU_ARCH_STR "arm64"
 +#else
-+constexpr std::string cpu_arch = "x86_64";
-+#endif
++#define CPU_ARCH_STR "x86_64"
 +#endif
 +
++#if BUILDFLAG(IS_MAC)
++constexpr std::string_view kUpdateBaseUrl = "https://updates.helium.computer/";
++constexpr const char kUpdateMacPath[] = "mac/appcast-" CPU_ARCH_STR ".xml";
++
++// Duplicated from helium_flag_choices.h to avoid importing it.
++constexpr const char kUpdateServerUrlCommandLine[] = "custom-update-server-url";
++#endif
+ 
  std::optional<GURL> GetValidUserOverridenURL(std::string_view user_url_) {
      if (user_url_.empty()) {
-         return std::nullopt;
-@@ -73,6 +81,11 @@ bool ShouldFetchBangs(const PrefService&
+@@ -73,6 +87,11 @@ bool ShouldFetchBangs(const PrefService&
              prefs.GetBoolean(prefs::kHeliumBangsEnabled);
  }
  
 +bool ShouldAccessUpdateService(const PrefService& prefs) {
-+    return ShouldAccessServices(prefs) &&
-+            prefs.GetBoolean(prefs::kHeliumUpdateFetchingEnabled);
++  return ShouldAccessServices(prefs) &&
++         prefs.GetBoolean(prefs::kHeliumUpdateFetchingEnabled);
 +}
 +
  GURL GetExtensionUpdateURL(const PrefService& prefs) {
      if (!ShouldAccessExtensionService(prefs)) {
          return GetDummyURL();
-@@ -98,6 +111,20 @@ GURL GetSpellcheckURL(const PrefService&
+@@ -98,6 +117,24 @@ GURL GetSpellcheckURL(const PrefService&
      return GetServicesBaseURL(prefs).Resolve("/dict/");
  }
  
 +GURL GetBrowserUpdateURL(const PrefService& prefs) {
-+    if (!ShouldAccessUpdateService(prefs)) {
-+        return GetDummyURL();
-+    }
++  if (!ShouldAccessUpdateService(prefs)) {
++    return GetDummyURL();
++  }
 +
 +#if BUILDFLAG(IS_MAC)
-+    std::string path = base::StringPrintf(
-+        "/updates/mac/appcast-%s.xml", cpu_arch);
-+    return GetServicesBaseURL(prefs).Resolve(path);
++  const auto* command_line = base::CommandLine::ForCurrentProcess();
++  std::string baseUrl(kUpdateBaseUrl);
++  if (command_line->HasSwitch(helium::kUpdateServerUrlCommandLine)) {
++    baseUrl =
++        command_line->GetSwitchValueASCII(helium::kUpdateServerUrlCommandLine);
++  }
++  return GURL(baseUrl).Resolve(kUpdateMacPath);
 +#else
-+    return GetDummyURL();
++  return GetDummyURL();
 +#endif
 +}
 +
@@ -92,12 +109,11 @@
      </template>
 --- a/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
 +++ b/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
-@@ -2253,6 +2253,10 @@ void AddPrivacyStrings(content::WebUIDat
+@@ -2253,6 +2253,9 @@ void AddPrivacyStrings(content::WebUIDat
        {"heliumSpellcheckToggle", IDS_SETTINGS_HELIUM_SERVICES_SPELLCHECK_TOGGLE},
        {"heliumSpellcheckToggleDescription",
          IDS_SETTINGS_HELIUM_SERVICES_SPELLCHECK_TOGGLE_DESCRIPTION},
-+      {"heliumUpdatesToggle",
-+        IDS_SETTINGS_HELIUM_SERVICES_UPDATE},
++      {"heliumUpdatesToggle", IDS_SETTINGS_HELIUM_SERVICES_UPDATE},
 +      {"heliumUpdatesToggleDescription",
 +        IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION},
        {"heliumOriginOverride", IDS_SETTINGS_HELIUM_SERVICES_OVERRIDE},
@@ -146,3 +162,25 @@
    <message name="IDS_SETTINGS_HELIUM_SERVICES_OVERRIDE" desc="Text input for overriding the Helium services server">
      Use your own instance of Helium services
    </message>
+--- a/chrome/browser/helium_flag_choices.h
++++ b/chrome/browser/helium_flag_choices.h
+@@ -26,6 +26,9 @@ namespace helium {
+     {kChannelBeta, kChannelCommandLine, kChannelBeta},
+   };
+ 
++  constexpr const char kUpdateServerUrlCommandLine[] =
++      "custom-update-server-url";
++
+ }  // namespace helium
+ 
+ #endif  /* CHROME_BROWSER_HELIUM_FLAG_CHOICES_H_ */
+--- a/chrome/browser/helium_flag_entries.h
++++ b/chrome/browser/helium_flag_entries.h
+@@ -11,4 +11,7 @@
+      "Maximum frame rate for Energy Saver",
+      "Configures the frame rate the browser is throttled to when Energy Saver is enabled. Helium flag.",
+      kOsDesktop, MULTI_VALUE_TYPE(helium::kEnergySaverFrameRateChoices)},
++    {helium::kUpdateServerUrlCommandLine, "Update server URL",
++     "Overrides the default URL for fetching updates. Helium flag.", kOsDesktop,
++     STRING_VALUE_TYPE(helium::kUpdateServerUrlCommandLine, "")},
+ #endif  /* CHROME_BROWSER_HELIUM_FLAG_ENTRIES_H_ */

--- a/patches/helium/core/component-updates.patch
+++ b/patches/helium/core/component-updates.patch
@@ -14,7 +14,7 @@
  }  // namespace component_updater
 --- a/components/helium_services/helium_services_helpers.cc
 +++ b/components/helium_services/helium_services_helpers.cc
-@@ -9,6 +9,7 @@
+@@ -10,6 +10,7 @@
  #include "base/functional/bind.h"
  #include "base/strings/stringprintf.h"
  #include "components/helium_services/pref_names.h"
@@ -22,8 +22,8 @@
  #include "components/prefs/pref_service.h"
  #include "net/base/url_util.h"
  #include "url/gurl.h"
-@@ -86,6 +87,12 @@ bool ShouldAccessUpdateService(const Pre
-             prefs.GetBoolean(prefs::kHeliumUpdateFetchingEnabled);
+@@ -92,6 +93,12 @@ bool ShouldAccessUpdateService(const Pre
+          prefs.GetBoolean(prefs::kHeliumUpdateFetchingEnabled);
  }
  
 +bool ShouldAccessComponentUpdateService(const PrefService& prefs) {
@@ -35,7 +35,7 @@
  bool ShouldAccessUBlockAssets(const PrefService& prefs) {
      return ShouldAccessServices(prefs) &&
              prefs.GetBoolean(prefs::kHeliumUBlockAssetsEnabled);
-@@ -130,6 +137,14 @@ GURL GetBrowserUpdateURL(const PrefServi
+@@ -140,6 +147,14 @@ GURL GetBrowserUpdateURL(const PrefServi
  #endif
  }
  

--- a/patches/helium/core/noise/audio.patch
+++ b/patches/helium/core/noise/audio.patch
@@ -1,6 +1,6 @@
 --- a/chrome/browser/helium_flag_choices.h
 +++ b/chrome/browser/helium_flag_choices.h
-@@ -30,6 +30,7 @@ namespace helium {
+@@ -33,6 +33,7 @@ namespace helium {
  
    constexpr const char kHeliumNoiseCommandLine[] = "helium-noise";
    constexpr const char kHeliumNoiseCanvasCommandLine[] = "helium-noise-canvas";
@@ -10,7 +10,7 @@
  
 --- a/chrome/browser/helium_flag_entries.h
 +++ b/chrome/browser/helium_flag_entries.h
-@@ -24,4 +24,8 @@
+@@ -27,4 +27,8 @@
       "[Helium Noise] Canvas pixel noising",
       "Adds insignificant noise to canvas pixels during readback to deceive canvas-based fingerprinting. Helium flag.",
       kOsAll, FEATURE_VALUE_TYPE(blink::features::kHeliumNoiseCanvas)},

--- a/patches/helium/core/noise/canvas.patch
+++ b/patches/helium/core/noise/canvas.patch
@@ -36,7 +36,7 @@
 
 --- a/chrome/browser/helium_flag_choices.h
 +++ b/chrome/browser/helium_flag_choices.h
-@@ -29,6 +29,7 @@ namespace helium {
+@@ -32,6 +32,7 @@ namespace helium {
    constexpr const char kDisableEchCommandLine[] = "disable-ech";
  
    constexpr const char kHeliumNoiseCommandLine[] = "helium-noise";
@@ -46,7 +46,7 @@
  
 --- a/chrome/browser/helium_flag_entries.h
 +++ b/chrome/browser/helium_flag_entries.h
-@@ -20,4 +20,8 @@
+@@ -23,4 +23,8 @@
       "Helium Noise",
       "Helium's anti-fingerprinting functionality. Adds insignificant noise to various features to deceive fingerprinting scripts. Enabled by default, must be enabled for other anti-fingerprinting features to work. Helium flag.",
       kOsAll, FEATURE_VALUE_TYPE(blink::features::kHeliumNoise)},

--- a/patches/helium/core/noise/core.patch
+++ b/patches/helium/core/noise/core.patch
@@ -36,7 +36,7 @@
 
 --- a/chrome/browser/helium_flag_choices.h
 +++ b/chrome/browser/helium_flag_choices.h
-@@ -28,6 +28,8 @@ namespace helium {
+@@ -31,6 +31,8 @@ namespace helium {
  
    constexpr const char kDisableEchCommandLine[] = "disable-ech";
  
@@ -47,7 +47,7 @@
  #endif  /* CHROME_BROWSER_HELIUM_FLAG_CHOICES_H_ */
 --- a/chrome/browser/helium_flag_entries.h
 +++ b/chrome/browser/helium_flag_entries.h
-@@ -16,4 +16,8 @@
+@@ -19,4 +19,8 @@
       "Disables TLS Encrypted Client Hello. Not recommended unless you live in an area with heavy Internet"
       " censorship and ECH prevents websites from loading. Helium flag.",
       kOsAll, SINGLE_VALUE_TYPE(helium::kDisableEchCommandLine)},

--- a/patches/helium/core/noise/hardware-concurrency.patch
+++ b/patches/helium/core/noise/hardware-concurrency.patch
@@ -1,6 +1,6 @@
 --- a/chrome/browser/helium_flag_choices.h
 +++ b/chrome/browser/helium_flag_choices.h
-@@ -31,6 +31,8 @@ namespace helium {
+@@ -34,6 +34,8 @@ namespace helium {
    constexpr const char kHeliumNoiseCommandLine[] = "helium-noise";
    constexpr const char kHeliumNoiseCanvasCommandLine[] = "helium-noise-canvas";
    constexpr const char kHeliumNoiseAudioCommandLine[] = "helium-noise-audio";
@@ -11,7 +11,7 @@
  
 --- a/chrome/browser/helium_flag_entries.h
 +++ b/chrome/browser/helium_flag_entries.h
-@@ -28,4 +28,9 @@
+@@ -31,4 +31,9 @@
       "[Helium Noise] Jitter audio context data",
       "Adds insignificant jitter to audio data to deceive AudioContext-based fingerprinting. Helium flag.",
       kOsAll, FEATURE_VALUE_TYPE(blink::features::kHeliumNoiseAudio)},

--- a/patches/helium/core/ublock-helium-services.patch
+++ b/patches/helium/core/ublock-helium-services.patch
@@ -1,7 +1,7 @@
 --- a/components/helium_services/helium_services_helpers.cc
 +++ b/components/helium_services/helium_services_helpers.cc
-@@ -86,6 +86,11 @@ bool ShouldAccessUpdateService(const Pre
-             prefs.GetBoolean(prefs::kHeliumUpdateFetchingEnabled);
+@@ -92,6 +92,11 @@ bool ShouldAccessUpdateService(const Pre
+          prefs.GetBoolean(prefs::kHeliumUpdateFetchingEnabled);
  }
  
 +bool ShouldAccessUBlockAssets(const PrefService& prefs) {
@@ -12,7 +12,7 @@
  GURL GetExtensionUpdateURL(const PrefService& prefs) {
      if (!ShouldAccessExtensionService(prefs)) {
          return GetDummyURL();
-@@ -125,6 +130,14 @@ GURL GetBrowserUpdateURL(const PrefServi
+@@ -135,6 +140,14 @@ GURL GetBrowserUpdateURL(const PrefServi
  #endif
  }
  
@@ -246,8 +246,8 @@
      </template>
 --- a/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
 +++ b/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
-@@ -2257,6 +2257,10 @@ void AddPrivacyStrings(content::WebUIDat
-         IDS_SETTINGS_HELIUM_SERVICES_UPDATE},
+@@ -2256,6 +2256,10 @@ void AddPrivacyStrings(content::WebUIDat
+       {"heliumUpdatesToggle", IDS_SETTINGS_HELIUM_SERVICES_UPDATE},
        {"heliumUpdatesToggleDescription",
          IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION},
 +      {"heliumUboToggle",

--- a/patches/helium/settings/add-search-engine-button.patch
+++ b/patches/helium/settings/add-search-engine-button.patch
@@ -32,7 +32,7 @@
        {"advancedPageTitle", IDS_SETTINGS_ADVANCED},
        {"back", IDS_ACCNAME_BACK},
        {"basicPageTitle", IDS_SETTINGS_BASIC},
-@@ -2924,6 +2925,8 @@ void AddSearchEnginesStrings(content::We
+@@ -2923,6 +2924,8 @@ void AddSearchEnginesStrings(content::We
         IDS_SETTINGS_SEARCH_ENGINES_PAGE_EXPLANATION},
        {"searchEnginesAddSiteSearch",
         IDS_SETTINGS_SEARCH_ENGINES_ADD_SITE_SEARCH},

--- a/patches/helium/settings/custom-keyboard-shortcuts-page.patch
+++ b/patches/helium/settings/custom-keyboard-shortcuts-page.patch
@@ -1024,7 +1024,7 @@
  #include "chrome/browser/browser_process.h"
  #include "chrome/browser/browser_process_platform_part.h"
  #include "chrome/browser/content_settings/host_content_settings_map_factory.h"
-@@ -4079,6 +4080,26 @@ void AddSystemStrings(content::WebUIData
+@@ -4078,6 +4079,26 @@ void AddSystemStrings(content::WebUIData
        {"isolationStateLabel", IDS_SETTINGS_SYSTEM_ISOLATION_STATE_LABEL},
  #endif  // BUILDFLAG(IS_WIN)
        {"proxySettingsLabel", IDS_SETTINGS_SYSTEM_PROXY_SETTINGS_LABEL},
@@ -1051,7 +1051,7 @@
  #if BUILDFLAG(IS_WIN) && BUILDFLAG(GOOGLE_CHROME_BRANDING)
        {"featureNotificationsLabel",
         IDS_SETTINGS_SYSTEM_FEATURE_NOTIFICATIONS_LABEL},
-@@ -4089,6 +4110,9 @@ void AddSystemStrings(content::WebUIData
+@@ -4088,6 +4109,9 @@ void AddSystemStrings(content::WebUIData
  #endif  // BUILDFLAG(GOOGLE_CHROME_BRANDING)
    };
    html_source->AddLocalizedStrings(kLocalizedStrings);

--- a/patches/helium/settings/fix-text-on-cookies-page.patch
+++ b/patches/helium/settings/fix-text-on-cookies-page.patch
@@ -31,7 +31,7 @@
        {"doNotTrackDialogLearnMoreA11yLabel",
         IDS_SETTINGS_ENABLE_DO_NOT_TRACK_DIALOG_LEARN_MORE_ACCESSIBILITY_LABEL},
        // TODO(crbug.com/40122957): This string is no longer used. Remove.
-@@ -3042,7 +3042,7 @@ void AddSiteSettingsStrings(content::Web
+@@ -3041,7 +3041,7 @@ void AddSiteSettingsStrings(content::Web
        {"trackingProtectionSitesAllowedCookiesTitle",
         IDS_SETTINGS_TRACKING_PROTECTION_SITES_ALLOWED_COOKIES_TITLE},
        {"trackingProtectionSitesAllowedCookiesDescription",

--- a/patches/helium/ui/experiments/zen-mode-wiring.patch
+++ b/patches/helium/ui/experiments/zen-mode-wiring.patch
@@ -179,7 +179,7 @@
  BASE_DECLARE_FEATURE(kBrowserWidgetCacheThemeService);
 --- a/chrome/browser/helium_flag_choices.h
 +++ b/chrome/browser/helium_flag_choices.h
-@@ -37,7 +37,7 @@ namespace helium {
+@@ -40,7 +40,7 @@ namespace helium {
    constexpr const char kMiddleClickAutoscrollCommandLine[] = "middle-click-autoscroll";
    constexpr const char kHeliumCompactLocationWidthCommandLine[] =
        "helium-compact-location-width";
@@ -190,7 +190,7 @@
  #endif  /* CHROME_BROWSER_HELIUM_FLAG_CHOICES_H_ */
 --- a/chrome/browser/helium_flag_entries.h
 +++ b/chrome/browser/helium_flag_entries.h
-@@ -41,4 +41,9 @@
+@@ -44,4 +44,9 @@
       "Automatic address bar width in compact layout",
       "Allows the location bar to automatically reduce its width in the compact browser layout. The omnibox may be uncomfortable to use. Helium flag.",
       kOsDesktop, FEATURE_VALUE_TYPE(features::kHeliumCompactLocationWidth)},

--- a/patches/helium/ui/layout/compact.patch
+++ b/patches/helium/ui/layout/compact.patch
@@ -1,6 +1,6 @@
 --- a/chrome/browser/helium_flag_choices.h
 +++ b/chrome/browser/helium_flag_choices.h
-@@ -35,6 +35,8 @@ namespace helium {
+@@ -38,6 +38,8 @@ namespace helium {
        "helium-noise-hw-concurrency";
  
    constexpr const char kMiddleClickAutoscrollCommandLine[] = "middle-click-autoscroll";
@@ -11,7 +11,7 @@
  
 --- a/chrome/browser/helium_flag_entries.h
 +++ b/chrome/browser/helium_flag_entries.h
-@@ -37,4 +37,8 @@
+@@ -40,4 +40,8 @@
       "Middle Click Autoscroll",
       "Enables autoscroll on middle click. Helium flag, Chromium feature.",
       kOsDesktop, FEATURE_VALUE_TYPE(blink::features::kHeliumMiddleClickAutoscroll)},


### PR DESCRIPTION
there is not really any benefit to passing updates via helium services, since they need to be signed and notarized anyways, so they are not really substitutable

on the other hand though, this lets us take advantage of CDN caching for serving updates which should hopefully make downloads a little faster