### PR TITLE
Enable autoplay blocking setting

### DIFF
--- a/i18n/source.gen.json
+++ b/i18n/source.gen.json
@@ -198,6 +198,12 @@
     "message": "Behavior"
   },
   {
+    "name": "IDS_SETTINGS_SITE_SETTINGS_BLOCK_AUTOPLAY",
+    "source": "chrome/app/settings_strings.grdp",
+    "context": "A label for a toggle in site settings to block autoplay. If the toggle is on then Helium will block autoplay by default and use an algorithm to determine which sites should still be able to autoplay. If the toggle is off then autoplay will be enabled for all sites.",
+    "message": "Block audio and video autoplay by default"
+  },
+  {
     "name": "IDS_SETTINGS_ACCESSIBILITY_COPY_PAGE_URL_SHORTCUT",
     "source": "chrome/app/settings_strings.grdp",
     "context": "Toggle in settings that allows you to enable the keyboard shortcut that copies the current page URL to the clipboard. It's enabled by default.",

--- a/patches/helium/settings/autoplay-site-setting.patch
+++ b/patches/helium/settings/autoplay-site-setting.patch
@@ -1,0 +1,22 @@
+--- a/media/base/media_switches.cc
++++ b/media/base/media_switches.cc
+@@ -1062,7 +1062,7 @@ BASE_FEATURE(kAutoplayBypassForMicCamera
+ // When enabled, the unified autoplay settings that are configurable via
+ // content settings are used.
+ BASE_FEATURE(kAutoplayDisableSettings,
+-             base::FEATURE_DISABLED_BY_DEFAULT);
++             base::FEATURE_ENABLED_BY_DEFAULT);
+ 
+ // Enables use of the Audio Focus Session Group.
+ BASE_FEATURE(kAudioFocusSessionGroup,
+--- a/chrome/app/settings_strings.grdp
++++ b/chrome/app/settings_strings.grdp
+@@ -3654,7 +3654,7 @@
+       No sites added
+     </message>
+     <message name="IDS_SETTINGS_SITE_SETTINGS_BLOCK_AUTOPLAY" desc="A label for a toggle in site settings to block autoplay. If the toggle is on then Chrome will block autoplay by default and use an algorithm to determine which sites should still be able to autoplay. If the toggle is off then autoplay will be enabled for all sites.">
+-      Let Chrome choose when sites can play sound (recommended)
++      Block audio and video autoplay by default
+     </message>
+     <message name="IDS_SETTINGS_SITE_SETTINGS_EMPTY_ALL_SITES_PAGE" desc="Explanation shown when there are no sites that have appeared yet on the All Sites page.">
+       Sites you visit will appear here

--- a/patches/series
+++ b/patches/series
@@ -123,6 +123,7 @@ helium/core/search/omnibox-default-search-icon.patch
 helium/core/search/add-kagi-image-search.patch
 
 helium/settings/setup-behavior-settings-page.patch
+helium/settings/autoplay-site-setting.patch
 helium/core/keyboard-shortcuts.patch
 helium/core/update-default-browser-prefs.patch
 helium/core/add-default-browser-reject-button.patch


### PR DESCRIPTION
## Summary
- enable Chromium's unified autoplay settings feature in Helium
- expose the existing Sound settings autoplay toggle by default
- rename the toggle to "Block audio and video autoplay by default" so the control is discoverable
- update the generated i18n source list for the changed setting label

## Notes
Chromium's current unified autoplay implementation uses the Sound content setting and its exceptions as the per-site override path. This PR keeps that existing behavior rather than introducing a separate, currently unenforced AUTOPLAY settings page.

Fixes #124.

## Validation
- python3 devutils/check_patch_files.py
- python3 devutils/i18n_lint.py
- git diff --check
- parsed the new patch with devutils.third_party.unidiff

A full Chromium/Helium build was not run in this lightweight checkout.