### PR TITLE
helium/ui/layout: fix new tab button hidden in dynamic mode

### DIFF
--- a/patches/helium/ui/layout/horizontal-tabs.patch
+++ b/patches/helium/ui/layout/horizontal-tabs.patch
@@ -38,7 +38,8 @@
 +  }
 +
 +  return layout_controller->IsClassicLayout() ||
-+         layout_controller->IsCompactLayout();
++         layout_controller->IsCompactLayout() ||
++         layout_controller->IsDynamicLayout();
 +}
 +
 +views::View* GetVisibleView(views::View* view) {
@@ -158,7 +159,8 @@
 +  }
 +
 +  return layout_controller->IsClassicLayout() ||
-+         layout_controller->IsCompactLayout();
++         layout_controller->IsCompactLayout() ||
++         layout_controller->IsDynamicLayout();
 +}
 +
  class TabStyleViewsImpl : public TabStyleViews {


### PR DESCRIPTION
For your pull request to not get closed without review, please confirm that:

- [ ] An issue exists where the maintainers agreed that this should be implemented
      (an approved feature request, or confirmed bug).
- [X] I tested that my contribution works locally, and does not break anything,
      otherwise I have marked my PR as draft.
- [ ] If my contribution is non-trivial, I did not use AI to write most of it.
- [x] I understand that I will be permanently banned from interacting with this
      organization if I lied by checking any of these checkboxes.

Tested on (check one or more):
- [X] Windows
- [ ] macOS
- [ ] Linux

---

The "+" new tab button disappears when switching to Dynamic mode.

In `horizontal-tabs.patch`, both `ShouldShowNewTabButton()` and
`ShouldShowTrailingSeparatorAfterLastTab()` only returned true for
Classic and Compact layouts — Dynamic was missing from both checks.

Fix: add `|| layout_controller->IsDynamicLayout()` to both return
conditions.

Relates to the bug report: #1861 

**note : i asked questions to ai to find you what might be causing the problem, then fixed it manually**