### PR TITLE
helium/core: enable bookmark bar visibility options

### DIFF
--- a/patches/helium/core/enable-bookmark-bar-settings.patch
+++ b/patches/helium/core/enable-bookmark-bar-settings.patch
@@ -1,0 +1,11 @@
+--- a/components/search/ntp_features.cc
++++ b/components/search/ntp_features.cc
+@@ -285,7 +285,7 @@ BASE_FEATURE(kNtpShortcutsRedesign, base
+ 
+ // If enabled, the bookmark bar may be auto-removed on the NTP and new
+ // visibility settings are added.
+-BASE_FEATURE(kNtpSimplificationBookmarkBar, base::FEATURE_DISABLED_BY_DEFAULT);
++BASE_FEATURE(kNtpSimplificationBookmarkBar, base::FEATURE_ENABLED_BY_DEFAULT);
+ 
+ // If enabled, the bookmark bar time interval and number of times it's shown on
+ // the NTP before auto-hiding is decreased for testing.

--- a/patches/series
+++ b/patches/series
@@ -195,6 +195,7 @@ helium/core/simplify-context-menu.patch
 helium/core/disable-pdf-infobar.patch
 helium/core/enable-screenshots.patch
 helium/core/enable-glow-up-features.patch
+helium/core/enable-bookmark-bar-settings.patch
 
 helium/settings/settings-page-icons.patch
 helium/settings/move-search-suggest.patch


### PR DESCRIPTION
enables kNtpSimplificationBookmarkBar, which includes proper visibility options for the bookmark bar

closes #1349 (for real this time)

