### PR TITLE
deps: bump onboarding

### DIFF
--- a/deps.ini
+++ b/deps.ini
@@ -7,10 +7,10 @@ sha256 = 00a87050fa3f941d04d67fb5763991e0b8ea399a88b505ab0e56dd263f06864c
 output_path = ./third_party/search_engines_data/resources_internal
 
 [onboarding]
-version = 202605050730
+version = 202606092023
 url = https://github.com/imputnet/helium-onboarding/releases/download/%(version)s/helium-onboarding-%(version)s.tar.gz
 download_filename = onboarding-page-%(version)s.tar.gz
-sha256 = 18bcec95d753e76b71536dc5aa1c517663f38eb17d5bf6c3b36f7b76165c43ce
+sha256 = 1d0236128349cb39fdd14a8c64a69831865d5c48703dfb23d6e9f91322c3aa8f
 output_path = ./components/helium_onboarding
 
 # If you are bumping this, you *NEED* to re-strip the assets.json


### PR DESCRIPTION
the new version uses new autoupdate strings across all platforms (https://github.com/imputnet/helium-onboarding/pull/32)