### PR TITLE
helium/core: disable pdf infobar feature

### DIFF
--- a/patches/helium/core/disable-pdf-infobar.patch
+++ b/patches/helium/core/disable-pdf-infobar.patch
@@ -1,0 +1,11 @@
+--- a/chrome/browser/ui/ui_features.cc
++++ b/chrome/browser/ui/ui_features.cc
+@@ -60,7 +60,7 @@ BASE_FEATURE(kInfobarRefresh, base::FEAT
+ #if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_MAC)
+ // Shows an infobar on PDFs offering to become the default PDF viewer if Chrome
+ // isn't the default already.
+-BASE_FEATURE(kPdfInfoBar, base::FEATURE_ENABLED_BY_DEFAULT);
++BASE_FEATURE(kPdfInfoBar, base::FEATURE_DISABLED_BY_DEFAULT);
+ 
+ BASE_FEATURE(kSeparateDefaultAndPinPrompt, base::FEATURE_DISABLED_BY_DEFAULT);
+ BASE_FEATURE_PARAM(int,

--- a/patches/series
+++ b/patches/series
@@ -194,6 +194,7 @@ helium/core/close-tabs-to-left.patch
 helium/core/custom-keyboard-shortcuts.patch
 helium/core/copy-url-tab-context-menu.patch
 helium/core/simplify-context-menu.patch
+helium/core/disable-pdf-infobar.patch
 
 helium/settings/settings-page-icons.patch
 helium/settings/move-search-suggest.patch


### PR DESCRIPTION
helium will no longer nag users about setting it as default pdf viewer