### PR TITLE
helium/ui/separators: remove rounded corner on attached side

### DIFF
--- a/patches/helium/ui/fix-layout-separators.patch
+++ b/patches/helium/ui/fix-layout-separators.patch
@@ -1,164 +1,47 @@
---- a/chrome/browser/ui/views/frame/custom_floating_corner.cc
-+++ b/chrome/browser/ui/views/frame/custom_floating_corner.cc
-@@ -9,8 +9,8 @@
- 
- #include "base/i18n/rtl.h"
- #include "chrome/browser/ui/color/chrome_color_provider_utils.h"
--#include "chrome/browser/ui/layout_constants.h"
- #include "chrome/browser/ui/views/frame/browser_view.h"
-+#include "chrome/browser/ui/views/helium/frame_corner_radius.h"
- #include "third_party/skia/include/core/SkPathBuilder.h"
- #include "ui/base/metadata/metadata_impl_macros.h"
- #include "ui/base/ui_base_features.h"
-@@ -19,7 +19,6 @@
- #include "ui/gfx/color_utils.h"
- #include "ui/gfx/scoped_canvas.h"
- #include "ui/views/controls/separator.h"
--#include "ui/views/layout/layout_provider.h"
- 
- namespace {
- 
-@@ -48,13 +47,11 @@ CustomFloatingCorner::CornerOrientation
- CustomFloatingCorner::CustomFloatingCorner(
-     BrowserView& browser_view,
-     CornerOrientation orientation,
--    views::ShapeContextTokens corner_radius_token,
-     ColorChoice color,
-     std::optional<ui::ColorId> stroke_color,
-     bool is_vertical_window_edge)
-     : CustomCorners(browser_view),
-       orientation_(orientation),
--      corner_radius_token_(corner_radius_token),
-       color_(color),
-       stroke_color_(stroke_color),
-       is_vertical_window_edge_(is_vertical_window_edge) {
-@@ -82,16 +79,6 @@ void CustomFloatingCorner::SetOrientatio
-   SchedulePaint();
- }
- 
--void CustomFloatingCorner::SetCornerRadius(
--    views::ShapeContextTokens corner_radius_token) {
--  if (corner_radius_token == corner_radius_token_) {
--    return;
--  }
--
--  corner_radius_token_ = corner_radius_token;
--  PreferredSizeChanged();
--}
--
- void CustomFloatingCorner::SetStroke(std::optional<ui::ColorId> stroke_color,
-                                      bool is_vertical_window_edge) {
-   if (stroke_color_ == stroke_color &&
-@@ -114,19 +101,8 @@ void CustomFloatingCorner::SetStroke(std
- 
- gfx::Size CustomFloatingCorner::CalculatePreferredSize(
-     const views::SizeBounds& available_size) const {
--  // This can return nullptr when there is no Widget (for context, see
--  // http://crbug.com/40178332). The nullptr dereference does not always
--  // crash due to compiler optimizations, so CHECKing here ensures we crash.
--  CHECK(GetLayoutProvider());
--  const float corner_radius =
--      GetLayoutProvider()->GetCornerRadiusMetric(corner_radius_token_);
--  const float horizontal_size =
--      corner_radius + (stroke_color_ ? views::Separator::kThickness : 0);
--  const float vertical_size =
--      corner_radius + (stroke_color_ && !is_vertical_window_edge_
--                           ? views::Separator::kThickness
--                           : 0);
--  return gfx::Size(horizontal_size, vertical_size);
-+  const int corner_radius = GetGenericFrameRadius();
-+  return gfx::Size(corner_radius, corner_radius);
- }
- 
- void CustomFloatingCorner::OnPaint(gfx::Canvas* canvas) {
-@@ -136,9 +112,8 @@ void CustomFloatingCorner::OnPaint(gfx::
-   gfx::ScopedCanvas scoped(canvas);
- 
-   // This assumes that the view has gotten its preferred size, however, it will
--  // scale gracefully if it is not that size. The view should be the preferred
--  // corner radius in each dimension, plus the stroke thickness if there is a
--  // stroke.
-+  // scale gracefully if it is not that size. The view is the outer corner
-+  // radius; the stroked arc is inset by the separator thickness.
-   const bool has_stroke = stroke_color_.has_value();
-   const bool extend_vertical = has_stroke && !is_vertical_window_edge_;
-   const SkVector corner_radius(
---- a/chrome/browser/ui/views/frame/custom_floating_corner.h
-+++ b/chrome/browser/ui/views/frame/custom_floating_corner.h
-@@ -16,7 +16,6 @@
- #include "ui/base/metadata/metadata_header_macros.h"
- #include "ui/color/color_id.h"
- #include "ui/views/background.h"
--#include "ui/views/layout/layout_provider.h"
- #include "ui/views/layout/layout_types.h"
- #include "ui/views/view.h"
- 
-@@ -39,7 +38,6 @@ class CustomFloatingCorner : public view
- 
-   CustomFloatingCorner(BrowserView& browser_view,
-                        CornerOrientation orientation,
--                       views::ShapeContextTokens corner_radius_token,
-                        ColorChoice color,
-                        std::optional<ui::ColorId> stroke_color = std::nullopt,
-                        bool is_vertical_window_edge = false);
-@@ -51,9 +49,6 @@ class CustomFloatingCorner : public view
-   // Sets the corner orientation.
-   void SetOrientation(CornerOrientation orientation);
- 
--  // Set the corner radius.
--  void SetCornerRadius(views::ShapeContextTokens corner_radius_token);
--
-   // Sets a stroke, or no stroke (std::nullopt). If `is_vertical_window_edge` is
-   // true, the stroke ends outside the vertical bounds of the corner.
-   void SetStroke(std::optional<ui::ColorId> stroke_color,
-@@ -74,7 +69,6 @@ class CustomFloatingCorner : public view
-   void SchedulePaintHost() override;
- 
-   CornerOrientation orientation_;
--  views::ShapeContextTokens corner_radius_token_;
-   ColorChoice color_;
-   std::optional<ui::ColorId> stroke_color_;
-   bool is_vertical_window_edge_ = false;
 --- a/chrome/browser/ui/views/frame/multi_contents_view.cc
 +++ b/chrome/browser/ui/views/frame/multi_contents_view.cc
-@@ -63,6 +63,7 @@ void MultiContentsView::ContentsSeparato
+@@ -23,7 +23,6 @@
+ #include "chrome/browser/ui/views/frame/contents_container_view.h"
+ #include "chrome/browser/ui/views/frame/contents_separator.h"
+ #include "chrome/browser/ui/views/frame/contents_web_view.h"
+-#include "chrome/browser/ui/views/frame/custom_floating_corner.h"
+ #include "chrome/browser/ui/views/frame/multi_contents_background_view.h"
+ #include "chrome/browser/ui/views/frame/multi_contents_drop_target_view.h"
+ #include "chrome/browser/ui/views/frame/multi_contents_resize_area.h"
+@@ -62,7 +61,6 @@ void MultiContentsView::ContentsSeparato
+   top_separator = nullptr;
    leading_separator = nullptr;
    trailing_separator = nullptr;
-   corner_separator = nullptr;
-+  trailing_corner_separator = nullptr;
+-  corner_separator = nullptr;
    leading_side_chrome_attached = false;
    trailing_side_chrome_attached = false;
  }
-@@ -120,12 +121,17 @@ MultiContentsView::MultiContentsView(
-   contents_separators_.corner_separator =
-       AddChildView(std::make_unique<CustomFloatingCorner>(
-           *browser_view_, CustomFloatingCorner::CornerOrientation::kTopLeading,
--          views::ShapeContextTokens::kContentSeparatorRadius,
-           CustomFloatingCorner::ToolbarTheme(),
-           kColorToolbarContentAreaSeparator));
-   contents_separators_.corner_separator->SetProperty(
-       views::kElementIdentifierKey, kContentsSeparatorTopCornerElementId);
+@@ -117,15 +115,6 @@ MultiContentsView::MultiContentsView(
+   contents_separators_.trailing_separator->SetProperty(
+       views::kElementIdentifierKey, kContentsSeparatorTrailingEdgeElementId);
  
-+  contents_separators_.trailing_corner_separator =
-+      AddChildView(std::make_unique<CustomFloatingCorner>(
-+          *browser_view_, CustomFloatingCorner::CornerOrientation::kTopTrailing,
-+          CustomFloatingCorner::ToolbarTheme(),
-+          kColorToolbarContentAreaSeparator));
-+
+-  contents_separators_.corner_separator =
+-      AddChildView(std::make_unique<CustomFloatingCorner>(
+-          *browser_view_, CustomFloatingCorner::CornerOrientation::kTopLeading,
+-          views::ShapeContextTokens::kContentSeparatorRadius,
+-          CustomFloatingCorner::ToolbarTheme(),
+-          kColorToolbarContentAreaSeparator));
+-  contents_separators_.corner_separator->SetProperty(
+-      views::kElementIdentifierKey, kContentsSeparatorTopCornerElementId);
+-
    for (auto* contents_container_view : contents_container_views_) {
      auto& view_map = container_focusable_map_[contents_container_view];
  
-@@ -664,6 +670,9 @@ gfx::Rect MultiContentsView::CalculateSe
+@@ -662,8 +651,6 @@ gfx::Rect MultiContentsView::CalculateSe
                                 false, gfx::Rect());
-     child_layouts.emplace_back(contents_separators_.corner_separator.get(),
+     child_layouts.emplace_back(contents_separators_.trailing_separator.get(),
                                 false, gfx::Rect());
-+    child_layouts.emplace_back(
-+        contents_separators_.trailing_corner_separator.get(), false,
-+        gfx::Rect());
+-    child_layouts.emplace_back(contents_separators_.corner_separator.get(),
+-                               false, gfx::Rect());
      return available_space;
    }
  
-@@ -680,6 +689,7 @@ gfx::Rect MultiContentsView::CalculateSe
+@@ -680,6 +667,7 @@ gfx::Rect MultiContentsView::CalculateSe
        gfx::Rect(available_space.origin(), {width, separator_height}));
  
    const bool should_show_leading =
@@ -166,7 +49,7 @@
        drop_target_view_->side() == MultiContentsDropTargetView::DropSide::START;
    const int leading_separator_width =
        should_show_leading
-@@ -690,6 +700,7 @@ gfx::Rect MultiContentsView::CalculateSe
+@@ -690,6 +678,7 @@ gfx::Rect MultiContentsView::CalculateSe
        gfx::Rect(available_space.origin(), {leading_separator_width, height}));
  
    const bool should_show_trailing =
@@ -174,44 +57,51 @@
        drop_target_view_->side() == MultiContentsDropTargetView::DropSide::END;
  
    const int trailing_separator_width =
-@@ -701,7 +712,6 @@ gfx::Rect MultiContentsView::CalculateSe
+@@ -701,29 +690,6 @@ gfx::Rect MultiContentsView::CalculateSe
        gfx::Rect(available_space.right() - trailing_separator_width,
                  available_space.y(), trailing_separator_width, height));
  
 -  // Place the corner separator and set its orientation.
-   auto* const corner_separator = contents_separators_.corner_separator.get();
-   const auto corner_preferred_size = corner_separator->GetPreferredSize();
-   views::ChildLayout corner_layout(
-@@ -724,6 +734,22 @@ gfx::Rect MultiContentsView::CalculateSe
-   }
-   child_layouts.push_back(corner_layout);
- 
-+  auto* const trailing_corner_separator =
-+      contents_separators_.trailing_corner_separator.get();
-+  views::ChildLayout trailing_corner_layout(
-+      trailing_corner_separator,
-+      contents_separators_.should_show_top && should_show_leading &&
-+          should_show_trailing);
-+  if (trailing_corner_layout.visible) {
-+    trailing_corner_layout.bounds = gfx::Rect(
-+        gfx::Point(available_space.right() - corner_preferred_size.width(),
-+                   available_space.y()),
-+        corner_preferred_size);
-+    trailing_corner_separator->SetOrientation(
-+        CustomFloatingCorner::CornerOrientation::kTopTrailing);
-+  }
-+  child_layouts.push_back(trailing_corner_layout);
-+
+-  auto* const corner_separator = contents_separators_.corner_separator.get();
+-  const auto corner_preferred_size = corner_separator->GetPreferredSize();
+-  views::ChildLayout corner_layout(
+-      corner_separator, contents_separators_.should_show_top &&
+-                            (should_show_leading || should_show_trailing));
+-  if (corner_layout.visible) {
+-    if (should_show_leading) {
+-      corner_layout.bounds =
+-          gfx::Rect(available_space.origin(), corner_preferred_size);
+-      corner_separator->SetOrientation(
+-          CustomFloatingCorner::CornerOrientation::kTopLeading);
+-    } else {
+-      corner_layout.bounds = gfx::Rect(
+-          gfx::Point(available_space.right() - corner_preferred_size.width(),
+-                     available_space.y()),
+-          corner_preferred_size);
+-      corner_separator->SetOrientation(
+-          CustomFloatingCorner::CornerOrientation::kTopTrailing);
+-    }
+-  }
+-  child_layouts.push_back(corner_layout);
+-
    return gfx::Rect(available_space.x() + leading_separator_width,
                     available_space.y() + separator_height,
                     width - trailing_separator_width - leading_separator_width,
 --- a/chrome/browser/ui/views/frame/multi_contents_view.h
 +++ b/chrome/browser/ui/views/frame/multi_contents_view.h
-@@ -221,6 +221,7 @@ class MultiContentsView
+@@ -25,7 +25,6 @@
+ 
+ class BrowserView;
+ class ContentsWebView;
+-class CustomFloatingCorner;
+ class MultiContentsBackgroundView;
+ class MultiContentsDropTargetView;
+ class MultiContentsResizeArea;
+@@ -220,7 +219,6 @@ class MultiContentsView
+     raw_ptr<views::View> top_separator = nullptr;
      raw_ptr<views::View> leading_separator = nullptr;
      raw_ptr<views::View> trailing_separator = nullptr;
-     raw_ptr<CustomFloatingCorner> corner_separator = nullptr;
-+    raw_ptr<CustomFloatingCorner> trailing_corner_separator = nullptr;
+-    raw_ptr<CustomFloatingCorner> corner_separator = nullptr;
  
      bool should_show_top = false;
      bool leading_side_chrome_attached = false;

--- a/patches/helium/ui/infobar.patch
+++ b/patches/helium/ui/infobar.patch
@@ -310,7 +310,7 @@
    // Updating the top, left and right insets for contents container view when
 --- a/chrome/browser/ui/views/frame/multi_contents_view.h
 +++ b/chrome/browser/ui/views/frame/multi_contents_view.h
-@@ -170,10 +170,13 @@ class MultiContentsView
+@@ -169,10 +169,13 @@ class MultiContentsView
    MultiContentsViewDropTargetController& drop_target_controller() const;
  
    bool IsDragAndDropEnabled() const;
@@ -324,7 +324,7 @@
    void SetAttachedSideChromeVisibility(bool leading_attached,
                                         bool trailing_attached);
    void SetSplitViewInsets(const gfx::Insets& insets);
-@@ -268,8 +271,6 @@ class MultiContentsView
+@@ -265,8 +268,6 @@ class MultiContentsView
    // `MultiContentsView`. Returns 0 if not in a split view.
    int GetMinViewSize(gfx::Rect available_space) const;
  
@@ -333,7 +333,7 @@
    void UpdateContentsBorderAndOverlay() const;
  
    double CalculateRatioWithSnapPoints(double start_size,
-@@ -334,6 +335,7 @@ class MultiContentsView
+@@ -331,6 +332,7 @@ class MultiContentsView
    PrefChangeRegistrar pref_change_registrar_;
    bool is_drag_drop_pref_enabled_ = false;
    bool is_rounded_frame_pref_enabled_ = false;
@@ -379,7 +379,7 @@
  #endif  // CHROME_BROWSER_UI_VIEWS_INFOBARS_INFOBAR_CONTAINER_VIEW_H_
 --- a/chrome/browser/ui/views/frame/multi_contents_view.cc
 +++ b/chrome/browser/ui/views/frame/multi_contents_view.cc
-@@ -524,8 +524,9 @@ views::ProposedLayout MultiContentsView:
+@@ -507,8 +507,9 @@ views::ProposedLayout MultiContentsView:
      available_space.Inset(split_view_insets_);
    } else if (should_use_rounded_frame) {
      gfx::Insets single_insets(kSplitViewContentInset);
@@ -391,7 +391,7 @@
      single_insets.set_left(contents_separators_.leading_side_chrome_attached
                                 ? 0
                                 : kSplitViewContentInset);
-@@ -663,8 +664,9 @@ gfx::Rect MultiContentsView::CalculateDr
+@@ -646,8 +647,9 @@ gfx::Rect MultiContentsView::CalculateDr
        available_space.x() + (is_drop_target_on_start ? drop_target_width : 0);
    int top_margin = 0;
    if (IsInSplitView() || should_use_rounded_frame) {
@@ -403,7 +403,7 @@
    } else if (contents_separators_.should_show_top) {
      top_margin =
          contents_separators_.top_separator->GetPreferredSize().height();
-@@ -940,10 +942,18 @@ void MultiContentsView::OnRoundedFramePr
+@@ -880,10 +882,18 @@ void MultiContentsView::OnRoundedFramePr
  }
  
  void MultiContentsView::SetShouldShowTopSeparator(bool should_show) {

--- a/patches/helium/ui/layout/zen-mode.patch
+++ b/patches/helium/ui/layout/zen-mode.patch
@@ -1625,7 +1625,7 @@
        CopyURL(browser_, browser_->tab_strip_model()->GetActiveWebContents());
 --- a/chrome/browser/ui/views/frame/multi_contents_view.h
 +++ b/chrome/browser/ui/views/frame/multi_contents_view.h
-@@ -84,6 +84,9 @@ class MultiContentsView
+@@ -83,6 +83,9 @@ class MultiContentsView
    const gfx::RoundedCornersF& background_radii() const;
    void SetBackgroundRadii(const gfx::RoundedCornersF& radii);
  
@@ -1635,7 +1635,7 @@
    // Returns true if more than one WebContents is displayed.
    bool IsInSplitView() const;
  
-@@ -231,6 +234,14 @@ class MultiContentsView
+@@ -228,6 +231,14 @@ class MultiContentsView
      bool trailing_side_chrome_attached = false;
    };
  
@@ -1650,7 +1650,7 @@
    static constexpr int kMinWebContentsSize = 200;
    static constexpr int kConstrainedMinWebContentsSize = 50;
    static constexpr double kMinWebContentsSizePercentage = 0.1;
-@@ -244,6 +255,7 @@ class MultiContentsView
+@@ -241,6 +252,7 @@ class MultiContentsView
    // available space after the layout.
    gfx::Rect CalculateDropTargetLayout(
        const gfx::Rect& available_space,
@@ -1658,7 +1658,7 @@
        std::vector<views::ChildLayout>& child_layouts) const;
  
    // Adds separator layouts to the given list and returns the remaining
-@@ -271,6 +283,9 @@ class MultiContentsView
+@@ -268,6 +280,9 @@ class MultiContentsView
    // `MultiContentsView`. Returns 0 if not in a split view.
    int GetMinViewSize(gfx::Rect available_space) const;
  
@@ -1668,7 +1668,7 @@
    void UpdateContentsBorderAndOverlay() const;
  
    double CalculateRatioWithSnapPoints(double start_size,
-@@ -320,10 +335,11 @@ class MultiContentsView
+@@ -317,10 +332,11 @@ class MultiContentsView
    // a resize action began. Nullopt if not currently resizing.
    std::optional<int> initial_start_size_on_resize_;
  
@@ -1928,7 +1928,7 @@
  
  #include "base/check_deref.h"
  #include "base/feature_list.h"
-@@ -56,8 +57,18 @@
+@@ -55,8 +56,18 @@
  
  namespace {
  constexpr int kSnapDistance = 15;
@@ -1947,7 +1947,7 @@
  void MultiContentsView::ContentsSeparators::Reset() {
    top_separator = nullptr;
    leading_separator = nullptr;
-@@ -443,6 +454,41 @@ int MultiContentsView::GetInactiveIndex(
+@@ -426,6 +437,41 @@ int MultiContentsView::GetInactiveIndex(
    return active_index_ == 0 ? 1 : 0;
  }
  
@@ -1989,7 +1989,7 @@
  void MultiContentsView::OnWebContentsFocused(views::WebView* web_view) {
    if (IsInSplitView()) {
      // Check whether the widget is visible as otherwise during browser hide,
-@@ -505,16 +551,17 @@ views::ProposedLayout MultiContentsView:
+@@ -488,16 +534,17 @@ views::ProposedLayout MultiContentsView:
  
    gfx::Rect available_space = gfx::Rect(width, height);
  
@@ -2012,7 +2012,7 @@
    }
  
    available_space =
-@@ -524,9 +571,7 @@ views::ProposedLayout MultiContentsView:
+@@ -507,9 +554,7 @@ views::ProposedLayout MultiContentsView:
      available_space.Inset(split_view_insets_);
    } else if (should_use_rounded_frame) {
      gfx::Insets single_insets(kSplitViewContentInset);
@@ -2023,7 +2023,7 @@
      single_insets.set_left(contents_separators_.leading_side_chrome_attached
                                 ? 0
                                 : kSplitViewContentInset);
-@@ -629,6 +674,7 @@ void MultiContentsView::BeforeApplyLayou
+@@ -612,6 +657,7 @@ void MultiContentsView::BeforeApplyLayou
  
  gfx::Rect MultiContentsView::CalculateDropTargetLayout(
      const gfx::Rect& available_space,
@@ -2031,7 +2031,7 @@
      std::vector<views::ChildLayout>& child_layouts) const {
    CHECK(IsDragAndDropEnabled());
    if (!drop_target_view_->GetVisible()) {
-@@ -642,19 +688,17 @@ gfx::Rect MultiContentsView::CalculateDr
+@@ -625,19 +671,17 @@ gfx::Rect MultiContentsView::CalculateDr
    const bool is_drop_target_on_start =
        drop_target_view_->side() == MultiContentsDropTargetView::DropSide::START;
    const bool should_use_rounded_frame = ShouldUseRoundedFrame();
@@ -2056,7 +2056,7 @@
    UpdateContentsBorderAndOverlay();
  
    const int drop_target_x =
-@@ -663,10 +707,8 @@ gfx::Rect MultiContentsView::CalculateDr
+@@ -646,10 +690,8 @@ gfx::Rect MultiContentsView::CalculateDr
    const int remaining_space_x =
        available_space.x() + (is_drop_target_on_start ? drop_target_width : 0);
    int top_margin = 0;
@@ -2069,34 +2069,7 @@
    } else if (contents_separators_.should_show_top) {
      top_margin =
          contents_separators_.top_separator->GetPreferredSize().height();
-@@ -737,10 +779,14 @@ gfx::Rect MultiContentsView::CalculateSe
-       gfx::Rect(available_space.right() - trailing_separator_width,
-                 available_space.y(), trailing_separator_width, height));
- 
-+  const bool show_floating_corners =
-+      !browser_view_->IsZenModeEnabledForLayout();
-+
-   auto* const corner_separator = contents_separators_.corner_separator.get();
-   const auto corner_preferred_size = corner_separator->GetPreferredSize();
-   views::ChildLayout corner_layout(
--      corner_separator, contents_separators_.should_show_top &&
-+      corner_separator, show_floating_corners &&
-+                            contents_separators_.should_show_top &&
-                             (should_show_leading || should_show_trailing));
-   if (corner_layout.visible) {
-     if (should_show_leading) {
-@@ -763,8 +809,8 @@ gfx::Rect MultiContentsView::CalculateSe
-       contents_separators_.trailing_corner_separator.get();
-   views::ChildLayout trailing_corner_layout(
-       trailing_corner_separator,
--      contents_separators_.should_show_top && should_show_leading &&
--          should_show_trailing);
-+      show_floating_corners && contents_separators_.should_show_top &&
-+          should_show_leading && should_show_trailing);
-   if (trailing_corner_layout.visible) {
-     trailing_corner_layout.bounds = gfx::Rect(
-         gfx::Point(available_space.right() - corner_preferred_size.width(),
-@@ -851,6 +897,12 @@ bool MultiContentsView::ShouldUseRounded
+@@ -791,6 +833,12 @@ bool MultiContentsView::ShouldUseRounded
           !is_fullscreen;
  }
  
@@ -2109,7 +2082,7 @@
  void MultiContentsView::UpdateContentsBorderAndOverlay() const {
    const views::Widget* widget = browser_view_->GetWidget();
    const bool is_fullscreen = widget && widget->IsFullscreen();
-@@ -864,17 +916,25 @@ void MultiContentsView::UpdateContentsBo
+@@ -804,17 +852,25 @@ void MultiContentsView::UpdateContentsBo
    const bool is_drop_target_on_end =
        is_drop_target_visible &&
        drop_target_view_->side() == MultiContentsDropTargetView::DropSide::END;
@@ -2144,7 +2117,7 @@
  
    for (auto* contents_container_view : contents_container_views_) {
      const bool is_active =
-@@ -893,6 +953,8 @@ void MultiContentsView::UpdateContentsBo
+@@ -833,6 +889,8 @@ void MultiContentsView::UpdateContentsBo
      contents_container_view->UpdateBorderAndOverlay(
          is_in_split, should_round_contents, is_active,
          is_active && active_contents_view_highlighted_,
@@ -2153,7 +2126,7 @@
          use_system_bottom_left_radius && is_first_view,
          use_system_bottom_right_radius && is_last_view);
    }
-@@ -954,9 +1016,7 @@ void MultiContentsView::SetTopChromeAtta
+@@ -894,9 +952,7 @@ void MultiContentsView::SetTopChromeAtta
    }
    top_edge_attached_to_infobar_ = top_edge_attached_to_infobar;
    contents_separators_.should_show_top = should_show_top_separator;
@@ -2164,7 +2137,7 @@
    // This can be called during BrowserView layout, so protect against creating a
    // layout loop.
    InvalidateLayout(/*avoid_propagate_during_layout=*/true);
-@@ -971,11 +1031,7 @@ void MultiContentsView::SetAttachedSideC
+@@ -911,11 +967,7 @@ void MultiContentsView::SetAttachedSideC
    }
    contents_separators_.leading_side_chrome_attached = leading_attached;
    contents_separators_.trailing_side_chrome_attached = trailing_attached;

--- a/patches/helium/ui/multi-contents-drop-target.patch
+++ b/patches/helium/ui/multi-contents-drop-target.patch
@@ -275,7 +275,7 @@
    raw_ptr<views::ImageView> icon_view_ = nullptr;
 --- a/chrome/browser/ui/views/frame/multi_contents_view.cc
 +++ b/chrome/browser/ui/views/frame/multi_contents_view.cc
-@@ -631,27 +631,50 @@ gfx::Rect MultiContentsView::CalculateDr
+@@ -614,27 +614,50 @@ gfx::Rect MultiContentsView::CalculateDr
      std::vector<views::ChildLayout>& child_layouts) const {
    CHECK(IsDragAndDropEnabled());
    if (!drop_target_view_->GetVisible()) {
@@ -337,7 +337,7 @@
  
    return gfx::Rect(remaining_space_x, available_space.y(),
                     available_space.width() - drop_target_width,
-@@ -826,23 +849,30 @@ bool MultiContentsView::ShouldUseRounded
+@@ -766,23 +789,30 @@ bool MultiContentsView::ShouldUseRounded
           !is_fullscreen;
  }
  
@@ -375,7 +375,7 @@
      const bool is_active =
 --- a/chrome/browser/ui/views/frame/multi_contents_view.h
 +++ b/chrome/browser/ui/views/frame/multi_contents_view.h
-@@ -270,7 +270,7 @@ class MultiContentsView
+@@ -267,7 +267,7 @@ class MultiContentsView
  
    bool ShouldUseRoundedFrame() const;
  


### PR DESCRIPTION
now web content is not rounded at all if the rounded frame is disabled, even if leading/trailing chrome is attached

<img width="287" height="133" alt="image" src="https://github.com/user-attachments/assets/7f37cc2a-c790-4abf-a42f-cd9b7ced222a" />

fixes #1133