### PR TITLE
helium/core/update-pref: improve auto updates strings

### DIFF
--- a/i18n/source.gen.json
+++ b/i18n/source.gen.json
@@ -261,19 +261,25 @@
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
     "source": "chrome/app/settings_strings.grdp",
     "context": "Toggle for automatic update downloads",
-    "message": "Allow automatic browser and component updates"
+    "message": "Allow automatic browser updates"
   },
   {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
     "source": "chrome/app/settings_strings.grdp",
     "context": "Description of the toggle for automatic update downloads",
-    "message": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates."
+    "message": "Helium will automatically check for updates and install them. This includes browser and component updates. We recommend keeping this setting enabled to ensure you get the latest features and security updates."
+  },
+  {
+    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
+    "source": "chrome/app/settings_strings.grdp",
+    "context": "Toggle for automatic update downloads",
+    "message": "Allow automatic component updates"
   },
   {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
     "source": "chrome/app/settings_strings.grdp",
     "context": "Description of the toggle for automatic update downloads",
-    "message": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date."
+    "message": "Helium will automatically check for component updates and install them. We recommend keeping this setting enabled. On Linux, browser updates are handled by your distro's package manager. Please check for Helium package updates at least every week."
   },
   {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",

--- a/i18n/translations/af.json
+++ b/i18n/translations/af.json
@@ -191,21 +191,6 @@
     "message": "Weergawe <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "Laat outomatiese blaaier- en komponentopdaterings toe"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium sal outomaties blaaier- en komponentopdaterings aflaai en installeer soos hulle beskikbaar word. Ons beveel aan dat u hierdie instelling geaktiveer hou om te verseker dat u die nuutste kenmerke en sekuriteitsopdaterings kry."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium sal outomaties blaaier- en komponentopdaterings aflaai en installeer soos hulle beskikbaar word. Ons beveel aan dat u hierdie instelling geaktiveer hou om te verseker dat u die nuutste kenmerke en sekuriteitsopdaterings kry. Outomatiese kernblaaier-opdaterings is nog nie op hierdie platform beskikbaar nie, maar komponentopdaterings wel. Gebruik asseblief eksterne sagteware om Helium op datum te hou."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "Laat die aflaai van filterlyste vir uBlock Origin toe"

--- a/i18n/translations/am.json
+++ b/i18n/translations/am.json
@@ -190,21 +190,6 @@
     "message": "ስሪት <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>፣ <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "ራስ-ሰር የአሳሽ እና የክፍለ-ነገር ማዘመኛዎችን ይፍቀዱ"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium የአሳሽ እና የክፍለ-ነገር ማዘመኛዎችን ሲገኙ በራስ-ሰር ያወርዳል እና ይጭናል። ወቅታዊ ባህሪያትን እና የደህንነት ማዘመኛዎችን ለማግኘት ይህን ቅንብር ነቅቶ እንዲቆይ እንመክራለን።"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium የአሳሽ እና የክፍለ-ነገር ማዘመኛዎችን ሲገኙ በራስ-ሰር ያወርዳል እና ይጭናል። ወቅታዊ ባህሪያትን እና የደህንነት ማዘመኛዎችን ለማግኘት ይህን ቅንብር ነቅቶ እንዲቆይ እንመክራለን። ራስ-ሰር ዋና የአሳሽ ማዘመኛዎች በዚህ መድረክ ላይ ገና አይገኙም፣ ነገር ግን የክፍለ-ነገር ማዘመኛዎች ይገኛሉ። Heliumን ወቅታዊ ለማድረግ እባክዎ ውጫዊ ሶፍትዌር ይጠቀሙ።"
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "ለuBlock Origin የማጣሪያ ዝርዝሮችን ማውረድ ይፍቀዱ"

--- a/i18n/translations/ar.json
+++ b/i18n/translations/ar.json
@@ -190,21 +190,6 @@
     "message": "الإصدار <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>، <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "السماح بالتحديثات التلقائية للمتصفح والمكونات"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "سيقوم Helium تلقائيًا بتنزيل وتثبيت تحديثات المتصفح والمكونات عند توفرها. نوصي بإبقاء هذا الإعداد مفعلاً لضمان حصولك على أحدث الميزات والتحديثات الأمنية."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "سيقوم Helium تلقائيًا بتنزيل وتثبيت تحديثات المتصفح والمكونات عند توفرها. نوصي بإبقاء هذا الإعداد مفعلاً لضمان حصولك على أحدث الميزات والتحديثات الأمنية. التحديثات التلقائية الأساسية للمتصفح غير متاحة على هذا النظام بعد، لكن تحديثات المكونات متاحة. يرجى استخدام برنامج خارجي لإبقاء Helium محدّثًا."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "السماح بتنزيل قوائم التصفية لـ uBlock Origin"

--- a/i18n/translations/as.json
+++ b/i18n/translations/as.json
@@ -190,21 +190,6 @@
     "message": "সংস্কৰণ <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "স্বয়ংক্ৰিয় ব্ৰাউজাৰ আৰু উপাদান আপডেটৰ অনুমতি দিয়ক"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium-এ উপলব্ধ হ'লে ব্ৰাউজাৰ আৰু উপাদান আপডেটসমূহ স্বয়ংক্ৰিয়ভাৱে ডাউনলোড আৰু ইনষ্টল কৰিব। আপুনি শেহতীয়া বৈশিষ্ট্য আৰু সুৰক্ষা আপডেটসমূহ পোৱাটো নিশ্চিত কৰিবলৈ আমি এই ছেটিং সক্ষম ৰাখিবলৈ পৰামৰ্শ দিওঁ।"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium-এ উপলব্ধ হ'লে ব্ৰাউজাৰ আৰু উপাদান আপডেটসমূহ স্বয়ংক্ৰিয়ভাৱে ডাউনলোড আৰু ইনষ্টল কৰিব। আপুনি শেহতীয়া বৈশিষ্ট্য আৰু সুৰক্ষা আপডেটসমূহ পোৱাটো নিশ্চিত কৰিবলৈ আমি এই ছেটিং সক্ষম ৰাখিবলৈ পৰামৰ্শ দিওঁ। এই প্লেটফৰ্মত এতিয়ালৈকে স্বয়ংক্ৰিয় মূল ব্ৰাউজাৰ আপডেট উপলব্ধ নহয়, কিন্তু উপাদান আপডেট উপলব্ধ। অনুগ্ৰহ কৰি Helium আপডেট কৰিবলৈ বাহ্যিক চফ্টৱেৰ ব্যৱহাৰ কৰক।"
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "uBlock Origin ৰ বাবে ফিল্টাৰ তালিকা ডাউনলোড কৰিবলৈ অনুমতি দিয়ক"

--- a/i18n/translations/az.json
+++ b/i18n/translations/az.json
@@ -190,21 +190,6 @@
     "message": "Versiya <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "Avtomatik brauzer və komponent yeniləmələrinə icazə ver"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium brauzer və komponent yeniləmələrini mövcud olduqca avtomatik yükləyəcək və quraşdıracaq. Ən son funksiyaları və təhlükəsizlik yeniləmələrini almağınızı təmin etmək üçün bu parametri aktiv saxlamağı tövsiyə edirik."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium brauzer və komponent yeniləmələrini mövcud olduqca avtomatik yükləyəcək və quraşdıracaq. Ən son funksiyaları və təhlükəsizlik yeniləmələrini almağınızı təmin etmək üçün bu parametri aktiv saxlamağı tövsiyə edirik. Avtomatik əsas brauzer yeniləmələri bu platformada hələ əlçatan deyil, lakin komponent yeniləmələri əlçatandır. Helium-u güncəl saxlamaq üçün xarici proqram təminatından istifadə edin."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "uBlock Origin üçün filtr siyahılarının yüklənməsinə icazə ver"

--- a/i18n/translations/be.json
+++ b/i18n/translations/be.json
@@ -190,21 +190,6 @@
     "message": "Версія <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "Дазволіць аўтаматычныя абнаўленні браўзера і кампанентаў"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium будзе аўтаматычна спампоўваць і ўсталёўваць абнаўленні браўзера і кампанентаў па меры іх з'яўлення. Мы рэкамендуем пакінуць гэту наладу ўключанай, каб атрымліваць апошнія функцыі і абнаўленні бяспекі."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium будзе аўтаматычна спампоўваць і ўсталёўваць абнаўленні браўзера і кампанентаў па меры іх з'яўлення. Мы рэкамендуем пакінуць гэту наладу ўключанай, каб атрымліваць апошнія функцыі і абнаўленні бяспекі. Аўтаматычныя абнаўленні ядра браўзера яшчэ недаступныя на гэтай платформе, але абнаўленні кампанентаў працуюць. Калі ласка, выкарыстоўвайце знешняе праграмнае забеспячэнне для падтрымкі Helium у актуальным стане."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "Дазволіць спампоўку спісаў фільтраў для uBlock Origin"

--- a/i18n/translations/bg.json
+++ b/i18n/translations/bg.json
@@ -190,21 +190,6 @@
     "message": "Версия <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "Разрешаване на автоматични актуализации на браузъра и компонентите"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium автоматично ще изтегля и инсталира актуализации на браузъра и компонентите, когато станат налични. Препоръчваме да оставите тази настройка включена, за да получавате най-новите функции и актуализации за сигурност."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium автоматично ще изтегля и инсталира актуализации на браузъра и компонентите, когато станат налични. Препоръчваме да оставите тази настройка включена, за да получавате най-новите функции и актуализации за сигурност. Автоматичните основни актуализации на браузъра все още не са налични на тази платформа, но актуализациите на компонентите са. Моля, използвайте външен софтуер, за да поддържате Helium актуален."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "Разрешаване на изтеглянето на филтърни списъци за uBlock Origin"

--- a/i18n/translations/bn.json
+++ b/i18n/translations/bn.json
@@ -190,21 +190,6 @@
     "message": "সংস্করণ <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "স্বয়ংক্রিয় ব্রাউজার ও কম্পোনেন্ট আপডেটের অনুমতি দিন"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium স্বয়ংক্রিয়ভাবে ব্রাউজার ও কম্পোনেন্ট আপডেট উপলব্ধ হলে ডাউনলোড ও ইনস্টল করবে। সর্বশেষ বৈশিষ্ট্য এবং নিরাপত্তা আপডেট পেতে এই সেটিং সক্রিয় রাখার পরামর্শ দেওয়া হচ্ছে।"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium স্বয়ংক্রিয়ভাবে ব্রাউজার ও কম্পোনেন্ট আপডেট উপলব্ধ হলে ডাউনলোড ও ইনস্টল করবে। সর্বশেষ বৈশিষ্ট্য এবং নিরাপত্তা আপডেট পেতে এই সেটিং সক্রিয় রাখার পরামর্শ দেওয়া হচ্ছে। এই প্ল্যাটফর্মে স্বয়ংক্রিয় মূল ব্রাউজার আপডেট এখনও উপলব্ধ নয়, তবে কম্পোনেন্ট আপডেট আছে। অনুগ্রহ করে Helium আপ টু ডেট রাখতে বাহ্যিক সফ্টওয়্যার ব্যবহার করুন।"
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "uBlock Origin-এর জন্য ফিল্টার তালিকা ডাউনলোডের অনুমতি দিন"

--- a/i18n/translations/bs.json
+++ b/i18n/translations/bs.json
@@ -191,21 +191,6 @@
     "message": "Verzija <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "Dozvoli automatska ažuriranja preglednika i komponenti"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium će automatski preuzimati i instalirati ažuriranja preglednika i komponenti čim postanu dostupna. Preporučujemo da ovu postavku ostavite omogućenom kako biste dobili najnovije funkcije i sigurnosna ažuriranja."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium će automatski preuzimati i instalirati ažuriranja preglednika i komponenti čim postanu dostupna. Preporučujemo da ovu postavku ostavite omogućenom kako biste dobili najnovije funkcije i sigurnosna ažuriranja. Automatska ažuriranja jezgra preglednika još nisu dostupna na ovoj platformi, ali ažuriranja komponenti jesu. Koristite vanjski softver da održavate Helium ažurnim."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "Dozvoli preuzimanje lista filtera za uBlock Origin"

--- a/i18n/translations/ca.json
+++ b/i18n/translations/ca.json
@@ -191,21 +191,6 @@
     "message": "Versió <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "Permet les actualitzacions automàtiques del navegador i els seus components"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium descarregarà i instal·larà automàticament les actualitzacions del navegador i dels components a mesura que estiguin disponibles. Recomanem mantenir aquesta opció activada per assegurar que tens les últimes funcions i actualitzacions de seguretat."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium descarregarà i instal·larà automàticament les actualitzacions del navegador i dels components a mesura que estiguin disponibles. Recomanem mantenir aquesta opció activada per assegurar que tens les últimes funcions i actualitzacions de seguretat. Les actualitzacions automàtiques del navegador principal encara no estan disponibles en aquesta plataforma, però les actualitzacions de components sí. Utilitza programari extern per mantenir Helium actualitzat."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "Permet descarregar llistes de filtres per a uBlock Origin"

--- a/i18n/translations/cs.json
+++ b/i18n/translations/cs.json
@@ -190,21 +190,6 @@
     "message": "Verze <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "Povolit automatické aktualizace prohlížeče a komponent"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium bude automaticky stahovat a instalovat aktualizace prohlížeče a komponent, jakmile budou dostupné. Doporučujeme ponechat toto nastavení povolené, abyste měli nejnovější funkce a bezpečnostní aktualizace."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium bude automaticky stahovat a instalovat aktualizace prohlížeče a komponent, jakmile budou dostupné. Doporučujeme ponechat toto nastavení povolené, abyste měli nejnovější funkce a bezpečnostní aktualizace. Automatické aktualizace prohlížeče zatím nejsou na této platformě dostupné, ale aktualizace komponent ano. Pro udržení Heliumu v aktuálním stavu prosím použijte externí software."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "Povolit stahování seznamů filtrů pro uBlock Origin"

--- a/i18n/translations/cy.json
+++ b/i18n/translations/cy.json
@@ -190,21 +190,6 @@
     "message": "Fersiwn <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "Caniatáu diweddariadau porwr a chydrannau awtomatig"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Bydd Helium yn llwytho ac yn gosod diweddariadau porwr a chydrannau yn awtomatig wrth iddynt ddod ar gael. Rydym yn argymell cadw'r gosodiad hwn wedi'i alluogi i sicrhau eich bod yn cael y nodweddion diweddaraf a diweddariadau diogelwch."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Bydd Helium yn llwytho ac yn gosod diweddariadau porwr a chydrannau yn awtomatig wrth iddynt ddod ar gael. Rydym yn argymell cadw'r gosodiad hwn wedi'i alluogi i sicrhau eich bod yn cael y nodweddion diweddaraf a diweddariadau diogelwch. Nid yw diweddariadau awtomatig i'r porwr craidd ar gael ar y platfform hwn eto, ond mae diweddariadau cydran ar gael. Defnyddiwch feddalwedd allanol i gadw Helium yn gyfredol."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "Caniatáu llwytho rhestrau hidlo ar gyfer uBlock Origin"

--- a/i18n/translations/da.json
+++ b/i18n/translations/da.json
@@ -190,21 +190,6 @@
     "message": "Version <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "Tillad automatiske browser- og komponentopdateringer"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium downloader og installerer automatisk browser- og komponentopdateringer, når de bliver tilgængelige. Vi anbefaler at holde denne indstilling aktiveret for at sikre, at du får de nyeste funktioner og sikkerhedsopdateringer."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium downloader og installerer automatisk browser- og komponentopdateringer, når de bliver tilgængelige. Vi anbefaler at holde denne indstilling aktiveret for at sikre, at du får de nyeste funktioner og sikkerhedsopdateringer. Automatiske kernebrowseropdateringer er endnu ikke tilgængelige på denne platform, men komponentopdateringer er. Brug ekstern software til at holde Helium opdateret."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "Tillad download af filterlister til uBlock Origin"

--- a/i18n/translations/de.json
+++ b/i18n/translations/de.json
@@ -190,21 +190,6 @@
     "message": "Version <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "Automatische Browser- und Komponentenupdates zulassen"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium lädt Browser- und Komponentenupdates automatisch herunter und installiert sie, sobald sie verfügbar sind. Wir empfehlen, diese Einstellung aktiviert zu lassen, damit du die neuesten Funktionen und Sicherheitsupdates erhältst."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium lädt Browser- und Komponentenupdates automatisch herunter und installiert sie, sobald sie verfügbar sind. Wir empfehlen, diese Einstellung aktiviert zu lassen, damit du die neuesten Funktionen und Sicherheitsupdates erhältst. Automatische Browser-Updates sind auf dieser Plattform noch nicht verfügbar, Komponentenupdates jedoch schon. Bitte verwende externe Software, um Helium aktuell zu halten."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "Download von Filterlisten für uBlock Origin erlauben"

--- a/i18n/translations/el.json
+++ b/i18n/translations/el.json
@@ -190,21 +190,6 @@
     "message": "Έκδοση <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "Να επιτρέπονται οι αυτόματες ενημερώσεις προγράμματος περιήγησης και στοιχείων"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Το Helium θα λαμβάνει και θα εγκαθιστά αυτόματα ενημερώσεις προγράμματος περιήγησης και στοιχείων μόλις γίνουν διαθέσιμες. Συνιστούμε να διατηρήσετε αυτήν τη ρύθμιση ενεργοποιημένη για να λαμβάνετε τις πιο πρόσφατες λειτουργίες και ενημερώσεις ασφαλείας."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Το Helium θα λαμβάνει και θα εγκαθιστά αυτόματα ενημερώσεις προγράμματος περιήγησης και στοιχείων μόλις γίνουν διαθέσιμες. Συνιστούμε να διατηρήσετε αυτήν τη ρύθμιση ενεργοποιημένη για να λαμβάνετε τις πιο πρόσφατες λειτουργίες και ενημερώσεις ασφαλείας. Οι αυτόματες ενημερώσεις του βασικού προγράμματος περιήγησης δεν είναι ακόμα διαθέσιμες σε αυτήν την πλατφόρμα, αλλά οι ενημερώσεις στοιχείων είναι. Χρησιμοποιήστε εξωτερικό λογισμικό για να διατηρείτε το Helium ενημερωμένο."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "Να επιτρέπεται η λήψη λιστών φίλτρων για το uBlock Origin"

--- a/i18n/translations/en-GB.json
+++ b/i18n/translations/en-GB.json
@@ -190,21 +190,6 @@
     "message": "Version <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "Allow automatic browser and component updates"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "Allow downloading filter lists for uBlock Origin"

--- a/i18n/translations/es-419.json
+++ b/i18n/translations/es-419.json
@@ -191,21 +191,6 @@
     "message": "Versión <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "Permitir actualizaciones automáticas del navegador y componentes"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium descargará e instalará automáticamente las actualizaciones del navegador y componentes a medida que estén disponibles. Recomendamos mantener esta opción habilitada para asegurarse de recibir las últimas funciones y actualizaciones de seguridad."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium descargará e instalará automáticamente las actualizaciones del navegador y componentes a medida que estén disponibles. Recomendamos mantener esta opción habilitada para asegurarse de recibir las últimas funciones y actualizaciones de seguridad. Las actualizaciones automáticas del navegador principal aún no están disponibles en esta plataforma, pero las actualizaciones de componentes sí lo están. Por favor, utilice software externo para mantener Helium actualizado."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "Permitir la descarga de listas de filtros para uBlock Origin"

--- a/i18n/translations/es.json
+++ b/i18n/translations/es.json
@@ -190,21 +190,6 @@
     "message": "Versión <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "Permitir actualizaciones automáticas del navegador y los componentes"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium descargará e instalará automáticamente las actualizaciones del navegador y los componentes en cuanto estén disponibles. Recomendamos que mantengas esta opción activada para asegurarte de obtener las últimas funciones y actualizaciones de seguridad."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium descargará e instalará automáticamente las actualizaciones del navegador y los componentes en cuanto estén disponibles. Recomendamos que mantengas esta opción activada para asegurarte de obtener las últimas funciones y actualizaciones de seguridad. Las actualizaciones automáticas del navegador base aún no están disponibles para esta plataforma, sin embargo, las de componentes sí. Usa software externo para mantener Helium actualizado."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "Permitir la descarga de listas de filtros para uBlock Origin"

--- a/i18n/translations/et.json
+++ b/i18n/translations/et.json
@@ -190,21 +190,6 @@
     "message": "Versioon <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "Luba automaatsed brauseri ja komponentide uuendused"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium laadib alla ja paigaldab brauseri ja komponentide uuendused automaatselt, kui need saadavale tulevad. Soovitame selle sätte lubatuna hoida, et saaksite uusimad funktsioonid ja turvauuendused."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium laadib alla ja paigaldab brauseri ja komponentide uuendused automaatselt, kui need saadavale tulevad. Soovitame selle sätte lubatuna hoida, et saaksite uusimad funktsioonid ja turvauuendused. Automaatsed brauseri põhiuuendused pole sellel platvormil veel saadaval, kuid komponentide uuendused on. Palun kasutage Heliumi ajakohasena hoidmiseks välist tarkvara."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "Luba uBlock Origini filtriloendite allalaadimine"

--- a/i18n/translations/eu.json
+++ b/i18n/translations/eu.json
@@ -192,21 +192,6 @@
     "message": "Bertsioa <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "Baimendu nabigatzailearen eta osagaien eguneraketa automatikoak"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium-ek automatikoki deskargatuko eta instalatuko ditu nabigatzailearen eta osagaien eguneraketak eskuragarri daudenean. Ezarpen hau gaituta mantentzea gomendatzen dugu azken funtzioak eta segurtasun-eguneraketak jasotzen dituzula ziurtatzeko."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium-ek automatikoki deskargatuko eta instalatuko ditu nabigatzailearen eta osagaien eguneraketak eskuragarri daudenean. Ezarpen hau gaituta mantentzea gomendatzen dugu azken funtzioak eta segurtasun-eguneraketak jasotzen dituzula ziurtatzeko. Nabigatzaile nagusiaren eguneraketa automatikoak oraindik ez daude eskuragarri plataforma honetan, baina osagaien eguneraketak bai. Mesedez, erabili kanpoko softwarea Helium eguneratuta mantentzeko."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "Baimendu uBlock Origin-en iragazki-zerrendak deskargatzea"

--- a/i18n/translations/fa.json
+++ b/i18n/translations/fa.json
@@ -190,21 +190,6 @@
     "message": "نسخه <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>، <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "اجازه به‌روزرسانی خودکار مرورگر و مؤلفه‌ها"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium به‌روزرسانی‌های مرورگر و مؤلفه‌ها را به‌طور خودکار دانلود و نصب می‌کند. توصیه می‌کنیم این تنظیم را فعال نگه دارید تا از دریافت آخرین قابلیت‌ها و به‌روزرسانی‌های امنیتی اطمینان حاصل کنید."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium به‌روزرسانی‌های مرورگر و مؤلفه‌ها را به‌طور خودکار دانلود و نصب می‌کند. توصیه می‌کنیم این تنظیم را فعال نگه دارید تا از دریافت آخرین قابلیت‌ها و به‌روزرسانی‌های امنیتی اطمینان حاصل کنید. به‌روزرسانی‌های خودکار هسته مرورگر هنوز در این پلتفرم در دسترس نیست، اما به‌روزرسانی مؤلفه‌ها امکان‌پذیر است. لطفاً از نرم‌افزار خارجی برای به‌روز نگه داشتن Helium استفاده کنید."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "اجازه دانلود فهرست‌های فیلتر برای uBlock Origin"

--- a/i18n/translations/fi.json
+++ b/i18n/translations/fi.json
@@ -190,21 +190,6 @@
     "message": "Versio <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "Salli automaattiset selain- ja komponenttipäivitykset"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium lataa ja asentaa selain- ja komponenttipäivitykset automaattisesti niiden tullessa saataville. Suosittelemme pitämään tämän asetuksen käytössä, jotta saat uusimmat ominaisuudet ja tietoturvapäivitykset."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium lataa ja asentaa selain- ja komponenttipäivitykset automaattisesti niiden tullessa saataville. Suosittelemme pitämään tämän asetuksen käytössä, jotta saat uusimmat ominaisuudet ja tietoturvapäivitykset. Automaattiset selainpäivitykset eivät ole vielä saatavilla tällä alustalla, mutta komponenttipäivitykset ovat. Käytä ulkoista ohjelmistoa pitääksesi Heliumin ajan tasalla."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "Salli suodatinlistojen lataaminen uBlock Originille"

--- a/i18n/translations/fil.json
+++ b/i18n/translations/fil.json
@@ -190,21 +190,6 @@
     "message": "Bersyon <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "Payagan ang mga awtomatikong pag-update ng browser at component"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Awtomatikong ida-download at ii-install ng Helium ang mga pag-update ng browser at component kapag available na ang mga ito. Inirerekomenda naming panatilihing naka-enable ang setting na ito para matiyak na makukuha mo ang mga pinakabagong feature at security update."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Awtomatikong ida-download at ii-install ng Helium ang mga pag-update ng browser at component kapag available na ang mga ito. Inirerekomenda naming panatilihing naka-enable ang setting na ito para matiyak na makukuha mo ang mga pinakabagong feature at security update. Hindi pa available ang mga awtomatikong pag-update ng core browser sa platform na ito, pero available ang mga pag-update ng component. Mangyaring gumamit ng external na software para mapanatiling updated ang Helium."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "Payagan ang pag-download ng mga filter list para sa uBlock Origin"

--- a/i18n/translations/fr-CA.json
+++ b/i18n/translations/fr-CA.json
@@ -190,21 +190,6 @@
     "message": "Version <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "Autoriser les mises à jour automatiques du navigateur et des composants"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium téléchargera et installera automatiquement les mises à jour du navigateur et des composants dès qu'elles seront disponibles. Nous vous recommandons de garder ce paramètre activé afin d'obtenir les dernières fonctionnalités et mises à jour de sécurité."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium téléchargera et installera automatiquement les mises à jour du navigateur et des composants dès qu'elles seront disponibles. Nous vous recommandons de garder ce paramètre activé afin d'obtenir les dernières fonctionnalités et mises à jour de sécurité. Les mises à jour automatiques du navigateur principal ne sont pas encore offertes sur cette plateforme, mais les mises à jour des composants le sont. Veuillez utiliser un logiciel externe pour garder Helium à jour."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "Autoriser le téléchargement des listes de filtres pour uBlock Origin"

--- a/i18n/translations/fr.json
+++ b/i18n/translations/fr.json
@@ -191,21 +191,6 @@
     "message": "Version <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "Autoriser les mises à jour automatiques du navigateur et des composants"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium téléchargera et installera automatiquement les mises à jour du navigateur et des composants dès qu'elles sont disponibles. Nous vous recommandons de garder ce paramètre activé pour bénéficier des dernières fonctionnalités et des mises à jour de sécurité."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium téléchargera et installera automatiquement les mises à jour du navigateur et des composants dès qu'elles sont disponibles. Nous vous recommandons de garder ce paramètre activé pour bénéficier des dernières fonctionnalités et des mises à jour de sécurité. Les mises à jour automatiques du navigateur principal ne sont pas encore disponibles sur cette plateforme, mais les mises à jour des composants le sont. Veuillez utiliser un logiciel externe pour maintenir Helium à jour."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "Autoriser le téléchargement des listes de filtres pour uBlock Origin"

--- a/i18n/translations/gl.json
+++ b/i18n/translations/gl.json
@@ -191,21 +191,6 @@
     "message": "Versión <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "Permitir actualizacións automáticas do navegador e compoñentes"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium descargará e instalará automaticamente as actualizacións do navegador e dos compoñentes cando estean dispoñibles. Recomendamos manter esta configuración activada para asegurarse de obter as últimas funcionalidades e actualizacións de seguridade."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium descargará e instalará automaticamente as actualizacións do navegador e dos compoñentes cando estean dispoñibles. Recomendamos manter esta configuración activada para asegurarse de obter as últimas funcionalidades e actualizacións de seguridade. As actualizacións automáticas do navegador principal aínda non están dispoñibles nesta plataforma, pero as dos compoñentes si. Use software externo para manter Helium actualizado."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "Permitir a descarga de listas de filtros para uBlock Origin"

--- a/i18n/translations/gu.json
+++ b/i18n/translations/gu.json
@@ -190,21 +190,6 @@
     "message": "સંસ્કરણ <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "બ્રાઉઝર અને ઘટકના આપમેળે અપડેટ્સને મંજૂરી આપો"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium બ્રાઉઝર અને ઘટક અપડેટ્સ ઉપલબ્ધ થતાં આપમેળે ડાઉનલોડ અને ઇન્સ્ટૉલ કરશે. નવીનતમ સુવિધાઓ અને સુરક્ષા અપડેટ્સ મેળવવા માટે આ સેટિંગ સક્ષમ રાખવાની અમે ભલામણ કરીએ છીએ."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium બ્રાઉઝર અને ઘટક અપડેટ્સ ઉપલબ્ધ થતાં આપમેળે ડાઉનલોડ અને ઇન્સ્ટૉલ કરશે. નવીનતમ સુવિધાઓ અને સુરક્ષા અપડેટ્સ મેળવવા માટે આ સેટિંગ સક્ષમ રાખવાની અમે ભલામણ કરીએ છીએ. આ પ્લેટફોર્મ પર આપમેળે કોર બ્રાઉઝર અપડેટ્સ હજુ ઉપલબ્ધ નથી, પરંતુ ઘટક અપડેટ્સ છે. Helium ને અપ ટુ ડેટ રાખવા માટે કૃપા કરીને બાહ્ય સોફ્ટવેરનો ઉપયોગ કરો."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "uBlock Origin માટે ફિલ્ટર સૂચિઓ ડાઉનલોડ કરવાની મંજૂરી આપો"

--- a/i18n/translations/he.json
+++ b/i18n/translations/he.json
@@ -190,21 +190,6 @@
     "message": "גרסה <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "אפשר עדכוני דפדפן ורכיבים אוטומטיים"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium יוריד ויתקין באופן אוטומטי עדכוני דפדפן ורכיבים כאשר הם זמינים. אנו ממליצים להשאיר הגדרה זו מופעלת כדי להבטיח שתקבל את התכונות ועדכוני האבטחה העדכניים."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium יוריד ויתקין באופן אוטומטי עדכוני דפדפן ורכיבים כאשר הם זמינים. אנו ממליצים להשאיר הגדרה זו מופעלת כדי להבטיח שתקבל את התכונות ועדכוני האבטחה העדכניים ביותר. עדכוני ליבת דפדפן אוטומטיים אינם זמינים עדיין בפלטפורמה זו, אך עדכוני רכיבים כן. אנא השתמש בתוכנה חיצונית כדי לשמור על Helium מעודכן."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "אפשר הורדת רשימות סינון עבור uBlock Origin"

--- a/i18n/translations/hi.json
+++ b/i18n/translations/hi.json
@@ -190,21 +190,6 @@
     "message": "संस्करण <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "ब्राउज़र और कंपोनेंट के ऑटोमैटिक अपडेट की अनुमति दें"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "अपडेट उपलब्ध होने पर Helium ब्राउज़र और कंपोनेंट को ऑटोमैटिक डाउनलोड और इंस्टॉल करेगा। लेटेस्ट फीचर्स और सिक्योरिटी अपडेट पाने के लिए हम इस सेटिंग को ऑन रखने की सलाह देते हैं।"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium उपलब्ध होने पर ब्राउज़र और कंपोनेंट अपडेट ऑटोमैटिक डाउनलोड और इंस्टॉल करेगा। लेटेस्ट फीचर्स और सिक्योरिटी अपडेट के लिए हम इस सेटिंग को ऑन रखने की सलाह देते हैं। इस प्लेटफ़ॉर्म पर कोर ब्राउज़र के ऑटोमैटिक अपडेट अभी उपलब्ध नहीं हैं, लेकिन कंपोनेंट अपडेट काम करेंगे। Helium को अपडेट रखने के लिए कृपया किसी बाहरी सॉफ़्टवेयर का इस्तेमाल करें।"
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "uBlock Origin के लिए फ़िल्टर सूचियाँ डाउनलोड करने की अनुमति दें"

--- a/i18n/translations/hr.json
+++ b/i18n/translations/hr.json
@@ -190,21 +190,6 @@
     "message": "Verzija <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "Dopusti automatska ažuriranja preglednika i komponenti"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium će automatski preuzimati i instalirati ažuriranja preglednika i komponenti čim postanu dostupna. Preporučujemo da ovu postavku ostavite uključenu kako biste dobivali najnovije značajke i sigurnosna ažuriranja."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium će automatski preuzimati i instalirati ažuriranja preglednika i komponenti čim postanu dostupna. Preporučujemo da ovu postavku ostavite uključenu kako biste dobivali najnovije značajke i sigurnosna ažuriranja. Automatska osnovna ažuriranja preglednika još nisu dostupna na ovoj platformi, ali ažuriranja komponenti jesu. Koristite vanjski softver za održavanje Heliuma ažurnim."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "Dopusti preuzimanje popisa filtara za uBlock Origin"

--- a/i18n/translations/hu.json
+++ b/i18n/translations/hu.json
@@ -190,21 +190,6 @@
     "message": "Verzió: <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "Automatikus böngésző- és komponensfrissítéseket engedélyezése"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "A Helium automatikusan letölti és telepíti a böngésző- és komponensfrissítéseket, amint elérhetővé válnak. Javasoljuk, hogy hagyja bekapcsolva ezt a beállítást a legújabb funkciók és biztonsági frissítések biztosítása érdekében."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "A Helium automatikusan letölti és telepíti a böngésző- és komponensfrissítéseket, amint elérhetővé válnak. Javasoljuk, hogy hagyja bekapcsolva ezt a beállítást a legújabb funkciók és biztonsági frissítések biztosítása érdekében. Az automatikus alapböngésző-frissítések ezen a platformon még nem érhetők el, de az komponensfrissítéseket igen. Kérjük, használjon külső szoftvert a Helium naprakészen tartásához."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "Szűrőlisták letöltésének engedélyezése a uBlock Origin számára"

--- a/i18n/translations/hy.json
+++ b/i18n/translations/hy.json
@@ -190,21 +190,6 @@
     "message": "Տարբերակ <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "Թույլատրել զննարկչի և բաղադրիչների ավտոմատ թարմացումները"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium-ը ավտոմատ կներբեռնի և կտեղադրի զննարկչի և բաղադրիչների թարմացումները, երբ դրանք հասանելի դառնան։ Խորհուրդ ենք տալիս այս կարգավորումը պահել միացված, որպեսզի ստանաք վերջին հնարավորություններն ու անվտանգության թարմացումները։"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium-ը ավտոմատ կներբեռնի և կտեղադրի զննարկչի և բաղադրիչների թարմացումները, երբ դրանք հասանելի դառնան։ Խորհուրդ ենք տալիս այս կարգավորումը պահել միացված, որպեսզի ստանաք վերջին հնարավորություններն ու անվտանգության թարմացումները։ Այս հարթակում հիմնական զննարկչի ավտոմատ թարմացումները դեռ հասանելի չեն, բայց բաղադրիչների թարմացումները հասանելի են։ Խնդրում ենք օգտագործել արտաքին ծրագրակազմ՝ Helium-ը արդիական պահելու համար։"
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "Թույլատրել uBlock Origin-ի ֆիլտրերի ցանկերի ներբեռնումը"

--- a/i18n/translations/id.json
+++ b/i18n/translations/id.json
@@ -190,21 +190,6 @@
     "message": "Versi <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "Izinkan pembaruan browser dan komponen otomatis"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium akan secara otomatis mengunduh dan menginstal pembaruan browser dan komponen saat tersedia. Kami menyarankan untuk tetap mengaktifkan pengaturan ini agar Anda mendapatkan fitur terbaru dan pembaruan keamanan."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium akan secara otomatis mengunduh dan menginstal pembaruan browser dan komponen saat tersedia. Kami menyarankan untuk tetap mengaktifkan pengaturan ini agar Anda mendapatkan fitur terbaru dan pembaruan keamanan. Pembaruan inti browser otomatis belum tersedia di platform ini, tetapi pembaruan komponen tersedia. Harap gunakan perangkat lunak eksternal untuk menjaga Helium tetap terbarui."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "Izinkan pengunduhan daftar filter untuk uBlock Origin"

--- a/i18n/translations/is.json
+++ b/i18n/translations/is.json
@@ -190,21 +190,6 @@
     "message": "Útgáfa <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "Leyfa sjálfvirkar uppfærslur á vafra og íhlutum"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium mun sjálfkrafa hlaða niður og setja upp uppfærslur á vafra og íhlutum eftir því sem þær verða tiltækar. Við mælum með að hafa þessa stillingu virka til að tryggja að þú fáir nýjustu eiginleikana og öryggisuppfærslurnar."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium mun sjálfkrafa hlaða niður og setja upp uppfærslur á vafra og íhlutum eftir því sem þær verða tiltækar. Við mælum með að hafa þessa stillingu virka til að tryggja að þú fáir nýjustu eiginleikana og öryggisuppfærslurnar. Sjálfvirkar uppfærslur á kjarnavafra eru ekki enn tiltækar á þessum vettvangi, en uppfærslur á íhlutum eru það. Vinsamlegast notaðu utanaðkomandi hugbúnað til að halda Helium uppfærðu."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "Leyfa niðurhal á síulista fyrir uBlock Origin"

--- a/i18n/translations/it.json
+++ b/i18n/translations/it.json
@@ -190,21 +190,6 @@
     "message": "Versione <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "Consenti aggiornamenti automatici del browser e dei componenti"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium scaricherà e installerà automaticamente gli aggiornamenti del browser e dei componenti non appena disponibili. Si consiglia di mantenere questa impostazione abilitata per ricevere le ultime funzionalità e gli aggiornamenti di sicurezza."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium scaricherà e installerà automaticamente gli aggiornamenti del browser e dei componenti non appena disponibili. Si consiglia di mantenere questa impostazione abilitata per ricevere le ultime funzionalità e gli aggiornamenti di sicurezza. Gli aggiornamenti automatici del browser principale non sono ancora disponibili su questa piattaforma, ma gli aggiornamenti dei componenti sì. Utilizza un software esterno per mantenere Helium aggiornato."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "Consenti il download delle liste di filtri per uBlock Origin"

--- a/i18n/translations/ja.json
+++ b/i18n/translations/ja.json
@@ -190,21 +190,6 @@
     "message": "バージョン <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>、<ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "ブラウザとコンポーネントの自動更新を許可する"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium はブラウザとコンポーネントの更新が利用可能になると自動的にダウンロードしてインストールします。最新の機能とセキュリティ更新を確実に受け取るために、この設定を有効のままにすることをお勧めします。"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium はブラウザとコンポーネントの更新が利用可能になると自動的にダウンロードしてインストールします。最新の機能とセキュリティ更新を確実に受け取るために、この設定を有効のままにすることをお勧めします。このプラットフォームではブラウザ本体の自動更新はまだ利用できませんが、コンポーネントの更新は利用可能です。Helium を最新の状態に保つには外部のソフトウェアをご利用ください。"
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "uBlock Origin のフィルターリストのダウンロードを許可する"

--- a/i18n/translations/ka.json
+++ b/i18n/translations/ka.json
@@ -190,21 +190,6 @@
     "message": "ვერსია <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "ბრაუზერისა და კომპონენტების ავტომატური განახლების ნებართვა"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium ავტომატურად ჩამოტვირთავს და დააინსტალირებს ბრაუზერისა და კომპონენტების განახლებებს მათი ხელმისაწვდომობისთანავე. გირჩევთ, ეს პარამეტრი ჩართული დატოვოთ უახლესი ფუნქციებისა და უსაფრთხოების განახლებების მისაღებად."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium ავტომატურად ჩამოტვირთავს და დააინსტალირებს ბრაუზერისა და კომპონენტების განახლებებს მათი ხელმისაწვდომობისთანავე. გირჩევთ, ეს პარამეტრი ჩართული დატოვოთ უახლესი ფუნქციებისა და უსაფრთხოების განახლებების მისაღებად. ბრაუზერის ძირითადი ავტომატური განახლებები ამ პლატფორმაზე ჯერ მიუწვდომელია, მაგრამ კომპონენტების განახლებები ხელმისაწვდომია. გთხოვთ, გამოიყენოთ გარე პროგრამული უზრუნველყოფა Helium-ის განახლებისთვის."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "uBlock Origin-ის ფილტრების სიების ჩამოტვირთვის ნებართვა"

--- a/i18n/translations/kk.json
+++ b/i18n/translations/kk.json
@@ -190,21 +190,6 @@
     "message": "Нұсқа <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "Браузер мен компоненттерді автоматты жаңартуға рұқсат беру"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium браузер мен компонент жаңартуларын қол жетімді болған кезде автоматты түрде жүктеп орнатады. Ең соңғы мүмкіндіктер мен қауіпсіздік жаңартуларын алу үшін бұл параметрді қосулы ұстауды ұсынамыз."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium браузер мен компонент жаңартуларын қол жетімді болған кезде автоматты түрде жүктеп орнатады. Ең соңғы мүмкіндіктер мен қауіпсіздік жаңартуларын алу үшін бұл параметрді қосулы ұстауды ұсынамыз. Бұл платформада негізгі браузердің автоматты жаңартулары әзірге қол жетімді емес, бірақ компонент жаңартулары қол жетімді. Helium жаңартып отыру үшін сыртқы бағдарламалық жасақтаманы пайдаланыңыз."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "uBlock Origin үшін сүзгі тізімдерін жүктеуге рұқсат беру"

--- a/i18n/translations/km.json
+++ b/i18n/translations/km.json
@@ -190,21 +190,6 @@
     "message": "Version <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "អនុញ្ញាតការធ្វើបច្ចុប្បន្នភាព Browser និងសមាសភាគដោយស្វ័យប្រវត្តិ"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium នឹងទាញយក និងដំឡើងបច្ចុប្បន្នភាព Browser និងសមាសភាគដោយស្វ័យប្រវត្តិនៅពេលមាន។ យើងណែនាំឱ្យបើកការកំណត់នេះដើម្បីធានាថាអ្នកទទួលបានមុខងារ និងបច្ចុប្បន្នភាពសុវត្ថិភាពថ្មីគេបំផុត។"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium នឹងទាញយក និងដំឡើងបច្ចុប្បន្នភាព Browser  និងសមាសភាគដោយស្វ័យប្រវត្តិនៅពេលមាន។ យើងណែនាំឱ្យបើកការកំណត់នេះដើម្បីធានាថាអ្នកទទួលបាននូវមុខងារ និងបច្ចុប្បន្នភាពសុវត្ថិភាពថ្មីគេបំផុត។ ការធ្វើបច្ចុប្បន្នភាព Browser ចម្បងដោយស្វ័យប្រវត្តិមិនទាន់មាននៅលើប្រព័ន្ធប្រតិបត្តិការនេះទេ ប៉ុន្តែបច្ចុប្បន្នភាពសមាសភាគមាន។ សូមប្រើកម្មវិធីខាងក្រៅដើម្បីរក្សាបច្ចុប្បន្នភាព Helium។"
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "អនុញ្ញាតការទាញយកបញ្ជីតម្រងសម្រាប់ uBlock Origin"

--- a/i18n/translations/kn.json
+++ b/i18n/translations/kn.json
@@ -190,21 +190,6 @@
     "message": "ಆವೃತ್ತಿ <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "ಸ್ವಯಂಚಾಲಿತ ಬ್ರೌಸರ್ ಮತ್ತು ಘಟಕ ನವೀಕರಣಗಳನ್ನು ಅನುಮತಿಸಿ"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium ಬ್ರೌಸರ್ ಮತ್ತು ಘಟಕ ನವೀಕರಣಗಳು ಲಭ್ಯವಾದಾಗ ಅವುಗಳನ್ನು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಡೌನ್‌ಲೋಡ್ ಮಾಡುತ್ತದೆ ಮತ್ತು ಸ್ಥಾಪಿಸುತ್ತದೆ. ಇತ್ತೀಚಿನ ವೈಶಿಷ್ಟ್ಯಗಳು ಮತ್ತು ಭದ್ರತಾ ನವೀಕರಣಗಳನ್ನು ಪಡೆಯಲು ಈ ಸೆಟ್ಟಿಂಗ್ ಅನ್ನು ಸಕ್ರಿಯವಾಗಿಡಲು ನಾವು ಶಿಫಾರಸು ಮಾಡುತ್ತೇವೆ."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium ಬ್ರೌಸರ್ ಮತ್ತು ಘಟಕ ನವೀಕರಣಗಳು ಲಭ್ಯವಾದಾಗ ಅವುಗಳನ್ನು ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಡೌನ್‌ಲೋಡ್ ಮಾಡುತ್ತದೆ ಮತ್ತು ಸ್ಥಾಪಿಸುತ್ತದೆ. ಇತ್ತೀಚಿನ ವೈಶಿಷ್ಟ್ಯಗಳು ಮತ್ತು ಭದ್ರತಾ ನವೀಕರಣಗಳನ್ನು ಪಡೆಯಲು ಈ ಸೆಟ್ಟಿಂಗ್ ಅನ್ನು ಸಕ್ರಿಯವಾಗಿಡಲು ನಾವು ಶಿಫಾರಸು ಮಾಡುತ್ತೇವೆ. ಸ್ವಯಂಚಾಲಿತ ಕೋರ್ ಬ್ರೌಸರ್ ನವೀಕರಣಗಳು ಈ ಪ್ಲಾಟ್‌ಫಾರ್ಮ್‌ನಲ್ಲಿ ಇನ್ನೂ ಲಭ್ಯವಿಲ್ಲ, ಆದರೆ ಘಟಕ ನವೀಕರಣಗಳು ಲಭ್ಯವಿವೆ. Helium ಅನ್ನು ನವೀಕೃತವಾಗಿ ಇಡಲು ದಯವಿಟ್ಟು ಬಾಹ್ಯ ಸಾಫ್ಟ್‌ವೇರ್ ಬಳಸಿ."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "uBlock Origin ಗಾಗಿ ಫಿಲ್ಟರ್ ಪಟ್ಟಿಗಳನ್ನು ಡೌನ್‌ಲೋಡ್ ಮಾಡಲು ಅನುಮತಿಸಿ"

--- a/i18n/translations/ko.json
+++ b/i18n/translations/ko.json
@@ -190,21 +190,6 @@
     "message": "버전 <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "자동 브라우저 및 구성요소 업데이트 허용"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium이 사용 가능한 브라우저 및 구성요소 업데이트를 자동으로 다운로드하여 설치합니다. 최신 기능과 보안 업데이트를 받으려면 이 설정을 사용 설정한 상태로 유지하는 것이 좋습니다."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium이 사용 가능한 브라우저 및 구성요소 업데이트를 자동으로 다운로드하여 설치합니다. 최신 기능과 보안 업데이트를 받으려면 이 설정을 사용 설정한 상태로 유지하는 것이 좋습니다. 이 플랫폼에서는 아직 핵심 브라우저 자동 업데이트를 사용할 수 없지만 구성요소 업데이트는 가능합니다. 외부 소프트웨어를 사용하여 Helium을 최신 상태로 유지하세요."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "uBlock Origin 필터 목록 다운로드 허용"

--- a/i18n/translations/ky.json
+++ b/i18n/translations/ky.json
@@ -192,21 +192,6 @@
     "message": "Версия <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "Браузер жана компоненттерди автоматтык жаңыртууга уруксат берүү"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium браузер жана компонент жаңыртууларын жеткиликтүү болгондо автоматтык түрдө жүктөп жана орнотот. Акыркы функцияларды жана коопсуздук жаңыртууларын алуу үчүн бул жөндөөнү иштетилген калтырууну сунуштайбыз."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium браузер жана компонент жаңыртууларын жеткиликтүү болгондо автоматтык түрдө жүктөп жана орнотот. Акыркы функцияларды жана коопсуздук жаңыртууларын алуу үчүн бул жөндөөнү иштетилген калтырууну сунуштайбыз. Бул платформада негизги браузердин автоматтык жаңыртуулары азырынча жеткиликсиз, бирок компонент жаңыртуулары бар. Helium жаңыртып туруу үчүн тышкы программаны колдонуңуз."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "uBlock Origin үчүн чыпка тизмелерин жүктөөгө уруксат берүү"

--- a/i18n/translations/lo.json
+++ b/i18n/translations/lo.json
@@ -190,21 +190,6 @@
     "message": "ເວີຊັນ <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "ອະນຸຍາດໃຫ້ອັບເດດບຣາວເຊີ ແລະ ອົງປະກອບອັດຕະໂນມັດ"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium ຈະດາວໂຫລດ ແລະ ຕິດຕັ້ງການອັບເດດບຣາວເຊີ ແລະ ອົງປະກອບໂດຍອັດຕະໂນມັດເມື່ອມີໃຫ້. ພວກເຮົາແນະນຳໃຫ້ເປີດໃຊ້ການຕັ້ງຄ່ານີ້ໄວ້ເພື່ອຮັບປະກັນວ່າທ່ານຈະໄດ້ຮັບຟີເຈີ ແລະ ການອັບເດດຄວາມປອດໄພຫຼ້າສຸດ."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium ຈະດາວໂຫລດ ແລະ ຕິດຕັ້ງການອັບເດດບຣາວເຊີ ແລະ ອົງປະກອບໂດຍອັດຕະໂນມັດເມື່ອມີໃຫ້. ພວກເຮົາແນະນຳໃຫ້ເປີດໃຊ້ການຕັ້ງຄ່ານີ້ໄວ້ເພື່ອຮັບປະກັນວ່າທ່ານຈະໄດ້ຮັບຟີເຈີ ແລະ ການອັບເດດຄວາມປອດໄພຫຼ້າສຸດ. ການອັບເດດບຣາວເຊີຫຼັກອັດຕະໂນມັດຍັງບໍ່ມີໃຫ້ໃນແພລດຟອມນີ້ເທື່ອ, ແຕ່ການອັບເດດອົງປະກອບມີໃຫ້ແລ້ວ. ກະລຸນາໃຊ້ຊອບແວພາຍນອກເພື່ອຮັກສາ Helium ໃຫ້ທັນສະໄໝ."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "ອະນຸຍາດໃຫ້ດາວໂຫລດລາຍການຕົວກອງສຳລັບ uBlock Origin"

--- a/i18n/translations/lt.json
+++ b/i18n/translations/lt.json
@@ -190,21 +190,6 @@
     "message": "Versija <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "Leisti automatinius naršyklės ir komponentų naujinimus"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium automatiškai atsisiųs ir įdiegs naršyklės bei komponentų naujinimus, kai tik jie bus prieinami. Rekomenduojame palikti šį nustatymą įjungtą, kad gautumėte naujausias funkcijas ir saugumo naujinimus."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium automatiškai atsisiųs ir įdiegs naršyklės bei komponentų naujinimus, kai tik jie bus prieinami. Rekomenduojame palikti šį nustatymą įjungtą, kad gautumėte naujausias funkcijas ir saugumo naujinimus. Automatiniai pagrindinės naršyklės naujinimai šioje platformoje dar nepasiekiami, tačiau komponentų naujinimai veikia. Naudokite išorinę programinę įrangą, kad Helium būtų atnaujinta."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "Leisti atsisiųsti uBlock Origin filtrų sąrašus"

--- a/i18n/translations/lv.json
+++ b/i18n/translations/lv.json
@@ -192,21 +192,6 @@
     "message": "Versija <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "Atļaut automātiskus pārlūkprogrammas un komponentu atjauninājumus"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium automātiski lejupielādēs un instalēs pārlūkprogrammas un komponentu atjauninājumus, tiklīdz tie būs pieejami. Mēs iesakām atstāt šo iestatījumu iespējotu, lai nodrošinātu jaunākās funkcijas un drošības atjauninājumus."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium automātiski lejupielādēs un instalēs pārlūkprogrammas un komponentu atjauninājumus, tiklīdz tie būs pieejami. Mēs iesakām atstāt šo iestatījumu iespējotu, lai nodrošinātu jaunākās funkcijas un drošības atjauninājumus. Automātiski pārlūkprogrammas pamata atjauninājumi šajā platformā vēl nav pieejami, bet komponentu atjauninājumi ir. Lūdzu, izmantojiet ārēju programmatūru, lai uzturētu Helium atjauninātu."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "Atļaut filtru sarakstu lejupielādi uBlock Origin"

--- a/i18n/translations/mk.json
+++ b/i18n/translations/mk.json
@@ -190,21 +190,6 @@
     "message": "Верзија <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "Дозволи автоматски ажурирања на прелистувачот и компонентите"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium автоматски ќе преземе и инсталира ажурирања на прелистувачот и компонентите кога ќе бидат достапни. Препорачуваме да ја задржите оваа поставка овозможена за да ги добивате најновите функции и безбедносни ажурирања."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium автоматски ќе преземе и инсталира ажурирања на прелистувачот и компонентите кога ќе бидат достапни. Препорачуваме да ја задржите оваа поставка овозможена за да ги добивате најновите функции и безбедносни ажурирања. Автоматските ажурирања на основниот прелистувач сè уште не се достапни на оваа платформа, но ажурирањата на компонентите се. Користете надворешен софтвер за да го одржувате Helium ажуриран."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "Дозволи преземање на листи со филтри за uBlock Origin"

--- a/i18n/translations/ml.json
+++ b/i18n/translations/ml.json
@@ -190,21 +190,6 @@
     "message": "പതിപ്പ് <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "ഓട്ടോമാറ്റിക് ബ്രൗസർ, കമ്പോണന്റ് അപ്‌ഡേറ്റുകൾ അനുവദിക്കുക"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "ബ്രൗസർ, കമ്പോണന്റ് അപ്‌ഡേറ്റുകൾ ലഭ്യമാകുമ്പോൾ Helium സ്വയമേവ ഡൗൺലോഡ് ചെയ്‌ത് ഇൻസ്‌റ്റാൾ ചെയ്യും. ഏറ്റവും പുതിയ ഫീച്ചറുകളും സുരക്ഷാ അപ്‌ഡേറ്റുകളും ലഭിക്കുന്നുണ്ടെന്ന് ഉറപ്പാക്കാൻ ഈ ക്രമീകരണം പ്രവർത്തനക്ഷമമായി നിലനിർത്താൻ ഞങ്ങൾ ശുപാർശ ചെയ്യുന്നു."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "ബ്രൗസർ, കമ്പോണന്റ് അപ്‌ഡേറ്റുകൾ ലഭ്യമാകുമ്പോൾ Helium സ്വയമേവ ഡൗൺലോഡ് ചെയ്‌ത് ഇൻസ്‌റ്റാൾ ചെയ്യും. ഏറ്റവും പുതിയ ഫീച്ചറുകളും സുരക്ഷാ അപ്‌ഡേറ്റുകളും ലഭിക്കുന്നുണ്ടെന്ന് ഉറപ്പാക്കാൻ ഈ ക്രമീകരണം പ്രവർത്തനക്ഷമമായി നിലനിർത്താൻ ഞങ്ങൾ ശുപാർശ ചെയ്യുന്നു. ഈ പ്ലാറ്റ്‌ഫോമിൽ ഓട്ടോമാറ്റിക് കോർ ബ്രൗസർ അപ്‌ഡേറ്റുകൾ ഇതുവരെ ലഭ്യമല്ല, പക്ഷേ കമ്പോണന്റ് അപ്‌ഡേറ്റുകൾ ലഭ്യമാണ്. Helium അപ്‌ഡേറ്റ് ചെയ്‌ത് നിലനിർത്താൻ ദയവായി ബാഹ്യ സോഫ്‌റ്റ്‌വെയർ ഉപയോഗിക്കുക."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "uBlock Origin-നായി ഫിൽട്ടർ ലിസ്‌റ്റുകൾ ഡൗൺലോഡ് ചെയ്യാൻ അനുവദിക്കുക"

--- a/i18n/translations/mn.json
+++ b/i18n/translations/mn.json
@@ -190,21 +190,6 @@
     "message": "Хувилбар <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "Хөтөч болон бүрэлдэхүүн хэсгүүдийн автомат шинэчлэлтийг зөвшөөрөх"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium хөтөч болон бүрэлдэхүүн хэсгүүдийн шинэчлэлтүүдийг автоматаар татаж суулгана. Хамгийн сүүлийн боломжууд болон аюулгүй байдлын шинэчлэлтүүдийг авахын тулд энэ тохиргоог идэвхтэй байлгахыг зөвлөж байна."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium хөтөч болон бүрэлдэхүүн хэсгүүдийн шинэчлэлтүүдийг автоматаар татаж суулгана. Хамгийн сүүлийн боломжууд болон аюулгүй байдлын шинэчлэлтүүдийг авахын тулд энэ тохиргоог идэвхтэй байлгахыг зөвлөж байна. Энэ платформ дээр хөтчийн үндсэн автомат шинэчлэлт хараахан боломжгүй байгаа боловч бүрэлдэхүүн хэсгүүдийн шинэчлэлт боломжтой. Helium-ийг шинэчлэхийн тулд гадны программ хангамж ашиглана уу."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "uBlock Origin-д зориулсан шүүлтүүрийн жагсаалт татаж авахыг зөвшөөрөх"

--- a/i18n/translations/mr.json
+++ b/i18n/translations/mr.json
@@ -190,21 +190,6 @@
     "message": "आवृत्ती <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "स्वयंचलित ब्राउझर आणि घटक अद्यतनांना अनुमती द्या"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium उपलब्ध होताच ब्राउझर आणि घटक अद्यतने स्वयंचलितपणे डाउनलोड आणि स्थापित करेल. तुम्हाला नवीनतम वैशिष्ट्ये आणि सुरक्षा अद्यतने मिळतील याची खात्री करण्यासाठी हे सेटिंग सक्षम ठेवण्याची आम्ही शिफारस करतो."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium उपलब्ध होताच ब्राउझर आणि घटक अद्यतने स्वयंचलितपणे डाउनलोड आणि स्थापित करेल. तुम्हाला नवीनतम वैशिष्ट्ये आणि सुरक्षा अद्यतने मिळतील याची खात्री करण्यासाठी हे सेटिंग सक्षम ठेवण्याची आम्ही शिफारस करतो. या प्लॅटफॉर्मवर स्वयंचलित मुख्य ब्राउझर अद्यतने अद्याप उपलब्ध नाहीत, परंतु घटक अद्यतने उपलब्ध आहेत. कृपया Helium अद्ययावत ठेवण्यासाठी बाह्य सॉफ्टवेअर वापरा."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "uBlock Origin साठी फिल्टर याद्या डाउनलोड करण्याची अनुमती द्या"

--- a/i18n/translations/ms.json
+++ b/i18n/translations/ms.json
@@ -190,21 +190,6 @@
     "message": "Versi <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "Benarkan kemas kini pelayar dan komponen automatik"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium akan memuat turun dan memasang kemas kini pelayar dan komponen secara automatik apabila tersedia. Kami mengesyorkan agar tetapan ini kekal didayakan untuk memastikan anda mendapat ciri terkini dan kemas kini keselamatan."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium akan memuat turun dan memasang kemas kini pelayar dan komponen secara automatik apabila tersedia. Kami mengesyorkan agar tetapan ini kekal didayakan untuk memastikan anda mendapat ciri terkini dan kemas kini keselamatan. Kemas kini teras pelayar automatik belum tersedia pada platform ini, tetapi kemas kini komponen tersedia. Sila gunakan perisian luaran untuk memastikan Helium sentiasa dikemas kini."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "Benarkan memuat turun senarai penapis untuk uBlock Origin"

--- a/i18n/translations/my.json
+++ b/i18n/translations/my.json
@@ -190,21 +190,6 @@
     "message": "ဗားရှင်း <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "ဘရောက်ဇာနှင့် အစိတ်အပိုင်း အလိုအလျောက် အပ်ဒိတ်များ ခွင့်ပြုပါ"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium သည် ဘရောက်ဇာနှင့် အစိတ်အပိုင်း အပ်ဒိတ်များကို ရရှိနိုင်သည်နှင့် အလိုအလျောက် ဒေါင်းလုဒ်လုပ်ပြီး ထည့်သွင်းပါမည်။ နောက်ဆုံးပေါ် လုပ်ဆောင်ချက်များနှင့် လုံခြုံရေး အပ်ဒိတ်များ ရရှိစေရန် ဤဆက်တင်ကို ဖွင့်ထားရန် အကြံပြုပါသည်။"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium သည် ဘရောက်ဇာနှင့် အစိတ်အပိုင်း အပ်ဒိတ်များကို ရရှိနိုင်သည်နှင့် အလိုအလျောက် ဒေါင်းလုဒ်လုပ်ပြီး ထည့်သွင်းပါမည်။ နောက်ဆုံးပေါ် လုပ်ဆောင်ချက်များနှင့် လုံခြုံရေး အပ်ဒိတ်များ ရရှိစေရန် ဤဆက်တင်ကို ဖွင့်ထားရန် အကြံပြုပါသည်။ ဤပလက်ဖောင်းတွင် အလိုအလျောက် အဓိက ဘရောက်ဇာ အပ်ဒိတ်များ မရရှိနိုင်သေးသော်လည်း အစိတ်အပိုင်း အပ်ဒိတ်များ ရရှိနိုင်ပါသည်။ Helium ကို နောက်ဆုံးအခြေအနေ ထိန်းသိမ်းရန် ပြင်ပဆော့ဖ်ဝဲကို အသုံးပြုပါ။"
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "uBlock Origin အတွက် filter စာရင်းများ ဒေါင်းလုဒ်ခွင့်ပြုပါ"

--- a/i18n/translations/nb.json
+++ b/i18n/translations/nb.json
@@ -190,21 +190,6 @@
     "message": "Versjon <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "Tillat automatiske nettleser- og komponentoppdateringer"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium laster automatisk ned og installerer nettleser- og komponentoppdateringer når de blir tilgjengelige. Vi anbefaler å holde denne innstillingen aktivert for å sikre at du får de nyeste funksjonene og sikkerhetsoppdateringene."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium laster automatisk ned og installerer nettleser- og komponentoppdateringer når de blir tilgjengelige. Vi anbefaler å holde denne innstillingen aktivert for å sikre at du får de nyeste funksjonene og sikkerhetsoppdateringene. Automatiske kjerneoppdateringer for nettleseren er ikke tilgjengelige på denne plattformen ennå, men komponentoppdateringer er det. Bruk ekstern programvare for å holde Helium oppdatert."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "Tillat nedlasting av filterlister for uBlock Origin"

--- a/i18n/translations/ne.json
+++ b/i18n/translations/ne.json
@@ -190,21 +190,6 @@
     "message": "संस्करण <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "स्वचालित ब्राउजर र कम्पोनेन्ट अपडेटहरू अनुमति दिनुहोस्"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium ले ब्राउजर र कम्पोनेन्ट अपडेटहरू उपलब्ध हुनासाथ स्वचालित रूपमा डाउनलोड र स्थापना गर्नेछ। तपाईंलाई नवीनतम सुविधाहरू र सुरक्षा अपडेटहरू प्राप्त हुने सुनिश्चित गर्न यो सेटिङ सक्षम राख्न हामी सिफारिस गर्छौं।"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium ले ब्राउजर र कम्पोनेन्ट अपडेटहरू उपलब्ध हुनासाथ स्वचालित रूपमा डाउनलोड र स्थापना गर्नेछ। तपाईंलाई नवीनतम सुविधाहरू र सुरक्षा अपडेटहरू प्राप्त हुने सुनिश्चित गर्न यो सेटिङ सक्षम राख्न हामी सिफारिस गर्छौं। यो प्लेटफर्ममा स्वचालित कोर ब्राउजर अपडेटहरू अझै उपलब्ध छैनन्, तर कम्पोनेन्ट अपडेटहरू छन्। कृपया Helium लाई अपटुडेट राख्न बाह्य सफ्टवेयर प्रयोग गर्नुहोस्।"
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "uBlock Origin का लागि फिल्टर सूचीहरू डाउनलोड गर्न अनुमति दिनुहोस्"

--- a/i18n/translations/nl.json
+++ b/i18n/translations/nl.json
@@ -190,21 +190,6 @@
     "message": "Versie <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "Automatische browser- en componentupdates toestaan"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium downloadt en installeert automatisch browser- en componentupdates zodra deze beschikbaar zijn. We raden aan deze instelling ingeschakeld te houden zodat u de nieuwste functies en beveiligingsupdates ontvangt."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium downloadt en installeert automatisch browser- en componentupdates zodra deze beschikbaar zijn. We raden aan deze instelling ingeschakeld te houden zodat u de nieuwste functies en beveiligingsupdates ontvangt. Automatische kernbrowserupdates zijn op dit platform nog niet beschikbaar, maar componentupdates wel. Gebruik externe software om Helium up-to-date te houden."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "Downloaden van filterlijsten voor uBlock Origin toestaan"

--- a/i18n/translations/or.json
+++ b/i18n/translations/or.json
@@ -190,21 +190,6 @@
     "message": "ସଂସ୍କରଣ <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "ସ୍ୱୟଂଚାଳିତ ବ୍ରାଉଜର ଏବଂ ଉପାଦାନ ଅଦ୍ୟତନ ଅନୁମତି ଦିଅନ୍ତୁ"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium ଉପଲବ୍ଧ ହେବାମାତ୍ରେ ସ୍ୱୟଂଚାଳିତ ଭାବରେ ବ୍ରାଉଜର ଏବଂ ଉପାଦାନ ଅଦ୍ୟତନଗୁଡ଼ିକ ଡାଉନଲୋଡ୍ ଏବଂ ଇନ୍‌ଷ୍ଟଲ୍ କରିବ। ଆପଣ ନବୀନତମ ବୈଶିଷ୍ଟ୍ୟ ଏବଂ ସୁରକ୍ଷା ଅଦ୍ୟତନଗୁଡ଼ିକ ପାଉଛନ୍ତି ବୋଲି ନିଶ୍ଚିତ କରିବା ପାଇଁ ଆମେ ଏହି ସେଟିଂ ସକ୍ଷମ ରଖିବାକୁ ସୁପାରିଶ କରୁ।"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium ଉପଲବ୍ଧ ହେବାମାତ୍ରେ ସ୍ୱୟଂଚାଳିତ ଭାବରେ ବ୍ରାଉଜର ଏବଂ ଉପାଦାନ ଅଦ୍ୟତନଗୁଡ଼ିକ ଡାଉନଲୋଡ୍ ଏବଂ ଇନ୍‌ଷ୍ଟଲ୍ କରିବ। ଆପଣ ନବୀନତମ ବୈଶିଷ୍ଟ୍ୟ ଏବଂ ସୁରକ୍ଷା ଅଦ୍ୟତନଗୁଡ଼ିକ ପାଉଛନ୍ତି ବୋଲି ନିଶ୍ଚିତ କରିବା ପାଇଁ ଆମେ ଏହି ସେଟିଂ ସକ୍ଷମ ରଖିବାକୁ ସୁପାରିଶ କରୁ। ସ୍ୱୟଂଚାଳିତ କୋର ବ୍ରାଉଜର ଅଦ୍ୟତନ ଏହି ପ୍ଲାଟଫର୍ମରେ ଏପର୍ଯ୍ୟନ୍ତ ଉପଲବ୍ଧ ନୁହେଁ, କିନ୍ତୁ ଉପାଦାନ ଅଦ୍ୟତନଗୁଡ଼ିକ ଉପଲବ୍ଧ। ଦୟାକରି Helium କୁ ଅଦ୍ୟତନ ରଖିବା ପାଇଁ ବାହ୍ୟ ସଫ୍ଟୱେର ବ୍ୟବହାର କରନ୍ତୁ।"
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "uBlock Origin ପାଇଁ ଫିଲ୍ଟର ତାଲିକା ଡାଉନଲୋଡ୍ ଅନୁମତି ଦିଅନ୍ତୁ"

--- a/i18n/translations/pa.json
+++ b/i18n/translations/pa.json
@@ -190,21 +190,6 @@
     "message": "ਵਰਜ਼ਨ <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "ਆਟੋਮੈਟਿਕ ਬ੍ਰਾਊਜ਼ਰ ਅਤੇ ਕੰਪੋਨੈਂਟ ਅੱਪਡੇਟ ਦੀ ਇਜਾਜ਼ਤ ਦਿਓ"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium ਬ੍ਰਾਊਜ਼ਰ ਅਤੇ ਕੰਪੋਨੈਂਟ ਅੱਪਡੇਟ ਉਪਲਬਧ ਹੋਣ 'ਤੇ ਆਪਣੇ ਆਪ ਡਾਊਨਲੋਡ ਅਤੇ ਇੰਸਟਾਲ ਕਰੇਗਾ। ਅਸੀਂ ਇਸ ਸੈਟਿੰਗ ਨੂੰ ਸਮਰੱਥ ਰੱਖਣ ਦੀ ਸਿਫ਼ਾਰਸ਼ ਕਰਦੇ ਹਾਂ ਤਾਂ ਜੋ ਤੁਹਾਨੂੰ ਨਵੀਨਤਮ ਵਿਸ਼ੇਸ਼ਤਾਵਾਂ ਅਤੇ ਸੁਰੱਖਿਆ ਅੱਪਡੇਟ ਮਿਲਦੇ ਰਹਿਣ।"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium ਬ੍ਰਾਊਜ਼ਰ ਅਤੇ ਕੰਪੋਨੈਂਟ ਅੱਪਡੇਟ ਉਪਲਬਧ ਹੋਣ 'ਤੇ ਆਪਣੇ ਆਪ ਡਾਊਨਲੋਡ ਅਤੇ ਇੰਸਟਾਲ ਕਰੇਗਾ। ਅਸੀਂ ਇਸ ਸੈਟਿੰਗ ਨੂੰ ਸਮਰੱਥ ਰੱਖਣ ਦੀ ਸਿਫ਼ਾਰਸ਼ ਕਰਦੇ ਹਾਂ ਤਾਂ ਜੋ ਤੁਹਾਨੂੰ ਨਵੀਨਤਮ ਵਿਸ਼ੇਸ਼ਤਾਵਾਂ ਅਤੇ ਸੁਰੱਖਿਆ ਅੱਪਡੇਟ ਮਿਲਦੇ ਰਹਿਣ। ਇਸ ਪਲੇਟਫ਼ਾਰਮ 'ਤੇ ਆਟੋਮੈਟਿਕ ਕੋਰ ਬ੍ਰਾਊਜ਼ਰ ਅੱਪਡੇਟ ਅਜੇ ਉਪਲਬਧ ਨਹੀਂ ਹਨ, ਪਰ ਕੰਪੋਨੈਂਟ ਅੱਪਡੇਟ ਉਪਲਬਧ ਹਨ। ਕਿਰਪਾ ਕਰਕੇ Helium ਨੂੰ ਅੱਪ ਟੂ ਡੇਟ ਰੱਖਣ ਲਈ ਬਾਹਰੀ ਸਾਫ਼ਟਵੇਅਰ ਵਰਤੋ।"
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "uBlock Origin ਲਈ ਫ਼ਿਲਟਰ ਸੂਚੀਆਂ ਡਾਊਨਲੋਡ ਕਰਨ ਦੀ ਇਜਾਜ਼ਤ ਦਿਓ"

--- a/i18n/translations/pl.json
+++ b/i18n/translations/pl.json
@@ -190,21 +190,6 @@
     "message": "Wersja <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "Zezwalaj na automatyczne aktualizacje przeglądarki i jej komponentów"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium będzie automatycznie pobierać i instalować aktualizacje przeglądarki i komponentów, gdy staną się dostępne. Zalecamy pozostawienie tej opcji włączonej, aby mieć dostęp do najnowszych funkcji i aktualizacji zabezpieczeń."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium będzie automatycznie pobierać i instalować aktualizacje przeglądarki i komponentów, gdy staną się dostępne. Zalecamy pozostawienie tej opcji włączonej, aby mieć dostęp do najnowszych funkcji i aktualizacji zabezpieczeń. Automatyczne aktualizacje głównej przeglądarki nie są jeszcze dostępne na tej platformie, ale aktualizacje komponentów tak. Użyj zewnętrznego oprogramowania, aby aktualizować Helium."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "Zezwalaj na pobieranie list filtrów dla uBlock Origin"

--- a/i18n/translations/pt-BR.json
+++ b/i18n/translations/pt-BR.json
@@ -191,21 +191,6 @@
     "message": "Versão <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "Permitir atualizações automáticas do navegador e dos componentes"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "O Helium baixará e instalará automaticamente atualizações do navegador e dos componentes à medida que estiverem disponíveis. Recomendamos manter esta configuração ativada para garantir que você receba os recursos e atualizações de segurança mais recentes."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "O Helium baixará e instalará automaticamente atualizações do navegador e dos componentes à medida que estiverem disponíveis. Recomendamos manter esta configuração ativada para garantir que você receba os recursos e atualizações de segurança mais recentes. As atualizações automáticas do navegador principal ainda não estão disponíveis nesta plataforma, mas as atualizações de componentes estão. Use um software externo para manter o Helium atualizado."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "Permitir download de listas de filtros para o uBlock Origin"

--- a/i18n/translations/pt-PT.json
+++ b/i18n/translations/pt-PT.json
@@ -190,21 +190,6 @@
     "message": "Versão <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "Permitir atualizações automáticas do navegador e dos seus componentes"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "O Helium irá transferir e instalar automaticamente as atualizações do navegador e dos componentes à medida que ficarem disponíveis. Recomendamos que mantenha esta definição ativada para garantir que obtém as funcionalidades e atualizações de segurança mais recentes."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "O Helium irá transferir e instalar automaticamente as atualizações do navegador e dos componentes à medida que ficarem disponíveis. Recomendamos que mantenha esta definição ativada para garantir que obtém as funcionalidades e atualizações de segurança mais recentes. As atualizações automáticas do núcleo do navegador ainda não estão disponíveis nesta plataforma, mas as atualizações de componentes estão. Por favor, utilize software externo para manter o Helium atualizado."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "Permitir a transferência de listas de filtros para o uBlock Origin"

--- a/i18n/translations/ro.json
+++ b/i18n/translations/ro.json
@@ -190,21 +190,6 @@
     "message": "Versiunea <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "Permite actualizarea automată a browserului și a componentelor"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium va descărca și instala automat actualizările browserului și ale componentelor pe măsură ce devin disponibile. Vă recomandăm să mențineți această setare activată pentru a beneficia de cele mai noi funcții și actualizări de securitate."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium va descărca și instala automat actualizările browserului și ale componentelor pe măsură ce devin disponibile. Vă recomandăm să mențineți această setare activată pentru a beneficia de cele mai noi funcții și actualizări de securitate. Actualizările automate ale browserului principal nu sunt încă disponibile pe această platformă, dar cele ale componentelor sunt. Folosiți un software extern pentru a menține Helium actualizat."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "Permite descărcarea listelor de filtre pentru uBlock Origin"

--- a/i18n/translations/ru.json
+++ b/i18n/translations/ru.json
@@ -190,21 +190,6 @@
     "message": "Версия <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "Разрешить автоматическое обновление браузера и компонентов"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium будет автоматически загружать и устанавливать обновления браузера и компонентов по мере их появления. Рекомендуем оставлять этот параметр включённым, чтобы получать новейшие функции и обновления безопасности."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium будет автоматически загружать и устанавливать обновления браузера и компонентов по мере их появления. Рекомендуем оставлять этот параметр включённым, чтобы получать новейшие функции и обновления безопасности. Автоматическое обновление браузера пока недоступно на этой платформе, но обновление компонентов поддерживается. Используйте сторонние средства для поддержания Helium в актуальном состоянии."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "Разрешить загрузку списков фильтров для uBlock Origin"

--- a/i18n/translations/si.json
+++ b/i18n/translations/si.json
@@ -190,21 +190,6 @@
     "message": "අනුවාදය <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "ස්වයංක්‍රිය බ්‍රවුසර සහ සංරචක යාවත්කාලීන වලට ඉඩ දෙන්න"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium බ්‍රවුසර සහ සංරචක යාවත්කාලීන ලැබෙන විට ස්වයංක්‍රියව බාගැනීම සහ ස්ථාපනය කරනු ඇත. නවතම විශේෂාංග සහ ආරක්ෂක යාවත්කාලීන ලබා ගැනීම සහතික කිරීමට මෙම සැකසුම සක්‍රියව තබා ගැනීම අපි නිර්දේශ කරමු."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium බ්‍රවුසර සහ සංරචක යාවත්කාලීන ලැබෙන විට ස්වයංක්‍රියව බාගැනීම සහ ස්ථාපනය කරනු ඇත. නවතම විශේෂාංග සහ ආරක්ෂක යාවත්කාලීන ලබා ගැනීම සහතික කිරීමට මෙම සැකසුම සක්‍රියව තබා ගැනීම අපි නිර්දේශ කරමු. මෙම වේදිකාවේ ස්වයංක්‍රිය මූලික බ්‍රවුසර යාවත්කාලීන තවම ලබා ගත නොහැක, නමුත් සංරචක යාවත්කාලීන ලබා ගත හැක. Helium යාවත්කාලීනව තබා ගැනීමට කරුණාකර බාහිර මෘදුකාංග භාවිතා කරන්න."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "uBlock Origin සඳහා පෙරහන ලැයිස්තු බාගැනීමට ඉඩ දෙන්න"

--- a/i18n/translations/sk.json
+++ b/i18n/translations/sk.json
@@ -190,21 +190,6 @@
     "message": "Verzia <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "Povoliť automatické aktualizácie prehliadača a komponentov"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium bude automaticky sťahovať a inštalovať aktualizácie prehliadača a komponentov, keď budú dostupné. Odporúčame ponechať toto nastavenie zapnuté, aby ste mali najnovšie funkcie a bezpečnostné aktualizácie."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium bude automaticky sťahovať a inštalovať aktualizácie prehliadača a komponentov, keď budú dostupné. Odporúčame ponechať toto nastavenie zapnuté, aby ste mali najnovšie funkcie a bezpečnostné aktualizácie. Automatické aktualizácie jadra prehliadača zatiaľ nie sú na tejto platforme k dispozícii, ale aktualizácie komponentov áno. Na udržiavanie Heliumu v aktuálnom stave použite externý softvér."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "Povoliť sťahovanie zoznamov filtrov pre uBlock Origin"

--- a/i18n/translations/sl.json
+++ b/i18n/translations/sl.json
@@ -190,21 +190,6 @@
     "message": "Različica <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "Dovoli samodejne posodobitve brskalnika in komponent"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium bo samodejno prenesel in namestil posodobitve brskalnika in komponent, ko bodo na voljo. Priporočamo, da to nastavitev pustite omogočeno, da boste vedno imeli najnovejše funkcije in varnostne posodobitve."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium bo samodejno prenesel in namestil posodobitve brskalnika in komponent, ko bodo na voljo. Priporočamo, da to nastavitev pustite omogočeno, da boste vedno imeli najnovejše funkcije in varnostne posodobitve. Samodejne posodobitve jedra brskalnika na tej platformi še niso na voljo, posodobitve komponent pa so. Za posodabljanje brskalnika Helium uporabite zunanjo programsko opremo."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "Dovoli prenašanje seznamov filtrov za uBlock Origin"

--- a/i18n/translations/sq.json
+++ b/i18n/translations/sq.json
@@ -191,21 +191,6 @@
     "message": "Versioni <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "Lejo përditësimet automatike të shfletuesit dhe komponentëve"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium do të shkarkojë dhe instalojë automatikisht përditësimet e shfletuesit dhe komponentëve sapo të bëhen të disponueshme. Rekomandojmë ta mbani këtë cilësim të aktivizuar për të siguruar që merrni veçoritë dhe përditësimet më të fundit të sigurisë."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium do të shkarkojë dhe instalojë automatikisht përditësimet e shfletuesit dhe komponentëve sapo të bëhen të disponueshme. Rekomandojmë ta mbani këtë cilësim të aktivizuar për të siguruar që merrni veçoritë dhe përditësimet më të fundit të sigurisë. Përditësimet automatike të shfletuesit bazë nuk janë ende të disponueshme në këtë platformë, por përditësimet e komponentëve janë. Ju lutemi përdorni softuer të jashtëm për ta mbajtur Helium të përditësuar."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "Lejo shkarkimin e listave të filtrave për uBlock Origin"

--- a/i18n/translations/sr-Latn.json
+++ b/i18n/translations/sr-Latn.json
@@ -191,21 +191,6 @@
     "message": "Verzija <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "Dozvoli automatska ažuriranja pregledača i komponenti"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium će automatski preuzimati i instalirati ažuriranja pregledača i komponenti čim postanu dostupna. Preporučujemo da ovo podešavanje ostane omogućeno kako biste dobijali najnovije funkcije i bezbednosna ažuriranja."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium će automatski preuzimati i instalirati ažuriranja pregledača i komponenti čim postanu dostupna. Preporučujemo da ovo podešavanje ostane omogućeno kako biste dobijali najnovije funkcije i bezbednosna ažuriranja. Automatska ažuriranja osnovnog pregledača još nisu dostupna na ovoj platformi, ali ažuriranja komponenti jesu. Koristite spoljni softver da održavate Helium ažurnim."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "Dozvoli preuzimanje lista filtera za uBlock Origin"

--- a/i18n/translations/sr.json
+++ b/i18n/translations/sr.json
@@ -190,21 +190,6 @@
     "message": "Верзија <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "Дозволи аутоматско ажурирање прегледача и компоненти"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium ће аутоматски преузимати и инсталирати ажурирања прегледача и компоненти чим постану доступна. Препоручујемо да ово подешавање остане омогућено како бисте добијали најновије функције и безбедносна ажурирања."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium ће аутоматски преузимати и инсталирати ажурирања прегледача и компоненти чим постану доступна. Препоручујемо да ово подешавање остане омогућено како бисте добијали најновије функције и безбедносна ажурирања. Аутоматска ажурирања основног прегледача још нису доступна на овој платформи, али ажурирања компоненти јесу. Користите екстерни софтвер да одржавате Helium ажурним."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "Дозволи преузимање листа филтера за uBlock Origin"

--- a/i18n/translations/sv.json
+++ b/i18n/translations/sv.json
@@ -190,21 +190,6 @@
     "message": "Version <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "Tillåt automatiska webbläsar- och komponentuppdateringar"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium laddar automatiskt ned och installerar webbläsar- och komponentuppdateringar när de blir tillgängliga. Vi rekommenderar att du håller den här inställningen aktiverad för att få de senaste funktionerna och säkerhetsuppdateringarna."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium laddar automatiskt ned och installerar webbläsar- och komponentuppdateringar när de blir tillgängliga. Vi rekommenderar att du håller den här inställningen aktiverad för att få de senaste funktionerna och säkerhetsuppdateringarna. Automatiska kärnuppdateringar av webbläsaren är inte tillgängliga på den här plattformen ännu, men komponentuppdateringar fungerar. Använd extern programvara för att hålla Helium uppdaterat."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "Tillåt nedladdning av filterlistor för uBlock Origin"

--- a/i18n/translations/sw.json
+++ b/i18n/translations/sw.json
@@ -190,21 +190,6 @@
     "message": "Toleo <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "Ruhusu masasisho ya kiotomatiki ya kivinjari na vijenzi"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium itapakua na kusakinisha masasisho ya kivinjari na vijenzi kiotomatiki yanapokuwa tayari. Tunapendekeza kuweka mpangilio huu ukiwa umewashwa ili uhakikishe unapata vipengele vipya na masasisho ya usalama."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium itapakua na kusakinisha masasisho ya kivinjari na vijenzi kiotomatiki yanapokuwa tayari. Tunapendekeza kuweka mpangilio huu ukiwa umewashwa ili uhakikishe unapata vipengele vipya na masasisho ya usalama. Masasisho ya kiotomatiki ya kivinjari bado hayapatikani kwenye jukwaa hili, lakini masasisho ya vijenzi yanapatikana. Tafadhali tumia programu ya nje kuweka Helium kuwa ya kisasa."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "Ruhusu kupakua orodha za vichujio vya uBlock Origin"

--- a/i18n/translations/ta.json
+++ b/i18n/translations/ta.json
@@ -190,21 +190,6 @@
     "message": "பதிப்பு <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "தானியங்கி உலாவி மற்றும் கூறு புதுப்பிப்புகளை அனுமதிக்கவும்"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "உலாவி மற்றும் கூறு புதுப்பிப்புகள் கிடைக்கும்போது Helium தானாகவே பதிவிறக்கி நிறுவும். சமீபத்திய அம்சங்கள் மற்றும் பாதுகாப்பு புதுப்பிப்புகளைப் பெற இந்த அமைப்பை இயக்கி வைக்க பரிந்துரைக்கிறோம்."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "உலாவி மற்றும் கூறு புதுப்பிப்புகள் கிடைக்கும்போது Helium தானாகவே பதிவிறக்கி நிறுவும். சமீபத்திய அம்சங்கள் மற்றும் பாதுகாப்பு புதுப்பிப்புகளைப் பெற இந்த அமைப்பை இயக்கி வைக்க பரிந்துரைக்கிறோம். இந்த தளத்தில் தானியங்கி முக்கிய உலாவி புதுப்பிப்புகள் இன்னும் கிடைக்கவில்லை, ஆனால் கூறு புதுப்பிப்புகள் கிடைக்கும். Helium-ஐ புதுப்பித்த நிலையில் வைக்க வெளிப்புற மென்பொருளைப் பயன்படுத்தவும்."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "uBlock Origin க்கான வடிகட்டி பட்டியல்களைப் பதிவிறக்க அனுமதிக்கவும்"

--- a/i18n/translations/te.json
+++ b/i18n/translations/te.json
@@ -190,21 +190,6 @@
     "message": "వెర్షన్ <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "స్వయంచాలక బ్రౌజర్ మరియు కాంపోనెంట్ అప్‌డేట్‌లను అనుమతించు"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "బ్రౌజర్ మరియు కాంపోనెంట్ అప్‌డేట్‌లు అందుబాటులోకి వచ్చినప్పుడు Helium వాటిని స్వయంచాలకంగా డౌన్‌లోడ్ చేసి ఇన్‌స్టాల్ చేస్తుంది. మీరు తాజా ఫీచర్‌లు మరియు భద్రతా నవీకరణలను పొందేలా ఈ సెట్టింగ్‌ను ఎనేబుల్‌గా ఉంచమని మేము సిఫారసు చేస్తున్నాము."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "బ్రౌజర్ మరియు కాంపోనెంట్ అప్‌డేట్‌లు అందుబాటులోకి వచ్చినప్పుడు Helium వాటిని స్వయంచాలకంగా డౌన్‌లోడ్ చేసి ఇన్‌స్టాల్ చేస్తుంది. మీరు తాజా ఫీచర్‌లు మరియు భద్రతా నవీకరణలను పొందేలా ఈ సెట్టింగ్‌ను ఎనేబుల్‌గా ఉంచమని మేము సిఫారసు చేస్తున్నాము. ఈ ప్లాట్‌ఫారమ్‌లో స్వయంచాలక కోర్ బ్రౌజర్ అప్‌డేట్‌లు ఇంకా అందుబాటులో లేవు, కానీ కాంపోనెంట్ అప్‌డేట్‌లు అందుబాటులో ఉన్నాయి. దయచేసి Heliumను తాజాగా ఉంచడానికి బాహ్య సాఫ్ట్‌వేర్‌ను ఉపయోగించండి."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "uBlock Origin కోసం ఫిల్టర్ జాబితాలను డౌన్‌లోడ్ చేయడానికి అనుమతించు"

--- a/i18n/translations/th.json
+++ b/i18n/translations/th.json
@@ -190,21 +190,6 @@
     "message": "เวอร์ชัน <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "อนุญาตให้อัปเดตเบราว์เซอร์และคอมโพเนนต์อัตโนมัติ"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium จะดาวน์โหลดและติดตั้งการอัปเดตเบราว์เซอร์และคอมโพเนนต์โดยอัตโนมัติเมื่อพร้อมใช้งาน เราแนะนำให้เปิดใช้การตั้งค่านี้ไว้เพื่อให้แน่ใจว่าคุณได้รับฟีเจอร์และการอัปเดตความปลอดภัยล่าสุด"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium จะดาวน์โหลดและติดตั้งการอัปเดตเบราว์เซอร์และคอมโพเนนต์โดยอัตโนมัติเมื่อพร้อมใช้งาน เราแนะนำให้เปิดใช้การตั้งค่านี้ไว้เพื่อให้แน่ใจว่าคุณได้รับฟีเจอร์และการอัปเดตความปลอดภัยล่าสุด การอัปเดตเบราว์เซอร์หลักอัตโนมัติยังไม่พร้อมใช้งานบนแพลตฟอร์มนี้ แต่การอัปเดตคอมโพเนนต์พร้อมใช้งาน กรุณาใช้ซอฟต์แวร์ภายนอกเพื่อให้ Helium เป็นเวอร์ชันล่าสุด"
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "อนุญาตให้ดาวน์โหลดรายการตัวกรองสำหรับ uBlock Origin"

--- a/i18n/translations/tr.json
+++ b/i18n/translations/tr.json
@@ -190,21 +190,6 @@
     "message": "Sürüm <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "Otomatik tarayıcı ve bileşen güncellemelerine izin ver"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium, tarayıcı ve bileşen güncellemelerini kullanıma sunuldukça otomatik olarak indirir ve yükler. En son özellikleri ve güvenlik güncellemelerini almanızı sağlamak için bu ayarı etkin tutmanızı öneririz."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium, tarayıcı ve bileşen güncellemelerini kullanıma sunuldukça otomatik olarak indirir ve yükler. En son özellikleri ve güvenlik güncellemelerini almanızı sağlamak için bu ayarı etkin tutmanızı öneririz. Bu platformda otomatik temel tarayıcı güncellemeleri henüz mevcut değildir, ancak bileşen güncellemeleri mevcuttur. Helium'u güncel tutmak için lütfen harici bir yazılım kullanın."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "uBlock Origin için filtre listelerinin indirilmesine izin ver"

--- a/i18n/translations/uk.json
+++ b/i18n/translations/uk.json
@@ -190,21 +190,6 @@
     "message": "Версія <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "Дозволити автоматичне оновлення браузера та компонентів"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium автоматично завантажуватиме й встановлюватиме оновлення браузера та компонентів, щойно вони стануть доступними. Рекомендуємо залишати цей параметр увімкненим, щоб отримувати найновіші функції та оновлення безпеки."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium автоматично завантажуватиме й встановлюватиме оновлення браузера та компонентів, щойно вони стануть доступними. Рекомендуємо залишати цей параметр увімкненим, щоб отримувати найновіші функції та оновлення безпеки. Автоматичне оновлення основного браузера поки що недоступне на цій платформі, але оновлення компонентів доступні. Використовуйте стороннє програмне забезпечення, щоб підтримувати Helium в актуальному стані."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "Дозволити завантаження списків фільтрів для uBlock Origin"

--- a/i18n/translations/ur.json
+++ b/i18n/translations/ur.json
@@ -192,21 +192,6 @@
     "message": "ورژن <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>، <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "براؤزر اور اجزاء کی خودکار اپ ڈیٹس کی اجازت دیں"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium براؤزر اور اجزاء کی اپ ڈیٹس دستیاب ہونے پر خود بخود ڈاؤن لوڈ اور انسٹال کرے گا۔ ہم تجویز کرتے ہیں کہ اس ترتیب کو فعال رکھیں تاکہ آپ کو تازہ ترین خصوصیات اور سیکیورٹی اپ ڈیٹس مل سکیں۔"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium براؤزر اور اجزاء کی اپ ڈیٹس دستیاب ہونے پر خود بخود ڈاؤن لوڈ اور انسٹال کرے گا۔ ہم تجویز کرتے ہیں کہ اس ترتیب کو فعال رکھیں تاکہ آپ کو تازہ ترین خصوصیات اور سیکیورٹی اپ ڈیٹس مل سکیں۔ اس پلیٹ فارم پر ابھی بنیادی براؤزر کی خودکار اپ ڈیٹس دستیاب نہیں ہیں، لیکن اجزاء کی اپ ڈیٹس دستیاب ہیں۔ براہ کرم Helium کو اپ ٹو ڈیٹ رکھنے کے لیے بیرونی سافٹ ویئر استعمال کریں۔"
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "uBlock Origin کے لیے فلٹر فہرستیں ڈاؤن لوڈ کرنے کی اجازت دیں"

--- a/i18n/translations/uz.json
+++ b/i18n/translations/uz.json
@@ -190,21 +190,6 @@
     "message": "Versiya <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "Avtomatik brauzer va komponent yangilanishlariga ruxsat berish"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium brauzer va komponent yangilanishlarini mavjud bo'lganda avtomatik ravishda yuklab oladi va o'rnatadi. Eng so'nggi funksiyalar va xavfsizlik yangilanishlarini olishingiz uchun bu sozlamani yoqiq holda saqlashni tavsiya etamiz."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium brauzer va komponent yangilanishlarini mavjud bo'lganda avtomatik ravishda yuklab oladi va o'rnatadi. Eng so'nggi funksiyalar va xavfsizlik yangilanishlarini olishingiz uchun bu sozlamani yoqiq holda saqlashni tavsiya etamiz. Bu platformada asosiy brauzerning avtomatik yangilanishlari hali mavjud emas, lekin komponent yangilanishlari mavjud. Helium ni yangilab turish uchun tashqi dasturlardan foydalaning."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "uBlock Origin uchun filtr ro'yxatlarini yuklashga ruxsat berish"

--- a/i18n/translations/vi.json
+++ b/i18n/translations/vi.json
@@ -190,21 +190,6 @@
     "message": "Phiên bản <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "Cho phép tự động cập nhật trình duyệt và thành phần"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium sẽ tự động tải xuống và cài đặt các bản cập nhật trình duyệt và thành phần khi có sẵn. Chúng tôi khuyên bạn nên bật cài đặt này để đảm bảo bạn nhận được các tính năng mới nhất và bản cập nhật bảo mật."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium sẽ tự động tải xuống và cài đặt các bản cập nhật trình duyệt và thành phần khi có sẵn. Chúng tôi khuyên bạn nên bật cài đặt này để đảm bảo bạn nhận được các tính năng mới nhất và bản cập nhật bảo mật. Tự động cập nhật trình duyệt chính chưa khả dụng trên nền tảng này, nhưng cập nhật thành phần thì có. Vui lòng sử dụng phần mềm bên ngoài để cập nhật Helium."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "Cho phép tải danh sách bộ lọc cho uBlock Origin"

--- a/i18n/translations/zh-CN.json
+++ b/i18n/translations/zh-CN.json
@@ -190,21 +190,6 @@
     "message": "版本 <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph>（<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>，<ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>）<ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "允许自动浏览器和组件更新"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium 将在更新可用时自动下载并安装浏览器和组件更新。我们建议您保持此设置为启用状态，以确保获得最新功能和安全更新。"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium 将在更新可用时自动下载并安装浏览器和组件更新。我们建议您保持此设置为启用状态，以确保获得最新功能和安全更新。此平台尚不支持核心浏览器的自动更新，但组件更新可用。请使用外部软件保持 Helium 为最新版本。"
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "允许下载 uBlock Origin 过滤规则列表"

--- a/i18n/translations/zh-HK.json
+++ b/i18n/translations/zh-HK.json
@@ -190,21 +190,6 @@
     "message": "版本 <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph>（<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>，<ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>）<ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "允許自動更新瀏覽器和元件"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium 會在有更新時自動下載並安裝瀏覽器和元件更新。我們建議保持此設定為啟用狀態，以確保您獲得最新功能和安全性更新。"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium 會在有更新時自動下載並安裝瀏覽器和元件更新。我們建議保持此設定為啟用狀態，以確保您獲得最新功能和安全性更新。此平台目前尚不支援自動核心瀏覽器更新，但支援元件更新。請使用外部軟件保持 Helium 處於最新狀態。"
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "允許下載 uBlock Origin 過濾器清單"

--- a/i18n/translations/zh-TW.json
+++ b/i18n/translations/zh-TW.json
@@ -190,21 +190,6 @@
     "message": "版本 <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph>（<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>，<ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>）<ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "允許自動下載瀏覽器和元件更新"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium 會在有可用更新時自動下載並安裝瀏覽器和元件更新。我們建議保持此設定為啟用狀態，以確保您獲得最新功能和安全性更新。"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium 會在有可用更新時自動下載並安裝瀏覽器和元件更新。我們建議保持此設定為啟用狀態，以確保您獲得最新功能和安全性更新。此平台尚不支援自動核心瀏覽器更新，但支援元件更新。請使用外部軟體保持 Helium 為最新版本。"
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "允許下載 uBlock Origin 的過濾清單"

--- a/i18n/translations/zu.json
+++ b/i18n/translations/zu.json
@@ -190,21 +190,6 @@
     "message": "Inguqulo <ph name=\"HELIUM_PRODUCT_VERSION\">$1<ex>0.0.0.0</ex></ph> (<ph name=\"PRODUCT_CHANNEL\">$4<ex>Developer Build</ex></ph>, <ph name=\"CHROMIUM_NAME\">$7</ph> <ph name=\"PRODUCT_VERSION\">$2<ex>15.0.865.0</ex></ph><ph name=\"PRODUCT_VERSION_SUFFIX\">$3<ex>-r123456</ex></ph>) <ph name=\"PRODUCT_MODIFIER\">$5</ph> <ph name=\"PRODUCT_VERSION_BITS\">$6</ph>"
   },
   {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE",
-    "source": "Allow automatic browser and component updates",
-    "message": "Vumela ukubuyekezwa okuzenzakalelayo kwesiphequluli nezingxenye"
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
-    "message": "Helium izolanda ngokuzenzakalelayo ifake izibuyekezo zesiphequluli nezingxenye njengoba zitholakala. Sincoma ukugcina lesi silungiselelo sinikiwe amandla ukuze uqinisekise ukuthi uthola izici zakamuva nezibuyekezo zokuvikeleka."
-  },
-  {
-    "name": "IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION",
-    "source": "Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.",
-    "message": "Helium izolanda ngokuzenzakalelayo ifake izibuyekezo zesiphequluli nezingxenye njengoba zitholakala. Sincoma ukugcina lesi silungiselelo sinikiwe amandla ukuze uqinisekise ukuthi uthola izici zakamuva nezibuyekezo zokuvikeleka. Ukubuyekezwa okuzenzakalelayo kwesiphequluli esiyinhloko akukatholakali kuleli phlathifomu okwamanje, kodwa izibuyekezo zezingxenye ziyatholakala. Sicela usebenzise isofthiwe yangaphandle ukugcina Helium ibuyekezwe."
-  },
-  {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_UBO",
     "source": "Allow downloading filter lists for uBlock Origin",
     "message": "Vumela ukulanda izinhlu zokuhlungela ze-uBlock Origin"

--- a/patches/helium/core/add-updater-preference.patch
+++ b/patches/helium/core/add-updater-preference.patch
@@ -151,21 +151,24 @@
    registry->RegisterBooleanPref(
 --- a/chrome/app/settings_strings.grdp
 +++ b/chrome/app/settings_strings.grdp
-@@ -1760,6 +1760,19 @@
+@@ -1760,6 +1760,22 @@
      <message name="IDS_SETTINGS_HELIUM_SERVICES_SPELLCHECK_TOGGLE_DESCRIPTION" desc="Description of the for enabling/disabling of downloading spellcheck files">
        Helium will fetch dictionary files used for spell checking when requested. When disabled, spell checking will not work.
      </message>
-+    <message name="IDS_SETTINGS_HELIUM_SERVICES_UPDATE" desc="Toggle for automatic update downloads">
-+      Allow automatic browser and component updates
-+    </message>
-+    <if expr="is_macosx">
++    <if expr="not is_linux">
++      <message name="IDS_SETTINGS_HELIUM_SERVICES_UPDATE" desc="Toggle for automatic update downloads">
++        Allow automatic browser updates
++      </message>
 +      <message name="IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION" desc="Description of the toggle for automatic update downloads">
-+        Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates.
++        Helium will automatically check for updates and install them. This includes browser and component updates. We recommend keeping this setting enabled to ensure you get the latest features and security updates.
 +      </message>
 +    </if>
-+    <if expr="not is_macosx">
++    <if expr="is_linux">
++      <message name="IDS_SETTINGS_HELIUM_SERVICES_UPDATE" desc="Toggle for automatic update downloads">
++        Allow automatic component updates
++      </message>
 +      <message name="IDS_SETTINGS_HELIUM_SERVICES_UPDATE_DESCRIPTION" desc="Description of the toggle for automatic update downloads">
-+        Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.
++        Helium will automatically check for component updates and install them. We recommend keeping this setting enabled. On Linux, browser updates are handled by your distro's package manager. Please check for Helium package updates at least every week.
 +      </message>
 +    </if>
      <message name="IDS_SETTINGS_HELIUM_SERVICES_OVERRIDE" desc="Text input for overriding the Helium services server">

--- a/patches/helium/core/ublock-helium-services.patch
+++ b/patches/helium/core/ublock-helium-services.patch
@@ -217,8 +217,8 @@
                  if ( bin.assetSourceRegistry instanceof Object ) {
 --- a/chrome/app/settings_strings.grdp
 +++ b/chrome/app/settings_strings.grdp
-@@ -1773,6 +1773,12 @@
-         Helium will automatically download and install browser and component updates as they become available. We recommend keeping this setting enabled to ensure you get the latest features and security updates. Automatic core browser updates are not available on this platform yet, but component updates are. Please use external software to keep Helium up to date.
+@@ -1776,6 +1776,12 @@
+         Helium will automatically check for component updates and install them. We recommend keeping this setting enabled. On Linux, browser updates are handled by your distro's package manager. Please check for Helium package updates at least every week.
        </message>
      </if>
 +    <message name="IDS_SETTINGS_HELIUM_SERVICES_UBO" desc="Description of the toggle for uBO filter lists">

--- a/patches/helium/settings/add-search-engine-button.patch
+++ b/patches/helium/settings/add-search-engine-button.patch
@@ -1,6 +1,6 @@
 --- a/chrome/app/settings_strings.grdp
 +++ b/chrome/app/settings_strings.grdp
-@@ -2518,6 +2518,9 @@
+@@ -2521,6 +2521,9 @@
      <message name="IDS_SETTINGS_SEARCH_ENGINES_ADD_SITE_SEARCH" desc="Title for a dialog that allows adding a new site search engine.">
        Add site search
      </message>

--- a/patches/helium/settings/custom-keyboard-shortcuts-page.patch
+++ b/patches/helium/settings/custom-keyboard-shortcuts-page.patch
@@ -1,6 +1,6 @@
 --- a/chrome/app/settings_strings.grdp
 +++ b/chrome/app/settings_strings.grdp
-@@ -4292,6 +4292,45 @@
+@@ -4295,6 +4295,45 @@
        <message name="IDS_SETTINGS_SYSTEM_FEATURE_NOTIFICATIONS_LABEL" desc="Label for the toggle that enables Chrome system notifications about features.">
          Show system notifications about Chrome features and tips
        </message>

--- a/patches/helium/settings/custom-profile-avatar-ui.patch
+++ b/patches/helium/settings/custom-profile-avatar-ui.patch
@@ -1,6 +1,6 @@
 --- a/chrome/app/settings_strings.grdp
 +++ b/chrome/app/settings_strings.grdp
-@@ -3999,6 +3999,21 @@
+@@ -4002,6 +4002,21 @@
        <message name="IDS_SETTINGS_PICK_AN_AVATAR" desc="Title of the edit avatar selection section on the manage profile page.">
          Pick an avatar
        </message>

--- a/patches/helium/settings/fix-text-on-cookies-page.patch
+++ b/patches/helium/settings/fix-text-on-cookies-page.patch
@@ -1,6 +1,6 @@
 --- a/chrome/app/settings_strings.grdp
 +++ b/chrome/app/settings_strings.grdp
-@@ -2034,6 +2034,9 @@
+@@ -2037,6 +2037,9 @@
      <message name="IDS_SETTINGS_ENABLE_DO_NOT_TRACK_DIALOG_TEXT" desc="The text of a confirmation dialog that confirms that the user want to send the 'Do Not Track' header">
        Enabling "Do Not Track" means that a request will be included with your browsing traffic. Any effect depends on whether a website responds to the request, and how the request is interpreted. For example, some websites may respond to this request by showing you ads that aren't based on other websites you've visited. Many websites will still collect and use your browsing data - for example to improve security, to provide content, services, ads and recommendations on their websites, and to generate reporting statistics.
      </message>
@@ -10,7 +10,7 @@
      <message name="IDS_SETTINGS_ENABLE_DO_NOT_TRACK_DIALOG_LEARN_MORE_ACCESSIBILITY_LABEL" desc="The accessibility label for a link to learn more about Do Not Track">
        Learn more about Do Not Track
      </message>
-@@ -3437,6 +3440,9 @@
+@@ -3440,6 +3443,9 @@
      <message name="IDS_SETTINGS_TRACKING_PROTECTION_SITES_ALLOWED_COOKIES_DESCRIPTION" desc="Description of the section on the Tracking Protection settings page that lets users manage which sites are allowed to use third-party cookies. Explains how to use a wildcard to create an exception for an entire domain.">
        Affects the sites listed here. Inserting “[*.]” before a domain name creates an exception for the entire domain. For example, adding “[*.]google.com” means that third-party cookies can also be active for mail.google.com, because it’s part of google.com.
      </message>

--- a/patches/helium/settings/privacy-page-tweaks.patch
+++ b/patches/helium/settings/privacy-page-tweaks.patch
@@ -1,6 +1,6 @@
 --- a/chrome/app/settings_strings.grdp
 +++ b/chrome/app/settings_strings.grdp
-@@ -2047,6 +2047,12 @@
+@@ -2050,6 +2050,12 @@
      users to manage security settings">
        Security
      </message>

--- a/patches/helium/ui/layout/shortcuts.patch
+++ b/patches/helium/ui/layout/shortcuts.patch
@@ -166,7 +166,7 @@
      VK_NEXT,        IDC_MOVE_TAB_NEXT,          VIRTKEY, CONTROL, SHIFT
 --- a/chrome/app/settings_strings.grdp
 +++ b/chrome/app/settings_strings.grdp
-@@ -4870,6 +4870,16 @@
+@@ -4873,6 +4873,16 @@
        Enable quick page link copying with Ctrl+Shift+C
      </message>
    </if>


### PR DESCRIPTION
- the common updater text is now easier to read and understand
- windows now has auto updates, so we use the same strings as on macos
- linux will not have in-browser auto updates, so we nudge the user towards updating helium via the package manager every week