### PR TITLE
helium/ui/vertical: fix incorrect tab alert indicator position

### DIFF
--- a/patches/helium/ui/layout/vertical.patch
+++ b/patches/helium/ui/layout/vertical.patch
@@ -676,7 +676,7 @@
                       /*align_leading=*/true,
                       /*expand=*/false),
 +      TabChildConfig(alert_indicator_, kIconDesignWidth, kDefaultPadding,
-+                     /*align_leading=*/false,
++                     /*align_leading=*/true,
 +                     /*expand=*/false, /*decorate_on_collapse=*/true),
        TabChildConfig(title_, kTitleMinWidth, kDefaultPadding,
                       /*align_leading=*/true,


### PR DESCRIPTION
fixes #1994

before:
<img width="210" height="47" alt="image" src="https://github.com/user-attachments/assets/466f9200-9a9e-4545-9b46-826a2f34b8c8" />

after:
<img width="216" height="52" alt="image" src="https://github.com/user-attachments/assets/e90a84fa-1aa4-48a7-bf04-4f862115792c" />
