### PR TITLE
helium/core/hibernate: add an option to hibernate other tabs

### DIFF
--- a/i18n/source.gen.json
+++ b/i18n/source.gen.json
@@ -318,10 +318,22 @@
     "message": "Hibernate"
   },
   {
+    "name": "IDS_TAB_CXMENU_HIBERNATE_OTHER_TABS",
+    "source": "chrome/app/generated_resources.grd",
+    "context": "The label of the 'Hibernate other tabs' Tab context menu item.",
+    "message": "Hibernate other tabs"
+  },
+  {
     "name": "IDS_TAB_CXMENU_HIBERNATE",
     "source": "chrome/app/generated_resources.grd",
     "context": "In Title Case: The label of the 'Hibernate' Tab context menu item.",
     "message": "Hibernate"
+  },
+  {
+    "name": "IDS_TAB_CXMENU_HIBERNATE_OTHER_TABS",
+    "source": "chrome/app/generated_resources.grd",
+    "context": "In Title Case: The label of the 'Hibernate Other Tabs' Tab context menu item.",
+    "message": "Hibernate Other Tabs"
   },
   {
     "name": "IDS_TAB_CXMENU_CLOSETABSABOVE",

--- a/patches/helium/core/close-tabs-to-left.patch
+++ b/patches/helium/core/close-tabs-to-left.patch
@@ -1,6 +1,6 @@
 --- a/chrome/app/generated_resources.grd
 +++ b/chrome/app/generated_resources.grd
-@@ -12119,6 +12119,9 @@ Check your passwords anytime in <ph name
+@@ -12122,6 +12122,9 @@ Check your passwords anytime in <ph name
          <message name="IDS_TAB_CXMENU_CLOSETABSBELOW" desc="The label of the 'Close Tabs Below' Tab context menu item.">
            Close tabs below
          </message>
@@ -10,7 +10,7 @@
          <message name="IDS_TAB_CXMENU_CLOSEALLTABS" desc="The label of the 'Close All Tabs' Tab context menu item.">
            Close all tabs
          </message>
-@@ -12238,6 +12241,9 @@ Check your passwords anytime in <ph name
+@@ -12244,6 +12247,9 @@ Check your passwords anytime in <ph name
          <message name="IDS_TAB_CXMENU_CLOSETABSBELOW" desc="In Title Case: The label of the 'Close Tabs Below' Tab context menu item.">
            Close Tabs Below
          </message>
@@ -22,7 +22,7 @@
          </message>
 --- a/chrome/browser/ui/tabs/tab_menu_model.cc
 +++ b/chrome/browser/ui/tabs/tab_menu_model.cc
-@@ -402,6 +402,19 @@ void TabMenuModel::Build(int index) {
+@@ -405,6 +405,19 @@ void TabMenuModel::Build(int index) {
                        IDS_TAB_CXMENU_CLOSEOTHERTABS);
  
    if (showing_vertical_tabs) {
@@ -44,7 +44,7 @@
    } else {
 --- a/chrome/browser/ui/tabs/tab_strip_model.cc
 +++ b/chrome/browser/ui/tabs/tab_strip_model.cc
-@@ -2508,6 +2508,7 @@ bool TabStripModel::IsContextMenuCommand
+@@ -2510,6 +2510,7 @@ bool TabStripModel::IsContextMenuCommand
      }
  
      case CommandCloseOtherTabs:
@@ -52,7 +52,7 @@
      case CommandCloseTabsToRight: {
        return !GetIndicesClosedByCommand(context_index, command_id).empty();
      }
-@@ -2724,6 +2725,7 @@ void TabStripModel::ExecuteContextMenuCo
+@@ -2727,6 +2728,7 @@ void TabStripModel::ExecuteContextMenuCo
        break;
      }
  
@@ -60,7 +60,7 @@
      case CommandCloseTabsToRight: {
        base::UmaHistogramCounts1000(
            "Tab.ContextMenu.CloseTabsToRight.SelectedTabsCount",
-@@ -3555,15 +3557,22 @@ std::vector<int> TabStripModel::GetIndic
+@@ -3584,15 +3586,22 @@ std::vector<int> TabStripModel::GetIndic
    if (!ContainsIndex(index)) {
      return indices;
    }
@@ -84,7 +84,7 @@
    }
  
    // If the tab that the context menu command is invoked on is not selected and
-@@ -3578,6 +3587,10 @@ std::vector<int> TabStripModel::GetIndic
+@@ -3607,6 +3616,10 @@ std::vector<int> TabStripModel::GetIndic
  
    // NOTE: callers expect the vector to be sorted in descending order.
    for (int i = count() - 1; i > last_unclosed_tab; --i) {
@@ -95,7 +95,7 @@
      if (!indices_to_exclude.Contains(gfx::Range(i, i + 1)) && !IsTabPinned(i) &&
          (!is_selected || !IsTabSelected(i))) {
        indices.push_back(i);
-@@ -3593,7 +3606,8 @@ std::vector<tabs::TabInterface*> TabStri
+@@ -3622,7 +3635,8 @@ std::vector<tabs::TabInterface*> TabStri
      return {};
    }
  
@@ -105,7 +105,7 @@
  
    tabs::TabInterface* invoked_tab = GetTabAtIndex(index);
  
-@@ -3609,6 +3623,10 @@ std::vector<tabs::TabInterface*> TabStri
+@@ -3638,6 +3652,10 @@ std::vector<tabs::TabInterface*> TabStri
      tabs::TabInterface* tab = *it;
  
      if (tab == invoked_tab || tab->IsPinned()) {

--- a/patches/helium/core/hibernate-tab-context-menu.patch
+++ b/patches/helium/core/hibernate-tab-context-menu.patch
@@ -1,21 +1,27 @@
 --- a/chrome/app/generated_resources.grd
 +++ b/chrome/app/generated_resources.grd
-@@ -12101,6 +12101,9 @@ Check your passwords anytime in <ph name
+@@ -12101,6 +12101,12 @@ Check your passwords anytime in <ph name
          <message name="IDS_TAB_CXMENU_DUPLICATE" desc="The label of the 'Duplicate' Tab context menu item.">
            Duplicate
          </message>
 +        <message name="IDS_TAB_CXMENU_HIBERNATE" desc="The label of the 'Hibernate' Tab context menu item.">
 +          Hibernate
 +        </message>
++        <message name="IDS_TAB_CXMENU_HIBERNATE_OTHER_TABS" desc="The label of the 'Hibernate other tabs' Tab context menu item.">
++          Hibernate other tabs
++        </message>
          <message name="IDS_TAB_CXMENU_CLOSETAB" desc="The label of the tab context menu item for closing one or more tabs.">
            Close
          </message>
-@@ -12217,6 +12220,9 @@ Check your passwords anytime in <ph name
+@@ -12217,6 +12223,12 @@ Check your passwords anytime in <ph name
          <message name="IDS_TAB_CXMENU_DUPLICATE" desc="In Title Case: The label of the 'Duplicate' Tab context menu item.">
            Duplicate
          </message>
 +        <message name="IDS_TAB_CXMENU_HIBERNATE" desc="In Title Case: The label of the 'Hibernate' Tab context menu item.">
 +          Hibernate
++        </message>
++        <message name="IDS_TAB_CXMENU_HIBERNATE_OTHER_TABS" desc="In Title Case: The label of the 'Hibernate Other Tabs' Tab context menu item.">
++          Hibernate Other Tabs
 +        </message>
          <message name="IDS_TAB_CXMENU_CLOSETAB" desc="In Title Case: The label of the tab context menu item for closing one or more tabs.">
            Close
@@ -30,6 +36,17 @@
      CommandLast
    };
    // LINT.ThenChange(//tools/metrics/histograms/metadata/tab/histograms.xml:TabContextMenuCommand)
+@@ -1095,6 +1096,10 @@ class TabStripModel {
+   // increasing order.
+   std::vector<int> GetIndicesForCommand(int index) const;
+ 
++  // Returns the indices that will be discarded when executing the discard
++  // command for the tab at |index|. Indices are sorted in increasing order.
++  std::vector<int> GetIndicesDiscardedByCommand(int index) const;
++
+   // Returns a vector of indices of the tabs that will close when executing the
+   // command |id| for the tab at |index|. The returned indices are sorted in
+   // descending order.
 --- a/chrome/browser/ui/tabs/tab_strip_model.cc
 +++ b/chrome/browser/ui/tabs/tab_strip_model.cc
 @@ -44,8 +44,11 @@
@@ -52,7 +69,7 @@
  #include "components/prefs/pref_service.h"
  #include "components/reading_list/core/reading_list_model.h"
  #include "components/split_tabs/split_tab_id.h"
-@@ -165,6 +169,54 @@ bool ShouldForgetOpenersForTransition(ui
+@@ -165,6 +169,55 @@ bool ShouldForgetOpenersForTransition(ui
                                        ui::PAGE_TRANSITION_AUTO_TOPLEVEL);
  }
  
@@ -76,8 +93,9 @@
 +    DiscardEligibilityPolicy* eligibility_policy) {
 +  CHECK(eligibility_policy);
 +
-+  // The active tab can't be discarded.
-+  if (index == tab_strip_model->active_index()) {
++  // Foreground tabs can't be discarded. Both tabs in an active split
++  // are considered foreground, so neither half can be discarded.
++  if (tab_strip_model->IsTabInForeground(index)) {
 +    return nullptr;
 +  }
 +
@@ -107,7 +125,7 @@
  }  // namespace
  
  TabGroupModelFactory::TabGroupModelFactory() {
-@@ -2440,6 +2492,21 @@ bool TabStripModel::IsContextMenuCommand
+@@ -2440,6 +2493,22 @@ bool TabStripModel::IsContextMenuCommand
      case CommandReload:
        return delegate_->CanReload();
  
@@ -117,7 +135,8 @@
 +        return false;
 +      }
 +
-+      const std::vector<int> indices = GetIndicesForCommand(context_index);
++      const std::vector<int> indices =
++          GetIndicesDiscardedByCommand(context_index);
 +      for (int index : indices) {
 +        if (GetDiscardCandidatePageNode(this, index, eligibility_policy)) {
 +          return true;
@@ -129,18 +148,18 @@
      case CommandCloseOtherTabs:
      case CommandCloseTabsToRight: {
        return !GetIndicesClosedByCommand(context_index, command_id).empty();
-@@ -2604,6 +2671,27 @@ void TabStripModel::ExecuteContextMenuCo
-       }
+@@ -2605,6 +2674,28 @@ void TabStripModel::ExecuteContextMenuCo
        break;
      }
-+
+ 
 +    case CommandDiscard: {
 +      auto* const eligibility_policy = GetDiscardEligibilityPolicy();
 +      if (!eligibility_policy) {
 +        break;
 +      }
 +
-+      const std::vector<int> indices = GetIndicesForCommand(context_index);
++      const std::vector<int> indices =
++          GetIndicesDiscardedByCommand(context_index);
 +      for (int index : indices) {
 +        base::WeakPtr<performance_manager::PageNode> page_node =
 +            GetDiscardCandidatePageNode(this, index, eligibility_policy);
@@ -154,21 +173,58 @@
 +      }
 +      break;
 +    }
- 
++
      case CommandCloseTab: {
        base::UmaHistogramCounts1000("Tab.ContextMenu.CloseTab.SelectedTabsCount",
+                                    selection_model_.size());
+@@ -3443,6 +3534,32 @@ std::vector<int> TabStripModel::GetIndic
+   return std::vector<int>(sel.begin(), sel.end());
+ }
+ 
++std::vector<int> TabStripModel::GetIndicesDiscardedByCommand(int index) const {
++  std::vector<int> indices;
++  if (!ContainsIndex(index)) {
++    return indices;
++  }
++
++  if (!IsTabInForeground(index)) {
++    return GetIndicesForCommand(index);
++  }
++
++  bool is_selected = IsTabSelected(index);
++  tabs::TabInterface* invoked_tab = GetTabAtIndex(index);
++  gfx::Range indices_to_exclude =
++      invoked_tab->IsSplit()
++          ? GetIndexRangeOfSplit(invoked_tab->GetSplit().value())
++          : gfx::Range(index, index + 1);
++
++  for (int i = 0; i < count(); ++i) {
++    if (!indices_to_exclude.Contains(gfx::Range(i, i + 1)) &&
++        (!is_selected || !IsTabSelected(i))) {
++      indices.push_back(i);
++    }
++  }
++  return indices;
++}
++
+ std::vector<tabs::TabInterface*> TabStripModel::GetTabsForCommand(
+     int index) const {
+   tabs::TabInterface* tab = GetTabAtIndex(index);
 --- a/chrome/browser/ui/tabs/tab_menu_model.cc
 +++ b/chrome/browser/ui/tabs/tab_menu_model.cc
-@@ -394,6 +394,9 @@ void TabMenuModel::Build(int index) {
+@@ -392,6 +392,12 @@ void TabMenuModel::Build(int index) {
+   }
+ #endif
  
++  AddSeparator(ui::NORMAL_SEPARATOR);
++  AddItemWithStringId(TabStripModel::CommandDiscard,
++                      tab_strip_->IsTabInForeground(index)
++                          ? IDS_TAB_CXMENU_HIBERNATE_OTHER_TABS
++                          : IDS_TAB_CXMENU_HIBERNATE);
++
    // Separator Close Tab items
    AddSeparator(ui::NORMAL_SEPARATOR);
-+
-+  AddItemWithStringId(TabStripModel::CommandDiscard, IDS_TAB_CXMENU_HIBERNATE);
-+
    AddItemWithStringId(TabStripModel::CommandCloseTab, IDS_TAB_CXMENU_CLOSETAB);
-   AddItemWithStringId(TabStripModel::CommandCloseOtherTabs,
-                       IDS_TAB_CXMENU_CLOSEOTHERTABS);
 --- a/chrome/browser/ui/performance_controls/memory_saver_chip_tab_helper.cc
 +++ b/chrome/browser/ui/performance_controls/memory_saver_chip_tab_helper.cc
 @@ -116,8 +116,9 @@ bool MemorySaverChipTabHelper::ComputeSh

--- a/patches/helium/ui/layout/zen-mode-wiring.patch
+++ b/patches/helium/ui/layout/zen-mode-wiring.patch
@@ -238,7 +238,7 @@
      {IDC_SHOW_BOOKMARK_MANAGER, ui::EF_COMMAND_DOWN | ui::EF_ALT_DOWN,
 --- a/chrome/app/generated_resources.grd
 +++ b/chrome/app/generated_resources.grd
-@@ -19484,6 +19484,9 @@ Please help our engineers fix this probl
+@@ -19490,6 +19490,9 @@ Please help our engineers fix this probl
        <message name="IDS_LINK_COPIED_TOAST_BODY" desc="Text on a toast notification that is shown when a link is successfully copied.">
          Link copied
        </message>

--- a/patches/helium/ui/ublock-show-in-settings.patch
+++ b/patches/helium/ui/ublock-show-in-settings.patch
@@ -87,7 +87,7 @@
  };
 --- a/chrome/app/generated_resources.grd
 +++ b/chrome/app/generated_resources.grd
-@@ -13906,6 +13906,9 @@ Check your passwords anytime in <ph name
+@@ -13912,6 +13912,9 @@ Check your passwords anytime in <ph name
          <message name="IDS_EXTENSIONS_INSTALL_LOCATION_SHARED_MODULE" desc="The text explaining the the installation of the extension was because of extensions that depend on this shared module">
            Installed because of dependent extension(s).
          </message>


### PR DESCRIPTION
the new option appears when calling the context menu on a foreground tab. users can select tabs to keep active, right click on the last one, and hibernate all other tabs. also, the hibernate option is now separated from close actions.

https://github.com/user-attachments/assets/3b3b8326-3e30-41ad-a385-5fcf52b4aa8a

