### PR TITLE
helium/core: add an option to copy URLs from tab context menu

### DIFF
--- a/i18n/source.gen.json
+++ b/i18n/source.gen.json
@@ -540,6 +540,30 @@
     "message": "Numpad <ph name=\"KEY_NAME\">$1<ex>1</ex></ph>"
   },
   {
+    "name": "IDS_TAB_CXMENU_COPY_URL",
+    "source": "chrome/app/generated_resources.grd",
+    "context": "The label of the 'Copy URL' Tab context menu item.",
+    "message": "Copy URL"
+  },
+  {
+    "name": "IDS_TAB_CXMENU_COPY_URLS",
+    "source": "chrome/app/generated_resources.grd",
+    "context": "The label of the 'Copy URLs' Tab context menu item.",
+    "message": "Copy URLs"
+  },
+  {
+    "name": "IDS_TAB_CXMENU_COPY_URL",
+    "source": "chrome/app/generated_resources.grd",
+    "context": "In Title Case: The label of the 'Copy URL' Tab context menu item.",
+    "message": "Copy URL"
+  },
+  {
+    "name": "IDS_TAB_CXMENU_COPY_URLS",
+    "source": "chrome/app/generated_resources.grd",
+    "context": "In Title Case: The label of the 'Copy URLs' Tab context menu item.",
+    "message": "Copy URLs"
+  },
+  {
     "name": "IDS_SETTINGS_PERMISSIONS_DESCRIPTION_NORMAL",
     "source": "chrome/app/settings_strings.grdp",
     "context": "Description of the controls available on the permissions and site content settings page",

--- a/patches/helium/core/copy-url-tab-context-menu.patch
+++ b/patches/helium/core/copy-url-tab-context-menu.patch
@@ -1,0 +1,209 @@
+--- a/chrome/app/generated_resources.grd
++++ b/chrome/app/generated_resources.grd
+@@ -12197,6 +12197,12 @@ Check your passwords anytime in <ph name
+         <message name="IDS_TAB_CXMENU_HIBERNATE_OTHER_TABS" desc="The label of the 'Hibernate other tabs' Tab context menu item.">
+           Hibernate other tabs
+         </message>
++        <message name="IDS_TAB_CXMENU_COPY_URL" desc="The label of the 'Copy URL' Tab context menu item.">
++          Copy URL
++        </message>
++        <message name="IDS_TAB_CXMENU_COPY_URLS" desc="The label of the 'Copy URLs' Tab context menu item.">
++          Copy URLs
++        </message>
+         <message name="IDS_TAB_CXMENU_CLOSETAB" desc="The label of the tab context menu item for closing one or more tabs.">
+           Close
+         </message>
+@@ -12322,6 +12328,12 @@ Check your passwords anytime in <ph name
+         <message name="IDS_TAB_CXMENU_HIBERNATE_OTHER_TABS" desc="In Title Case: The label of the 'Hibernate Other Tabs' Tab context menu item.">
+           Hibernate Other Tabs
+         </message>
++        <message name="IDS_TAB_CXMENU_COPY_URL" desc="In Title Case: The label of the 'Copy URL' Tab context menu item.">
++          Copy URL
++        </message>
++        <message name="IDS_TAB_CXMENU_COPY_URLS" desc="In Title Case: The label of the 'Copy URLs' Tab context menu item.">
++          Copy URLs
++        </message>
+         <message name="IDS_TAB_CXMENU_CLOSETAB" desc="In Title Case: The label of the tab context menu item for closing one or more tabs.">
+           Close
+         </message>
+--- a/chrome/browser/ui/tabs/tab_menu_model.cc
++++ b/chrome/browser/ui/tabs/tab_menu_model.cc
+@@ -95,7 +95,7 @@ TabMenuModel::TabMenuModel(ui::SimpleMen
+ TabMenuModel::~TabMenuModel() = default;
+ 
+ void TabMenuModel::BuildForWebApp(int index) {
+-  AddItemWithStringId(TabStripModel::CommandCopyURL, IDS_COPY_URL);
++  AddItemWithStringId(TabStripModel::CommandCopyURL, IDS_TAB_CXMENU_COPY_URL);
+   AddItemWithStringId(TabStripModel::CommandReload, IDS_TAB_CXMENU_RELOAD);
+   AddItemWithStringId(TabStripModel::CommandGoBack, IDS_CONTENT_CONTEXT_BACK);
+ 
+@@ -271,6 +271,11 @@ void TabMenuModel::Build(int index) {
+   }
+ 
+   AddSeparator(ui::NORMAL_SEPARATOR);
++  AddItemWithStringId(TabStripModel::CommandCopyURL,
++                      num_tabs == 1 ? IDS_TAB_CXMENU_COPY_URL
++                                    : IDS_TAB_CXMENU_COPY_URLS);
++
++  AddSeparator(ui::NORMAL_SEPARATOR);
+   AddItemWithStringId(TabStripModel::CommandReload, IDS_TAB_CXMENU_RELOAD);
+ 
+   AddItemWithStringId(TabStripModel::CommandDuplicate,
+--- a/chrome/browser/ui/browser_commands.cc
++++ b/chrome/browser/ui/browser_commands.cc
+@@ -255,6 +255,13 @@ namespace {
+ const char kOsOverrideForTabletSite[] = "Linux; Android 9; Chrome tablet";
+ const char kChPlatformOverrideForTabletSite[] = "Android";
+ 
++std::u16string FormatURLForCopy(content::WebContents* web_contents) {
++  return url_formatter::FormatUrl(web_contents->GetVisibleURL(),
++                                  url_formatter::kFormatReplaceChromeProtocol,
++                                  base::UnescapeRule::NORMAL, nullptr, nullptr,
++                                  nullptr);
++}
++
+ // Creates a new tabbed browser window, with the same size, type and profile as
+ // |original_browser|'s window, inserts |contents| into it, and shows it.
+ void CreateAndShowNewWindowWithContents(
+@@ -2530,11 +2537,7 @@ bool IsDebuggerAttachedToCurrentTab(Brow
+ void CopyURL(BrowserWindowInterface* browser,
+              content::WebContents* web_contents) {
+   ui::ScopedClipboardWriter scw(ui::ClipboardBuffer::kCopyPaste);
+-  const std::u16string formatted_url =
+-      url_formatter::FormatUrl(web_contents->GetVisibleURL(),
+-                               url_formatter::kFormatReplaceChromeProtocol,
+-                               base::UnescapeRule::NORMAL, nullptr,
+-                               nullptr, nullptr);
++  const std::u16string formatted_url = FormatURLForCopy(web_contents);
+   scw.WriteText(formatted_url);
+ 
+ #if !BUILDFLAG(IS_ANDROID)
+@@ -2548,6 +2551,28 @@ void CopyURL(BrowserWindowInterface* bro
+ #endif
+ }
+ 
++void CopyURLs(
++    const std::vector<content::WebContents*>& web_contentses) {
++  std::u16string urls;
++  for (content::WebContents* web_contents : web_contentses) {
++    if (!web_contents) {
++      continue;
++    }
++
++    if (!urls.empty()) {
++      urls.push_back(u'\n');
++    }
++    urls.append(FormatURLForCopy(web_contents));
++  }
++
++  if (urls.empty()) {
++    return;
++  }
++
++  ui::ScopedClipboardWriter scw(ui::ClipboardBuffer::kCopyPaste);
++  scw.WriteText(urls);
++}
++
+ bool CanCopyUrl(BrowserWindowInterface* browser) {
+   return IsWebAppOrCustomTab(browser) ||
+          !sharing_hub::SharingIsDisabledByPolicy(browser->GetProfile());
+--- a/chrome/browser/ui/tabs/tab_strip_model.cc
++++ b/chrome/browser/ui/tabs/tab_strip_model.cc
+@@ -2586,8 +2586,7 @@ bool TabStripModel::IsContextMenuCommand
+       return true;
+ 
+     case CommandCopyURL:
+-      DCHECK(delegate()->IsForWebApp());
+-      return true;
++      return GetWebContentsAt(context_index) != nullptr;
+ 
+     case CommandGoBack:
+       DCHECK(delegate()->IsForWebApp());
+@@ -3040,10 +3039,14 @@ void TabStripModel::ExecuteContextMenuCo
+     }
+ 
+     case CommandCopyURL: {
++      std::vector<int> indices = GetIndicesForCommand(context_index);
+       base::UmaHistogramCounts1000("Tab.ContextMenu.CopyURL.SelectedTabsCount",
+-                                   selection_model_.size());
++                                   indices.size());
+       base::RecordAction(UserMetricsAction("TabContextMenu_CopyURL"));
+-      delegate()->CopyURL(GetWebContentsAt(context_index));
++
++      std::vector<content::WebContents*> web_contentses =
++          GetWebContentsesByIndices(indices);
++      delegate()->CopyURLs(web_contentses);
+       break;
+     }
+ 
+--- a/chrome/browser/ui/browser_commands.h
++++ b/chrome/browser/ui/browser_commands.h
+@@ -322,6 +322,7 @@ void ClearCache(BrowserWindowInterface*
+ bool IsDebuggerAttachedToCurrentTab(BrowserWindowInterface* browser);
+ void CopyURL(BrowserWindowInterface* browser,
+              content::WebContents* web_contents);
++void CopyURLs(const std::vector<content::WebContents*>& web_contentses);
+ bool CanCopyUrl(BrowserWindowInterface* browser);
+ // Returns true if the browser window is for a web app or custom tab.
+ bool IsWebAppOrCustomTab(const BrowserWindowInterface* browser);
+--- a/chrome/browser/ui/browser_tab_strip_model_delegate.cc
++++ b/chrome/browser/ui/browser_tab_strip_model_delegate.cc
+@@ -318,6 +318,11 @@ void BrowserTabStripModelDelegate::CopyU
+   chrome::CopyURL(browser_, web_contents);
+ }
+ 
++void BrowserTabStripModelDelegate::CopyURLs(
++    const std::vector<content::WebContents*>& web_contentses) {
++  chrome::CopyURLs(web_contentses);
++}
++
+ void BrowserTabStripModelDelegate::GoBack(content::WebContents* web_contents) {
+   chrome::GoBack(web_contents);
+ }
+--- a/chrome/browser/ui/browser_tab_strip_model_delegate.h
++++ b/chrome/browser/ui/browser_tab_strip_model_delegate.h
+@@ -73,6 +73,8 @@ class BrowserTabStripModelDelegate : pub
+   bool SupportsReadLater() override;
+   bool IsForWebApp() override;
+   void CopyURL(content::WebContents* web_contents) override;
++  void CopyURLs(
++      const std::vector<content::WebContents*>& web_contentses) override;
+   void GoBack(content::WebContents* web_contents) override;
+   bool CanGoBack(content::WebContents* web_contents) override;
+   bool IsNormalWindow() override;
+--- a/chrome/browser/ui/tabs/tab_strip_model_delegate.h
++++ b/chrome/browser/ui/tabs/tab_strip_model_delegate.h
+@@ -183,6 +183,10 @@ class TabStripModelDelegate {
+   // Copies the URL of the given WebContents.
+   virtual void CopyURL(content::WebContents* web_contents) = 0;
+ 
++  // Copies the URLs of the given WebContentses.
++  virtual void CopyURLs(
++      const std::vector<content::WebContents*>& web_contentses) = 0;
++
+   // Navigates the web_contents back to the previous page.
+   virtual void GoBack(content::WebContents* web_contents) = 0;
+ 
+--- a/chrome/browser/ui/tabs/test_tab_strip_model_delegate.cc
++++ b/chrome/browser/ui/tabs/test_tab_strip_model_delegate.cc
+@@ -118,6 +118,9 @@ bool TestTabStripModelDelegate::IsForWeb
+ 
+ void TestTabStripModelDelegate::CopyURL(content::WebContents* web_contents) {}
+ 
++void TestTabStripModelDelegate::CopyURLs(
++    const std::vector<content::WebContents*>& web_contentses) {}
++
+ void TestTabStripModelDelegate::GoBack(content::WebContents* web_contents) {}
+ 
+ bool TestTabStripModelDelegate::CanGoBack(content::WebContents* web_contents) {
+--- a/chrome/browser/ui/tabs/test_tab_strip_model_delegate.h
++++ b/chrome/browser/ui/tabs/test_tab_strip_model_delegate.h
+@@ -73,6 +73,8 @@ class TestTabStripModelDelegate : public
+   bool SupportsReadLater() override;
+   bool IsForWebApp() override;
+   void CopyURL(content::WebContents* web_contents) override;
++  void CopyURLs(
++      const std::vector<content::WebContents*>& web_contentses) override;
+   void GoBack(content::WebContents* web_contents) override;
+   bool CanGoBack(content::WebContents* web_contents) override;
+   bool IsNormalWindow() override;

--- a/patches/helium/ui/layout/context-menu.patch
+++ b/patches/helium/ui/layout/context-menu.patch
@@ -105,7 +105,7 @@
  #include "chrome/browser/ui/intent_picker_tab_helper.h"
  #include "chrome/browser/ui/lens/lens_search_controller.h"
  #include "chrome/browser/ui/location_bar/location_bar.h"
-@@ -2266,6 +2267,20 @@ void ToggleVerticalTabsExpandOnHover(Bro
+@@ -2273,6 +2274,20 @@ void ToggleVerticalTabsExpandOnHover(Bro
    controller->SetExpandOnHoverEnabled(!controller->IsExpandOnHoverEnabled());
  }
  

--- a/patches/helium/ui/layout/vertical.patch
+++ b/patches/helium/ui/layout/vertical.patch
@@ -1119,7 +1119,7 @@
  }
 --- a/chrome/browser/ui/tabs/tab_menu_model.cc
 +++ b/chrome/browser/ui/tabs/tab_menu_model.cc
-@@ -344,32 +344,6 @@ void TabMenuModel::Build(int index) {
+@@ -349,32 +349,6 @@ void TabMenuModel::Build(int index) {
      }
    }
  

--- a/patches/helium/ui/layout/zen-mode-wiring.patch
+++ b/patches/helium/ui/layout/zen-mode-wiring.patch
@@ -238,7 +238,7 @@
      {IDC_SHOW_BOOKMARK_MANAGER, ui::EF_COMMAND_DOWN | ui::EF_ALT_DOWN,
 --- a/chrome/app/generated_resources.grd
 +++ b/chrome/app/generated_resources.grd
-@@ -19490,6 +19490,9 @@ Please help our engineers fix this probl
+@@ -19502,6 +19502,9 @@ Please help our engineers fix this probl
        <message name="IDS_LINK_COPIED_TOAST_BODY" desc="Text on a toast notification that is shown when a link is successfully copied.">
          Link copied
        </message>

--- a/patches/helium/ui/ublock-show-in-settings.patch
+++ b/patches/helium/ui/ublock-show-in-settings.patch
@@ -87,7 +87,7 @@
  };
 --- a/chrome/app/generated_resources.grd
 +++ b/chrome/app/generated_resources.grd
-@@ -13912,6 +13912,9 @@ Check your passwords anytime in <ph name
+@@ -13924,6 +13924,9 @@ Check your passwords anytime in <ph name
          <message name="IDS_EXTENSIONS_INSTALL_LOCATION_SHARED_MODULE" desc="The text explaining the the installation of the extension was because of extensions that depend on this shared module">
            Installed because of dependent extension(s).
          </message>

--- a/patches/series
+++ b/patches/series
@@ -192,6 +192,7 @@ helium/core/disable-side-panel-flyover.patch
 helium/core/custom-profile-avatar.patch
 helium/core/close-tabs-to-left.patch
 helium/core/custom-keyboard-shortcuts.patch
+helium/core/copy-url-tab-context-menu.patch
 
 helium/settings/settings-page-icons.patch
 helium/settings/move-search-suggest.patch


### PR DESCRIPTION
closes #166
closes #1817

https://github.com/user-attachments/assets/899d332a-89fc-4e0b-89bc-fcb372d76ba5

