### PR TITLE
helium/ui/cab: invalidate toolbar layout on window state change

### DIFF
--- a/patches/helium/ui/layout/centered-address-bar.patch
+++ b/patches/helium/ui/layout/centered-address-bar.patch
@@ -252,3 +252,16 @@
          </div>
  
          <div
+--- a/chrome/browser/ui/views/frame/browser_view.cc
++++ b/chrome/browser/ui/views/frame/browser_view.cc
+@@ -2916,6 +2916,10 @@ void BrowserView::NotifyWidgetSizeConstr
+ }
+ 
+ void BrowserView::OnWidgetShowStateChanged(views::Widget* widget) {
++  if (toolbar_) {
++    toolbar_->InvalidateLayout();
++  }
++
+   // `display-state` @media feature value in renderer needs to be updated.
+   SynchronizeRenderWidgetHostVisualPropertiesForMainFrame();
+ }

--- a/patches/helium/ui/layout/compact.patch
+++ b/patches/helium/ui/layout/compact.patch
@@ -142,7 +142,7 @@
  void BrowserView::OnProjectsPanelStateChanged(
      ProjectsPanelStateController* controller) {
    projects_panel_container_->OnProjectsPanelStateChanged(controller);
-@@ -3831,9 +3862,10 @@ void BrowserView::ReparentTabStripAndWeb
+@@ -3835,9 +3866,10 @@ void BrowserView::ReparentTabStripAndWeb
    // The TabStrip must be placed in the same position before the reparenting
    // to maintain the correct Z-order to ensure it can receive mouse events.
    // See crbug.com/454852658.
@@ -156,7 +156,7 @@
  
    // Reparent PWA views that were moved for immersive and ChromeOS tablet
    // mode.
-@@ -4979,6 +5011,16 @@ void BrowserView::AddedToWidget() {
+@@ -4983,6 +5015,16 @@ void BrowserView::AddedToWidget() {
      }
    }
  

--- a/patches/helium/ui/layout/vertical.patch
+++ b/patches/helium/ui/layout/vertical.patch
@@ -1049,7 +1049,7 @@
      horizontal_tab_strip_region_view_->ResetTabStrip();
      vertical_tab_strip_region_view_->InitializeTabStrip();
    } else {
-@@ -4230,13 +4229,23 @@ const views::Widget* BrowserView::GetWid
+@@ -4234,13 +4233,23 @@ const views::Widget* BrowserView::GetWid
  }
  
  void BrowserView::CreateTabSearchBubble() {
@@ -1075,7 +1075,7 @@
      tab_search_host->CloseTabSearchBubble();
    }
  }
-@@ -4276,34 +4285,21 @@ void BrowserView::UpdateTabSearchBubbleH
+@@ -4280,34 +4289,21 @@ void BrowserView::UpdateTabSearchBubbleH
      return;
    }
  
@@ -1125,7 +1125,7 @@
    }
  }
  
-@@ -5084,9 +5080,6 @@ void BrowserView::AddedToWidget() {
+@@ -5088,9 +5084,6 @@ void BrowserView::AddedToWidget() {
    layout_views.horizontal_tab_strip_region_view =
        horizontal_tab_strip_region_view_;
    layout_views.vertical_tab_strip_region_view = vertical_tab_strip_region_view_;

--- a/patches/helium/ui/layout/zen-mode.patch
+++ b/patches/helium/ui/layout/zen-mode.patch
@@ -608,7 +608,7 @@
    LocationBar* location_bar = GetLocationBar();
    location_bar->FocusLocation(is_user_initiated,
                                /*clear_focus_if_failed=*/true);
-@@ -3079,7 +3590,7 @@ bool BrowserView::IsToolbarVisible() con
+@@ -3083,7 +3594,7 @@ bool BrowserView::IsToolbarVisible() con
  }
  
  bool BrowserView::IsToolbarShowing() const {
@@ -617,7 +617,7 @@
  }
  
  bool BrowserView::IsLocationBarVisible() const {
-@@ -4167,6 +4678,11 @@ void BrowserView::OnWidgetActivationChan
+@@ -4171,6 +4682,11 @@ void BrowserView::OnWidgetActivationChan
      }
    }
  
@@ -629,7 +629,7 @@
    browser_->GetFeatures()
        .extension_keybinding_registry()
        ->OnHostActivationChanged(active);
-@@ -5015,6 +5531,8 @@ void BrowserView::AddedToWidget() {
+@@ -5019,6 +5535,8 @@ void BrowserView::AddedToWidget() {
              base::BindRepeating(&BrowserView::OnToolbarTabStripStateChanged,
                                  base::Unretained(this)));
      OnToolbarTabStripStateChanged(helium_layout_controller);
@@ -638,7 +638,7 @@
    }
  
    UpdateTabSearchBubbleHost();
-@@ -5099,6 +5617,9 @@ void BrowserView::AddedToWidget() {
+@@ -5103,6 +5621,9 @@ void BrowserView::AddedToWidget() {
    // once per browser instance.
    auto* toolbar_button_provider = ToolbarButtonProvider::From(browser_);
    CHECK(toolbar_button_provider);
@@ -648,7 +648,7 @@
  
    // `AutofillBubbleHandlerImpl` depends on the ToolbarButtonProvider so it must
    // be constructed following the check above.
-@@ -5155,6 +5676,8 @@ void BrowserView::AddedToWidget() {
+@@ -5159,6 +5680,8 @@ void BrowserView::AddedToWidget() {
  }
  
  void BrowserView::RemovedFromWidget() {
@@ -657,7 +657,7 @@
    CHECK(GetFocusManager());
    focus_manager_observation_.Reset();
  }
-@@ -5183,6 +5706,14 @@ void BrowserView::OnThemeChanged() {
+@@ -5187,6 +5710,14 @@ void BrowserView::OnThemeChanged() {
    }
  
    FrameColorsChanged();
@@ -672,7 +672,7 @@
  }
  
  bool BrowserView::GetDropFormats(
-@@ -5446,6 +5977,9 @@ void BrowserView::UpdateFastResizeForCon
+@@ -5450,6 +5981,9 @@ void BrowserView::UpdateFastResizeForCon
  }
  
  int BrowserView::GetClientAreaTop() {
@@ -682,7 +682,7 @@
    views::View* top_view = toolbar_;
  
    // Get the top of the top view in browser view coordinates.
-@@ -6057,6 +6591,56 @@ void BrowserView::OnWillChangeFocus(View
+@@ -6061,6 +6595,56 @@ void BrowserView::OnWillChangeFocus(View
  }
  void BrowserView::OnDidChangeFocus(View* focused_before, View* focused_now) {
    UpdateAccessibleNameForRootView();


### PR DESCRIPTION
fixes the stale alignment issue on Windows by invalidating toolbar layout after maximize/restore so the centered address bar recomputes against the new frame width

fixes #1958