### PR TITLE
helium/core: enable the chromium screenshot feature

### DIFF
--- a/patches/helium/core/enable-screenshots.patch
+++ b/patches/helium/core/enable-screenshots.patch
@@ -1,0 +1,27 @@
+--- a/chrome/browser/sharing_hub/sharing_hub_features.cc
++++ b/chrome/browser/sharing_hub/sharing_hub_features.cc
+@@ -66,7 +66,7 @@ bool HasPageAction(content::BrowserConte
+ #endif
+ }
+ 
+-BASE_FEATURE(kDesktopScreenshots, base::FEATURE_DISABLED_BY_DEFAULT);
++BASE_FEATURE(kDesktopScreenshots, base::FEATURE_ENABLED_BY_DEFAULT);
+ 
+ #if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_CHROMEOS)
+ void RegisterProfilePrefs(PrefRegistrySimple* registry) {
+--- a/chrome/browser/ui/views/sharing_hub/screenshot/screenshot_captured_bubble.cc
++++ b/chrome/browser/ui/views/sharing_hub/screenshot/screenshot_captured_bubble.cc
+@@ -169,11 +169,11 @@ void ScreenshotCapturedBubble::Init() {
+ const std::u16string ScreenshotCapturedBubble::GetFilenameForURL(
+     const GURL& url) {
+   if (!url.has_host() || url.HostIsIPAddress()) {
+-    return u"chrome_screenshot.png";
++    return u"helium_screenshot.png";
+   }
+ 
+   return base::ASCIIToUTF16(
+-      base::StrCat({"chrome_screenshot_", url.GetHost(), ".png"}));
++      base::StrCat({"helium_screenshot_", url.GetHost(), ".png"}));
+ }
+ 
+ void ScreenshotCapturedBubble::DownloadButtonPressed() {

--- a/patches/series
+++ b/patches/series
@@ -195,6 +195,7 @@ helium/core/custom-keyboard-shortcuts.patch
 helium/core/copy-url-tab-context-menu.patch
 helium/core/simplify-context-menu.patch
 helium/core/disable-pdf-infobar.patch
+helium/core/enable-screenshots.patch
 
 helium/settings/settings-page-icons.patch
 helium/settings/move-search-suggest.patch


### PR DESCRIPTION
i don't really see its purpose, but we already compile it, and it works fine, so why not enable it by default

https://github.com/user-attachments/assets/1aaf399f-ee38-4881-b071-d7b91000bd4c

closes (?) #206 