### PR TITLE
helium/ui: improve tab group UI in all layouts

### DIFF
--- a/patches/helium/ui/layout/vertical.patch
+++ b/patches/helium/ui/layout/vertical.patch
@@ -1538,3 +1538,62 @@
    float expansion_factor_ = 1.0f;
    views::LayoutOrientation expansion_orientation_ =
        views::LayoutOrientation::kHorizontal;
+--- a/chrome/browser/ui/views/tabs/vertical/vertical_tab_group_view.cc
++++ b/chrome/browser/ui/views/tabs/vertical/vertical_tab_group_view.cc
+@@ -53,10 +53,10 @@
+ namespace {
+ constexpr int kTabVerticalPadding = 2;
+ constexpr int kGroupLineWidth = 2;
+-constexpr int kGroupLineCollapsedLeadingPadding = 6;
+-constexpr int kGroupLineCornerRadius = 4;
++constexpr int kGroupLineCollapsedLeadingPadding = 2;
++constexpr int kGroupLineCornerRadius = 2;
+ constexpr int kGroupHeaderHeight = 26;
+-constexpr int kGroupHeaderVerticalMargin = 4;
++constexpr int kGroupHeaderVerticalMargin = 3;
+ 
+ const TabGroup* GetTabGroupFromNode(TabCollectionNode* node) {
+   CHECK(node);
+@@ -164,8 +164,7 @@ views::ProposedLayout VerticalTabGroupVi
+   // aligned with the header.
+   if (tab_strip_collapse_state ==
+       tabs::VerticalTabStripCollapseState::kExpanded) {
+-    group_line_bounds.set_x(
+-        (VerticalTabGroupView::kTabLeadingPadding - kGroupLineWidth) / 2);
++    group_line_bounds.set_x(0);
+     group_line_bounds.set_y(height);
+   }
+ 
+@@ -363,8 +362,8 @@ void VerticalTabGroupView::OnDataChanged
+     SkColor color = GetColorProvider()->GetColor(GetTabGroupTabStripColorId(
+         tab_group_visual_data_.color(), GetWidget()->ShouldPaintAsActive()));
+     group_line_->SetBackground(views::CreateRoundedRectBackground(
+-        color, gfx::RoundedCornersF(0, kGroupLineCornerRadius,
+-                                    kGroupLineCornerRadius, 0)));
++        color, gfx::RoundedCornersF(kGroupLineCornerRadius, kGroupLineCornerRadius,
++                                    kGroupLineCornerRadius, kGroupLineCornerRadius)));
+   }
+   InvalidateLayout();
+ }
+--- a/chrome/browser/ui/views/tabs/vertical/vertical_tab_group_view.h
++++ b/chrome/browser/ui/views/tabs/vertical/vertical_tab_group_view.h
+@@ -34,7 +34,7 @@ class VerticalTabGroupView
+   METADATA_HEADER(VerticalTabGroupView, views::View)
+ 
+  public:
+-  static constexpr int kTabLeadingPadding = 10;
++  static constexpr int kTabLeadingPadding = 6;
+ 
+   explicit VerticalTabGroupView(TabCollectionNode* collection_node);
+   VerticalTabGroupView(const VerticalTabGroupView&) = delete;
+--- a/chrome/browser/ui/views/tabs/vertical/vertical_tab_group_header_view.cc
++++ b/chrome/browser/ui/views/tabs/vertical/vertical_tab_group_header_view.cc
+@@ -46,7 +46,7 @@
+ 
+ namespace {
+ constexpr int kGroupHeaderCornerRadius = 8;
+-constexpr int kGroupHeaderHorizontalInset = 8;
++constexpr int kGroupHeaderHorizontalInset = 7;
+ constexpr int kIconSize = 16;
+ constexpr int kFocusRingInset = 2;
+ constexpr int kAttentionIndicatorWidth = 8;

--- a/patches/helium/ui/tabs.patch
+++ b/patches/helium/ui/tabs.patch
@@ -609,3 +609,12 @@
  BASE_FEATURE(kWebuiRefresh2026, base::FEATURE_DISABLED_BY_DEFAULT);
  
  #if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_MAC) || BUILDFLAG(IS_LINUX)
+@@ -160,7 +160,7 @@ bool IsTabGroupMenuMoreEntryPointsEnable
+   return base::FeatureList::IsEnabled(kTabGroupMenuMoreEntryPoints);
+ }
+ 
+-BASE_FEATURE(kTabGroupHoverCards, base::FEATURE_DISABLED_BY_DEFAULT);
++BASE_FEATURE(kTabGroupHoverCards, base::FEATURE_ENABLED_BY_DEFAULT);
+ 
+ bool IsTabGroupHoverCardsEnabled() {
+   return base::FeatureList::IsEnabled(kTabGroupHoverCards);

--- a/patches/helium/ui/tabs.patch
+++ b/patches/helium/ui/tabs.patch
@@ -493,18 +493,6 @@
  
    return gfx::Insets::TLBR(0, left_inset, 0, right_inset);
  }
-@@ -116,10 +117,7 @@ gfx::Rect TabGroupUnderline::CalculateTa
-   gfx::Rect group_bounds = ToEnclosingRect(leading_bounds);
-   group_bounds.UnionEvenIfEmpty(ToEnclosingRect(trailing_bounds));
- 
--  int y = group_bounds.bottom() -
--          GetLayoutConstant(LayoutConstant::kTabstripToolbarOverlap);
--
--  return gfx::Rect(group_bounds.x(), y - kStrokeThickness, group_bounds.width(),
-+  return gfx::Rect(group_bounds.x(), 0, group_bounds.width(),
-                    kStrokeThickness);
- }
- 
 --- a/chrome/browser/ui/views/tabs/tab_group_underline.h
 +++ b/chrome/browser/ui/views/tabs/tab_group_underline.h
 @@ -25,8 +25,7 @@ class TabGroupUnderline : public views::
@@ -513,7 +501,7 @@
   public:
 -  static constexpr int kStrokeThickness =
 -      views::FocusRing::kDefaultHaloThickness;
-+  static constexpr int kStrokeThickness = 1;
++  static constexpr int kStrokeThickness = 2;
  
    static int GetStrokeInset();
  

--- a/patches/helium/ui/tabs.patch
+++ b/patches/helium/ui/tabs.patch
@@ -534,39 +534,6 @@
  }
  
  int TabGroupHeader::GetChipHeight() const {
-@@ -567,7 +571,11 @@ void TabGroupHeader::UpdateTitleView() {
-   title_->SetText(group_title_);
- 
-   if (!group_title_.empty()) {
--    title_->SetEnabledColor(color_utils::GetColorWithMaxContrast(color_));
-+    const SkColor text_color = GetColorProvider()->GetColor(
-+        GetSavedTabGroupForegroundColorId(
-+          tab_slot_controller_->GetGroupColorId(group().value())));
-+
-+    title_->SetEnabledColor(text_color);
-   }
- }
- 
-@@ -705,8 +713,18 @@ void TabGroupHeader::CreateHeaderWithTit
-   const int corner_radius = group_style_->GetChipCornerRadius();
-   title_chip_->SetBounds(named_origin.x(), chip_y, title_chip_width,
-                          chip_height);
-+  const tab_groups::TabGroupColorId group_color_id =
-+      tab_slot_controller_->GetGroupColorId(group().value());
-+
-+  const SkColor background_color =
-+      GetColorProvider()->GetColor(GetTabGroupBookmarkColorId(group_color_id));
-+  const SkColor stroke_color =
-+      GetColorProvider()->GetColor(GetSavedTabGroupOutlineColorId(group_color_id));
-+
-   title_chip_->SetBackground(
--      views::CreateRoundedRectBackground(color_, corner_radius));
-+      views::CreateRoundedRectBackground(background_color, corner_radius));
-+  title_chip_->SetBorder(views::CreateRoundedRectBorder(
-+      kTabGroupStrokeThickness, corner_radius, stroke_color));
- 
-   // Set the bounds of the sync icon first, followed by the title.
-   const int start_of_sync_icon = title_chip_insets.left();
 --- a/media/base/media_switches.cc
 +++ b/media/base/media_switches.cc
 @@ -379,7 +379,7 @@ BASE_FEATURE(kExtendedVideoBitstreamVali
@@ -631,3 +598,14 @@
  }
  
  gfx::ImageSkia AlertIndicatorButton::GetImageToPaint() {
+--- a/chrome/browser/ui/ui_features.cc
++++ b/chrome/browser/ui/ui_features.cc
+@@ -39,7 +39,7 @@ BASE_FEATURE(kTabStripDeclutter, base::F
+ BASE_FEATURE(kToolbarGlowUp, base::FEATURE_DISABLED_BY_DEFAULT);
+ BASE_FEATURE(kRoundedIcons, base::FEATURE_DISABLED_BY_DEFAULT);
+ BASE_FEATURE(kMenuSimplification, base::FEATURE_DISABLED_BY_DEFAULT);
+-BASE_FEATURE(kTabGroupColorRefresh, base::FEATURE_DISABLED_BY_DEFAULT);
++BASE_FEATURE(kTabGroupColorRefresh, base::FEATURE_ENABLED_BY_DEFAULT);
+ BASE_FEATURE(kWebuiRefresh2026, base::FEATURE_DISABLED_BY_DEFAULT);
+ 
+ #if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_MAC) || BUILDFLAG(IS_LINUX)


### PR DESCRIPTION
- moved horiz tab group underline to bottom, made it thick:
<img width="1356" height="141" alt="image" src="https://github.com/user-attachments/assets/7a1ce7a1-b2ec-4823-97fb-3482d8c37109" />
<img width="1371" height="102" alt="image" src="https://github.com/user-attachments/assets/accf0ea1-d97b-4fff-b134-5a593c6251f7" />


- restored solid group header colors in the horizontal layout, enabled new tab group colors:
<img width="160" height="60" alt="image" src="https://github.com/user-attachments/assets/41405c60-9224-4e3f-8e25-a6bfd261fd35" />


- fixed tab group appearance in vertical layout, including the collapsed state:
<img width="238" height="193" alt="image" src="https://github.com/user-attachments/assets/e36d7dde-5db8-413c-8c3e-049068ecc35e" />
<img width="80" height="189" alt="image" src="https://github.com/user-attachments/assets/4c4bb894-4421-4be3-a37d-3658c3486ba8" />


- enabled tab group hover cards:
<img width="437" height="144" alt="image" src="https://github.com/user-attachments/assets/69046301-15d4-4e3c-8b33-a5dd2f18cb1e" />


fixes #890
fixes #1910
fixes #1802
closes #1179
fixes #1034