### PR TITLE
helium/ui/tabs: fix horizontal tab hover background color

### DIFF
--- a/patches/helium/ui/tabs.patch
+++ b/patches/helium/ui/tabs.patch
@@ -207,6 +207,18 @@
  
    PaintBackgroundStroke(canvas, selection_state,
                          group_color.value_or(tab_stroke_color));
+@@ -992,11 +928,6 @@ void TabStyleViewsImpl::PaintTabBackgrou
+         BrowserView::GetBrowserViewForBrowser(tab_->controller()->GetBrowser()),
+         image);
+   }
+-
+-  if (hovered &&
+-      (!features::IsGlassFrameEnabled() || GetHoverAnimationValue() > 0.0)) {
+-    PaintBackgroundHover(canvas, scale);
+-  }
+ }
+ 
+ void TabStyleViewsImpl::PaintBackgroundHover(gfx::Canvas* canvas,
 --- a/chrome/browser/ui/views/tabs/tab.cc
 +++ b/chrome/browser/ui/views/tabs/tab.cc
 @@ -134,10 +134,7 @@ namespace {


### PR DESCRIPTION
the hover background was drawn twice, which is not how it's handled in vertical tabs. now both tab types have the same hover bg color.

horizontal (before):
<img width="687" height="86" alt="image" src="https://github.com/user-attachments/assets/4876f92f-4f8d-467b-84fb-2e545ffe8482" />

horizontal (after):
<img width="639" height="72" alt="image" src="https://github.com/user-attachments/assets/72da93bf-5a62-449b-9529-112dec1fdd5a" />


vertical (for reference):
<img width="235" height="193" alt="image" src="https://github.com/user-attachments/assets/4c943d0e-d4b8-4d35-813e-b406429b2d81" />


fixes (?) #1850

