### PR TITLE
helium/ui/vertical: fix new tab button alignment and icon size

### DIFF
--- a/patches/helium/ui/layout/vertical.patch
+++ b/patches/helium/ui/layout/vertical.patch
@@ -744,7 +744,7 @@
      "vertical_tab_drag_handler.cc",
 --- /dev/null
 +++ b/chrome/browser/ui/views/tabs/vertical/vertical_new_tab_button.cc
-@@ -0,0 +1,40 @@
+@@ -0,0 +1,41 @@
 +// Copyright 2026 The Helium Authors
 +// You can use, redistribute, and/or modify this source code under
 +// the terms of the GPL-3.0 license that can be found in the LICENSE file.
@@ -759,8 +759,9 @@
 +
 +namespace {
 +
-+constexpr int kIconSize = 15;
++constexpr int kIconSize = 16;
 +constexpr int kBasePadding = 4;
++constexpr int kBigPadding = kBasePadding * 2 - 1;
 +
 +}  // namespace
 +
@@ -772,9 +773,9 @@
 +  SetCornerRadius(GetLayoutConstant(LayoutConstant::kVerticalTabCornerRadius));
 +  SetForegroundColorId(kColorToolbarButtonIconDisabled);
 +  SetHorizontalAlignment(gfx::HorizontalAlignment::ALIGN_LEFT);
-+  SetLabelInsets(gfx::Insets::VH(kBasePadding, kBasePadding * 2 - 1),
-+                 gfx::Insets::VH(kBasePadding, kBasePadding * 2 - 1));
-+  SetImageLabelSpacing(kBasePadding * 2);
++  SetLabelInsets(gfx::Insets::VH(kBasePadding, kBigPadding),
++                 gfx::Insets::VH(kBasePadding, kBigPadding));
++  SetImageLabelSpacing(kBigPadding);
 +  SetShouldShowLabel(true);
 +  SetLabelText(l10n_util::GetStringUTF16(IDS_ACCNAME_NEWTAB));
 +  SetPreferredSize(


### PR DESCRIPTION
before & after:

<img width="661" height="849" alt="image" src="https://github.com/user-attachments/assets/56c1482b-2b19-472c-be46-469560b9f1ed" />