### PR TITLE
helium/ui/tabs: fix new tab button hover/press colors

### DIFF
--- a/patches/helium/ui/layout/vertical.patch
+++ b/patches/helium/ui/layout/vertical.patch
@@ -1446,8 +1446,8 @@
 +    return foreground_color_id_.value();
 +  }
    return GetWidget() && GetWidget()->ShouldPaintAsActive()
-              ? kColorTabSearchButtonCRForegroundFrameActive
-              : kColorTabSearchButtonCRForegroundFrameInactive;
+              ? kColorNewTabButtonCRForegroundFrameActive
+              : kColorNewTabButtonCRForegroundFrameInactive;
 @@ -271,26 +304,26 @@ ui::ColorId TabStripFlatEdgeButton::GetB
  
  gfx::RoundedCornersF TabStripFlatEdgeButton::GetButtonCornerRadii() const {

--- a/patches/helium/ui/tabs.patch
+++ b/patches/helium/ui/tabs.patch
@@ -618,3 +618,58 @@
  
  bool IsTabGroupHoverCardsEnabled() {
    return base::FeatureList::IsEnabled(kTabGroupHoverCards);
+--- a/chrome/browser/ui/views/tabs/shared/tab_strip_flat_edge_button.cc
++++ b/chrome/browser/ui/views/tabs/shared/tab_strip_flat_edge_button.cc
+@@ -72,8 +72,8 @@ TabStripFlatEdgeButton::TabStripFlatEdge
+       this, std::make_unique<views::RoundRectHighlightPathGenerator>(
+                 gfx::Insets(), GetButtonCornerRadii()));
+   ConfigureToolbarInkdropForRefresh2023(
+-      this, kColorTabStripControlButtonInkDrop,
+-      kColorTabStripControlButtonInkDropRipple);
++      this, kColorTabBackgroundInactiveHoverFrameActive,
++      kColorTabBackgroundActiveFrameActive);
+   SetIconSize(
+       GetLayoutConstant(LayoutConstant::kVerticalTabStripComboButtonIconSize));
+   SetImageLabelSpacing(kButtonWithLabelPadding);
+@@ -259,14 +259,14 @@ void TabStripFlatEdgeButton::RemovedFrom
+ 
+ ui::ColorId TabStripFlatEdgeButton::GetForegroundColor() const {
+   return GetWidget() && GetWidget()->ShouldPaintAsActive()
+-             ? kColorTabSearchButtonCRForegroundFrameActive
+-             : kColorTabSearchButtonCRForegroundFrameInactive;
++             ? kColorNewTabButtonCRForegroundFrameActive
++             : kColorNewTabButtonCRForegroundFrameInactive;
+ }
+ 
+ ui::ColorId TabStripFlatEdgeButton::GetBackgroundColor() const {
+   return GetWidget() && GetWidget()->ShouldPaintAsActive()
+-             ? kColorNewTabButtonCRBackgroundFrameActive
+-             : kColorNewTabButtonCRBackgroundFrameInactive;
++             ? kColorTabBackgroundInactiveFrameActive
++             : kColorTabBackgroundInactiveFrameInactive;
+ }
+ 
+ gfx::RoundedCornersF TabStripFlatEdgeButton::GetButtonCornerRadii() const {
+--- a/chrome/browser/ui/views/tabs/tab_strip_control_button.cc
++++ b/chrome/browser/ui/views/tabs/tab_strip_control_button.cc
+@@ -104,15 +104,15 @@ TabStripControlButton::TabStripControlBu
+   SetImageCentered(true);
+   SetEventTargeter(std::make_unique<views::ViewTargeter>(this));
+ 
+-  foreground_frame_active_color_id_ = kColorTabForegroundInactiveFrameActive;
++  foreground_frame_active_color_id_ = kColorNewTabButtonCRForegroundFrameActive;
+   foreground_frame_inactive_color_id_ =
+       kColorNewTabButtonCRForegroundFrameInactive;
+-  background_frame_active_color_id_ = kColorNewTabButtonBackgroundFrameActive;
++  background_frame_active_color_id_ = kColorTabBackgroundInactiveFrameActive;
+   background_frame_inactive_color_id_ =
+-      kColorNewTabButtonBackgroundFrameInactive;
++      kColorTabBackgroundInactiveFrameInactive;
+ 
+-  inkdrop_hover_color_id_ = kColorTabStripControlButtonInkDrop;
+-  inkdrop_ripple_color_id_ = kColorTabStripControlButtonInkDropRipple;
++  inkdrop_hover_color_id_ = kColorTabBackgroundInactiveHoverFrameActive;
++  inkdrop_ripple_color_id_ = kColorTabBackgroundActiveFrameActive;
+ 
+   UpdateIcon();
+   SetHorizontalAlignment(gfx::ALIGN_CENTER);


### PR DESCRIPTION
the new tab buttons no longer stand out and have the same hover color as the tabs next to them

before:

https://github.com/user-attachments/assets/3bf7428a-9330-4d29-82f7-dd309e4bd252

https://github.com/user-attachments/assets/23578299-df37-46c0-b11e-6ada4918c802


after:

https://github.com/user-attachments/assets/a770f555-9a85-43eb-b013-8f98e2dbb278

https://github.com/user-attachments/assets/6daaa7f6-1194-432d-9ece-234fb7ebad64


