### PR TITLE
helium/ui: add experimental native frame materials for macOS

### DIFF
--- a/i18n/source.gen.json
+++ b/i18n/source.gen.json
@@ -961,6 +961,18 @@
     "message": "New tab opened"
   },
   {
+    "name": "IDS_SETTINGS_NATIVE_FRAME_MATERIALS",
+    "source": "chrome/app/settings_strings.grdp",
+    "context": "Label for the toggle which enables or disables native system materials on the browser frame.",
+    "message": "Use native frame materials (experimental)"
+  },
+  {
+    "name": "IDS_SETTINGS_NATIVE_FRAME_MATERIALS_DESCRIPTION",
+    "source": "chrome/app/settings_strings.grdp",
+    "context": "Description for the toggle which enables native system materials on the browser frame.",
+    "message": "Applies native materials to the browser frame surfaces. May cause UI clarity issues."
+  },
+  {
     "name": "IDS_CONTENT_CONTEXT_SYSTEM_TRANSLATE",
     "source": "chrome/app/generated_resources.grd",
     "context": "The name of the macOS system Translate command in the content area context menu",

--- a/patches/helium/ui/native-frame-materials.patch
+++ b/patches/helium/ui/native-frame-materials.patch
@@ -1,0 +1,1296 @@
+--- a/chrome/browser/ui/ui_features.h
++++ b/chrome/browser/ui/ui_features.h
+@@ -22,6 +22,9 @@ namespace features {
+ BASE_DECLARE_FEATURE(kHeliumCompactLocationWidth);
+ bool HeliumUseCompactLocationWidth();
+ 
++BASE_DECLARE_FEATURE(kHeliumNativeFrameMaterials);
++bool HeliumNativeFrameAvailable();
++
+ BASE_DECLARE_FEATURE(kAllowEyeDropperWGCScreenCapture);
+ 
+ // Enables a compositor-driven rotation animation for the tab load throbber.
+--- a/chrome/browser/ui/ui_features.cc
++++ b/chrome/browser/ui/ui_features.cc
+@@ -36,6 +36,16 @@ bool HeliumUseCompactLocationWidth() {
+   return base::FeatureList::IsEnabled(kHeliumCompactLocationWidth);
+ }
+ 
++BASE_FEATURE(kHeliumNativeFrameMaterials, base::FEATURE_DISABLED_BY_DEFAULT);
++
++bool HeliumNativeFrameAvailable() {
++#if BUILDFLAG(IS_MAC)
++  return base::FeatureList::IsEnabled(kHeliumNativeFrameMaterials);
++#else
++  return false;
++#endif
++}
++
+ // Enables the use of WGC for the Eye Dropper screen capture.
+ BASE_FEATURE(kAllowEyeDropperWGCScreenCapture,
+ #if BUILDFLAG(IS_WIN)
+--- a/chrome/browser/helium_flag_choices.h
++++ b/chrome/browser/helium_flag_choices.h
+@@ -40,6 +40,8 @@ namespace helium {
+   constexpr const char kMiddleClickAutoscrollCommandLine[] = "middle-click-autoscroll";
+   constexpr const char kHeliumCompactLocationWidthCommandLine[] =
+       "helium-compact-location-width";
++  constexpr const char kHeliumNativeFrameMaterialsCommandLine[] =
++      "helium-native-frame-materials";
+ 
+ }  // namespace helium
+ 
+--- a/chrome/browser/helium_flag_entries.h
++++ b/chrome/browser/helium_flag_entries.h
+@@ -44,4 +44,8 @@
+      "Automatic address bar width in compact layout",
+      "Allows the location bar to automatically reduce its width in the compact browser layout. The omnibox may be uncomfortable to use. Helium flag.",
+      kOsDesktop, FEATURE_VALUE_TYPE(features::kHeliumCompactLocationWidth)},
++    {helium::kHeliumNativeFrameMaterialsCommandLine,
++     "Native frame materials",
++     "Enables an option to apply native materials to the browser frame surfaces. May cause UI clarity issues. Helium flag.",
++     kOsMac, FEATURE_VALUE_TYPE(features::kHeliumNativeFrameMaterials)},
+ #endif  /* CHROME_BROWSER_HELIUM_FLAG_ENTRIES_H_ */
+--- a/chrome/common/pref_names.h
++++ b/chrome/common/pref_names.h
+@@ -668,6 +668,11 @@ inline constexpr char kTabCyclingMRU[] =
+ // frame.
+ inline constexpr char kHeliumRoundedFrame[] = "helium.browser.rounded_frame";
+ 
++// A boolean pref set to true if browser frame surfaces should use native system
++// materials instead of opaque fills.
++inline constexpr char kHeliumNativeFrameMaterials[] =
++    "helium.browser.native_frame_materials";
++
+ // An enum (HeliumLayoutType) pref that controls the browser layout.
+ inline constexpr char kHeliumLayout[] = "helium.browser.layout";
+ 
+--- a/chrome/browser/ui/browser_ui_prefs.cc
++++ b/chrome/browser/ui/browser_ui_prefs.cc
+@@ -125,6 +125,8 @@ void RegisterBrowserUserPrefs(user_prefs
+ 
+   registry->RegisterBooleanPref(prefs::kHeliumRoundedFrame, true);
+ 
++  registry->RegisterBooleanPref(prefs::kHeliumNativeFrameMaterials, false);
++
+   registry->RegisterBooleanPref(prefs::kHeliumCenteredLocationBar, false);
+ 
+   registry->RegisterBooleanPref(prefs::kHeliumMinimalLocationBar, false);
+--- a/chrome/browser/extensions/api/settings_private/prefs_util.cc
++++ b/chrome/browser/extensions/api/settings_private/prefs_util.cc
+@@ -223,6 +223,8 @@ const PrefsUtil::TypedPrefMap& PrefsUtil
+       settings_api::PrefType::kBoolean;
+   (*s_allowlist)[::prefs::kHeliumZenModeTopChromePinned] =
+       settings_api::PrefType::kBoolean;
++  (*s_allowlist)[::prefs::kHeliumNativeFrameMaterials] =
++      settings_api::PrefType::kBoolean;
+ 
+   // Miscellaneous
+   (*s_allowlist)[::embedder_support::kAlternateErrorPagesEnabled] =
+--- a/chrome/app/settings_strings.grdp
++++ b/chrome/app/settings_strings.grdp
+@@ -274,6 +274,12 @@
+     <message name="IDS_SETTINGS_ROUNDED_FRAME" desc="Label for the toggle which enables or disables a rounded frame around web contents.">
+       Show a rounded frame around web contents
+     </message>
++    <message name="IDS_SETTINGS_NATIVE_FRAME_MATERIALS" desc="Label for the toggle which enables or disables native system materials on the browser frame.">
++      Use native frame materials (experimental)
++    </message>
++    <message name="IDS_SETTINGS_NATIVE_FRAME_MATERIALS_DESCRIPTION" desc="Description for the toggle which enables native system materials on the browser frame.">
++      Applies native materials to the browser frame surfaces. May cause UI clarity issues.
++    </message>
+     <message name="IDS_SETTINGS_BROWSER_LAYOUT" desc="Label for the browser layout dropdown that controls how the browser UI is displayed.">
+       Browser layout
+     </message>
+--- a/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
++++ b/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
+@@ -552,6 +552,9 @@ void AddAppearanceStrings(content::WebUI
+       {"openNewTabNextToActive", IDS_SETTINGS_NEW_TAB_NEXT_TO_ACTIVE_BUTTON},
+       {"cycleTabsInMRUOrder", IDS_SETTINGS_CYCLE_TABS_IN_MRU_ORDER},
+       {"roundedFrame", IDS_SETTINGS_ROUNDED_FRAME},
++      {"nativeFrameMaterials", IDS_SETTINGS_NATIVE_FRAME_MATERIALS},
++      {"nativeFrameMaterialsDescription",
++       IDS_SETTINGS_NATIVE_FRAME_MATERIALS_DESCRIPTION},
+       {"browserLayout", IDS_SETTINGS_BROWSER_LAYOUT},
+       {"browserLayoutClassic", IDS_SETTINGS_BROWSER_LAYOUT_CLASSIC},
+       {"browserLayoutDynamic", IDS_SETTINGS_BROWSER_LAYOUT_DYNAMIC},
+@@ -657,6 +660,8 @@ void AddAppearanceStrings(content::WebUI
+ 
+   html_source->AddBoolean("showCtrlTabMru",
+                           base::FeatureList::IsEnabled(features::kCtrlTabMru));
++  html_source->AddBoolean("showNativeFrameMaterialsOption",
++                          features::HeliumNativeFrameAvailable());
+ 
+   std::string configurable_alignments_json;
+   base::JSONWriter::Write(
+--- a/chrome/browser/resources/settings/appearance_page/appearance_page.ts
++++ b/chrome/browser/resources/settings/appearance_page/appearance_page.ts
+@@ -234,6 +234,13 @@ export class SettingsAppearancePageEleme
+         },
+       },
+ 
++      showNativeFrameMaterialsOption_: {
++        type: Boolean,
++        value() {
++          return loadTimeData.getBoolean('showNativeFrameMaterialsOption');
++        },
++      },
++
+       ntpSimplificationBookmarksBarEnabled_: {
+         type: Boolean,
+         value() {
+@@ -374,6 +381,7 @@ export class SettingsAppearancePageEleme
+   // </if>
+ 
+   declare private showVerticalTabsEnabled_: boolean;
++  declare private showNativeFrameMaterialsOption_: boolean;
+   declare private showVerticalSettings_: boolean;
+   declare private ntpSimplificationBookmarksBarEnabled_: boolean;
+   declare private bookmarksBarOptions_: DropdownMenuOptionList;
+--- a/chrome/browser/resources/settings/appearance_page/appearance_page.html
++++ b/chrome/browser/resources/settings/appearance_page/appearance_page.html
+@@ -149,6 +149,12 @@
+             pref="{{prefs.helium.browser.rounded_frame}}"
+             label="$i18n{roundedFrame}">
+         </settings-toggle-button>
++        <settings-toggle-button class="hr"
++            hidden="[[!showNativeFrameMaterialsOption_]]"
++            pref="{{prefs.helium.browser.native_frame_materials}}"
++            label="$i18n{nativeFrameMaterials}"
++            sub-label="$i18n{nativeFrameMaterialsDescription}">
++        </settings-toggle-button>
+         <settings-toggle-button class="hr" elide-label
+             hidden="[[!pageVisibility.homeButton]]"
+             pref="{{prefs.browser.show_home_button}}"
+--- a/chrome/browser/ui/BUILD.gn
++++ b/chrome/browser/ui/BUILD.gn
+@@ -3276,6 +3276,8 @@ static_library("ui") {
+       "views/frame/immersive_mode_overlay_views_mac.h",
+       "views/frame/immersive_mode_overlay_views_mac.mm",
+       "views/helium/frame_corner_radius_mac.mm",
++      "views/helium/native_frame_materials_mac.h",
++      "views/helium/native_frame_materials_mac.mm",
+       "views/tab_contents/chrome_web_contents_view_delegate_views_mac.h",
+       "views/tab_contents/chrome_web_contents_view_delegate_views_mac.mm",
+       "webui/help/version_updater_mac.mm",
+@@ -3966,6 +3968,8 @@ static_library("ui") {
+       "views/global_media_controls/media_toolbar_button_view.h",
+       "views/helium/frame_corner_radius.cc",
+       "views/helium/frame_corner_radius.h",
++      "views/helium/native_frame_materials.cc",
++      "views/helium/native_frame_materials.h",
+       "views/hover_button_controller.cc",
+       "views/hover_button_controller.h",
+       "views/hung_renderer_view.cc",
+--- /dev/null
++++ b/chrome/browser/ui/views/helium/native_frame_materials.h
+@@ -0,0 +1,23 @@
++// Copyright 2026 The Helium Authors
++// You can use, redistribute, and/or modify this source code under
++// the terms of the GPL-3.0 license that can be found in the LICENSE file.
++
++#ifndef CHROME_BROWSER_UI_VIEWS_HELIUM_NATIVE_FRAME_MATERIALS_H_
++#define CHROME_BROWSER_UI_VIEWS_HELIUM_NATIVE_FRAME_MATERIALS_H_
++
++class BrowserView;
++class BrowserWindowInterface;
++
++namespace views {
++class View;
++}  // namespace views
++
++namespace helium {
++
++bool ShouldUseNativeFrameMaterials(const BrowserView* browser_view);
++bool ShouldUseNativeFrameMaterials(const BrowserWindowInterface* browser);
++bool ShouldUseNativeFrameMaterials(const views::View* view);
++
++}  // namespace helium
++
++#endif  // CHROME_BROWSER_UI_VIEWS_HELIUM_NATIVE_FRAME_MATERIALS_H_
+--- /dev/null
++++ b/chrome/browser/ui/views/helium/native_frame_materials.cc
+@@ -0,0 +1,46 @@
++// Copyright 2026 The Helium Authors
++// You can use, redistribute, and/or modify this source code under
++// the terms of the GPL-3.0 license that can be found in the LICENSE file.
++
++#include "chrome/browser/ui/views/helium/native_frame_materials.h"
++
++#include "build/build_config.h"
++#include "chrome/browser/profiles/profile.h"
++#include "chrome/browser/ui/browser_window/public/browser_window_interface.h"
++#include "chrome/browser/ui/ui_features.h"
++#include "chrome/browser/ui/views/frame/browser_view.h"
++#include "chrome/common/pref_names.h"
++#include "components/prefs/pref_service.h"
++#include "ui/views/view.h"
++#include "ui/views/widget/widget.h"
++
++namespace helium {
++
++bool ShouldUseNativeFrameMaterials(const BrowserView* browser_view) {
++#if BUILDFLAG(IS_MAC)
++  if (!features::HeliumNativeFrameAvailable() || !browser_view) {
++    return false;
++  }
++
++  const Profile* profile = browser_view->GetProfile();
++  return profile &&
++         profile->GetPrefs()->GetBoolean(prefs::kHeliumNativeFrameMaterials);
++#else
++  return false;
++#endif
++}
++
++bool ShouldUseNativeFrameMaterials(const BrowserWindowInterface* browser) {
++  return ShouldUseNativeFrameMaterials(
++      browser ? BrowserView::GetBrowserViewForBrowser(browser) : nullptr);
++}
++
++bool ShouldUseNativeFrameMaterials(const views::View* view) {
++  const views::Widget* widget = view ? view->GetWidget() : nullptr;
++  return ShouldUseNativeFrameMaterials(
++      widget ? BrowserView::GetBrowserViewForNativeWindow(
++                   widget->GetNativeWindow())
++             : nullptr);
++}
++
++}  // namespace helium
+--- /dev/null
++++ b/chrome/browser/ui/views/helium/native_frame_materials_mac.h
+@@ -0,0 +1,22 @@
++// Copyright 2026 The Helium Authors
++// You can use, redistribute, and/or modify this source code under
++// the terms of the GPL-3.0 license that can be found in the LICENSE file.
++
++#ifndef CHROME_BROWSER_UI_VIEWS_HELIUM_NATIVE_FRAME_MATERIALS_MAC_H_
++#define CHROME_BROWSER_UI_VIEWS_HELIUM_NATIVE_FRAME_MATERIALS_MAC_H_
++
++#import <Cocoa/Cocoa.h>
++
++#include "third_party/skia/include/core/SkColor.h"
++#include "ui/color/color_provider_key.h"
++
++namespace helium {
++
++NSView* CreateNativeFrameMaterialBackgroundView(
++    NSRect frame,
++    ui::ColorProviderKey::ColorMode color_mode,
++    SkColor theme_color);
++
++}  // namespace helium
++
++#endif  // CHROME_BROWSER_UI_VIEWS_HELIUM_NATIVE_FRAME_MATERIALS_MAC_H_
+--- /dev/null
++++ b/chrome/browser/ui/views/helium/native_frame_materials_mac.mm
+@@ -0,0 +1,101 @@
++// Copyright 2026 The Helium Authors
++// You can use, redistribute, and/or modify this source code under
++// the terms of the GPL-3.0 license that can be found in the LICENSE file.
++
++#import "chrome/browser/ui/views/helium/native_frame_materials_mac.h"
++
++namespace helium {
++namespace {
++
++// Low-alpha black or white overlay applied before the browser theme tint.
++constexpr CGFloat kFrameMaterialNeutralOverlayAlpha = 0.2;
++
++// Menu material is slightly brighter and more translucent in light mode,
++// so we use it for the light theme instead of Sidebar.
++NSVisualEffectMaterial GetFrameMaterial(bool is_dark) {
++  return is_dark ? NSVisualEffectMaterialSidebar
++                 : NSVisualEffectMaterialMenu;
++}
++
++// Light material needs a stronger theme tint than dark material to avoid
++// looking washed out.
++CGFloat GetFrameMaterialThemeTintOverlayAlpha(bool is_dark) {
++  return is_dark ? 0.55 : 0.8;
++}
++
++NSColor* GetFrameMaterialNeutralOverlayColor(bool is_dark) {
++  const CGFloat component = is_dark ? 0.0 : 1.0;
++  return [NSColor colorWithSRGBRed:component
++                             green:component
++                              blue:component
++                             alpha:kFrameMaterialNeutralOverlayAlpha];
++}
++
++// Applies the browser theme color over the black/white neutral overlay while
++// keeping enough translucency for AppKit's material effect to show through.
++NSColor* GetFrameMaterialThemeTintOverlayColor(SkColor theme_color,
++                                               bool is_dark) {
++  const CGFloat red = SkColorGetR(theme_color) / 255.0;
++  const CGFloat green = SkColorGetG(theme_color) / 255.0;
++  const CGFloat blue = SkColorGetB(theme_color) / 255.0;
++  return [NSColor colorWithSRGBRed:red
++                             green:green
++                              blue:blue
++                             alpha:GetFrameMaterialThemeTintOverlayAlpha(
++                                       is_dark)];
++}
++
++NSView* CreateFrameMaterialTintView(NSRect frame, NSColor* color) {
++  NSView* tint_view = [[NSView alloc] initWithFrame:frame];
++  tint_view.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
++  tint_view.wantsLayer = YES;
++  tint_view.layer.backgroundColor = [color CGColor];
++  return tint_view;
++}
++
++}  // namespace
++}  // namespace helium
++
++// NSVisualEffectView intercepts hit testing even when added below the
++// WebContents NSViews. Returning nil here lets clicks pass through to the
++// sibling subviews that are supposed to receive them.
++@interface HeliumFrameMaterialBackgroundView : NSVisualEffectView
++@end
++
++@implementation HeliumFrameMaterialBackgroundView
++- (NSView*)hitTest:(NSPoint)point {
++  return nil;
++}
++@end
++
++namespace helium {
++
++NSView* CreateNativeFrameMaterialBackgroundView(
++    NSRect frame,
++    ui::ColorProviderKey::ColorMode color_mode,
++    SkColor theme_color) {
++  NSVisualEffectView* material_view =
++      [[HeliumFrameMaterialBackgroundView alloc] initWithFrame:frame];
++  material_view.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
++  material_view.blendingMode = NSVisualEffectBlendingModeBehindWindow;
++  material_view.state = NSVisualEffectStateActive;
++
++  const bool is_dark = color_mode == ui::ColorProviderKey::ColorMode::kDark;
++  material_view.material = GetFrameMaterial(is_dark);
++  material_view.appearance =
++      [NSAppearance appearanceNamed:is_dark ? NSAppearanceNameVibrantDark
++                                            : NSAppearanceNameVibrantLight];
++
++  NSView* neutral_overlay = CreateFrameMaterialTintView(
++      material_view.bounds, GetFrameMaterialNeutralOverlayColor(is_dark));
++  [material_view addSubview:neutral_overlay];
++
++  NSView* theme_tint_overlay = CreateFrameMaterialTintView(
++      material_view.bounds,
++      GetFrameMaterialThemeTintOverlayColor(theme_color, is_dark));
++  [material_view addSubview:theme_tint_overlay];
++
++  return material_view;
++}
++
++}  // namespace helium
+--- a/chrome/browser/ui/views/frame/browser_widget.cc
++++ b/chrome/browser/ui/views/frame/browser_widget.cc
+@@ -22,6 +22,7 @@
+ #include "chrome/browser/ui/browser.h"
+ #include "chrome/browser/ui/browser_window/public/browser_window_features.h"
+ #include "chrome/browser/ui/browser_window_state.h"
++#include "chrome/browser/ui/ui_features.h"
+ #include "chrome/browser/ui/unload_controller.h"
+ #include "chrome/browser/ui/views/frame/browser_frame_view.h"
+ #include "chrome/browser/ui/views/frame/browser_native_widget.h"
+@@ -31,6 +32,7 @@
+ #include "chrome/browser/ui/views/frame/immersive_mode_controller.h"
+ #include "chrome/browser/ui/views/frame/system_menu_model_builder.h"
+ #include "chrome/browser/ui/views/frame/top_container_view.h"
++#include "chrome/browser/ui/views/helium/native_frame_materials.h"
+ #include "chrome/browser/ui/web_applications/app_browser_controller.h"
+ #include "chrome/common/chrome_features.h"
+ #include "chrome/common/chrome_switches.h"
+@@ -200,7 +202,11 @@ void BrowserWidget::InitBrowserWidget()
+     }
+   }
+ 
+-  if (features::IsGlassFrameEnabled()) {
++  // The widget must enter the translucent compositing path at creation time so
++  // the native-materials pref can be toggled live. If an initially opaque
++  // widget is made translucent later, the Chromium layer tree can keep painting
++  // the opaque active-frame fallback color until the window is recreated.
++  if (features::HeliumNativeFrameAvailable()) {
+     params.opacity = views::Widget::InitParams::WindowOpacity::kTranslucent;
+   }
+ 
+--- a/chrome/browser/ui/views/frame/browser_native_widget_mac.h
++++ b/chrome/browser/ui/views/frame/browser_native_widget_mac.h
+@@ -10,15 +10,17 @@
+ #include "base/memory/raw_ptr.h"
+ #include "chrome/browser/command_observer.h"
+ #include "chrome/browser/ui/views/frame/browser_native_widget.h"
++#include "components/prefs/pref_change_registrar.h"
+ #include "third_party/skia/include/core/SkColor.h"
+ #include "ui/base/mojom/window_show_state.mojom-forward.h"
+-#include "ui/native_theme/native_theme.h"
++#include "ui/color/color_provider_key.h"
+ #include "ui/views/widget/native_widget_mac.h"
+ 
+ class BrowserWidget;
+ class BrowserView;
+ @class BrowserWindowTouchBarController;
+ @class BrowserWindowTouchBarViewsDelegate;
++@class NSWindow;
+ 
+ ////////////////////////////////////////////////////////////////////////////////
+ //  BrowserNativeWidgetMac is a NativeWidgetMac subclass that provides
+@@ -92,12 +94,14 @@ class BrowserNativeWidgetMac : public vi
+   raw_ptr<BrowserView> browser_view_;  // Weak. Our ClientView.
+   BrowserWindowTouchBarViewsDelegate* __strong touch_bar_delegate_;
+   NSView* __strong background_view_;
++  PrefChangeRegistrar pref_change_registrar_;
+ 
+-  std::optional<ui::NativeTheme::PreferredColorScheme>
+-      last_preferred_color_scheme_;
++  std::optional<ui::ColorProviderKey::ColorMode> last_color_mode_;
+   std::optional<SkColor> last_theme_color_;
+ 
++  void SetNativeFrameMaterialWindowState(NSWindow* ns_window, bool enabled);
+   void UpdateBackground();
++  void OnNativeFrameMaterialsPrefChanged();
+ };
+ 
+ #endif  // CHROME_BROWSER_UI_VIEWS_FRAME_BROWSER_NATIVE_WIDGET_MAC_H_
+--- a/chrome/browser/ui/views/frame/browser_native_widget_mac.mm
++++ b/chrome/browser/ui/views/frame/browser_native_widget_mac.mm
+@@ -5,6 +5,7 @@
+ #import "chrome/browser/ui/views/frame/browser_native_widget_mac.h"
+ 
+ #import "base/apple/foundation_util.h"
++#include "base/functional/bind.h"
+ #include "base/memory/raw_ptr.h"
+ #include "base/metrics/user_metrics.h"
+ #include "base/metrics/user_metrics_action.h"
+@@ -16,12 +17,14 @@
+ #include "chrome/browser/browsing_data/browsing_data_important_sites_util.h"
+ #include "chrome/browser/global_keyboard_shortcuts_mac.h"
+ #include "chrome/browser/media/router/media_router_feature.h"
++#include "chrome/browser/profiles/profile.h"
+ #include "chrome/browser/ui/browser_command_controller.h"
+ #include "chrome/browser/ui/browser_commands.h"
+ #include "chrome/browser/ui/browser_window/public/browser_window_features.h"
+ #import "chrome/browser/ui/cocoa/browser_window_command_handler.h"
+ #import "chrome/browser/ui/cocoa/chrome_command_dispatcher_delegate.h"
+ #import "chrome/browser/ui/cocoa/touchbar/browser_window_touch_bar_controller.h"
++#include "chrome/browser/ui/color/chrome_color_id.h"
+ #include "chrome/browser/ui/lens/lens_overlay_entry_point_controller.h"
+ #include "chrome/browser/ui/omnibox/omnibox_next_features.h"
+ #include "chrome/browser/ui/tabs/vertical_tab_strip_metrics.h"
+@@ -30,6 +33,8 @@
+ #include "chrome/browser/ui/views/frame/browser_view.h"
+ #include "chrome/browser/ui/views/frame/browser_widget.h"
+ #include "chrome/browser/ui/views/frame/immersive_mode_controller.h"
++#include "chrome/browser/ui/views/helium/native_frame_materials.h"
++#include "chrome/browser/ui/views/helium/native_frame_materials_mac.h"
+ #include "chrome/browser/ui/views/web_apps/frame_toolbar/web_app_frame_toolbar_utils.h"
+ #include "chrome/browser/ui/web_applications/app_browser_controller.h"
+ #include "chrome/common/pref_names.h"
+@@ -53,8 +58,6 @@
+ #import "ui/base/cocoa/window_size_constants.h"
+ #include "ui/base/l10n/l10n_util.h"
+ #include "ui/base/mojom/window_show_state.mojom.h"
+-#include "ui/base/ui_base_features.h"
+-#include "ui/native_theme/native_theme.h"
+ #import "ui/views/cocoa/native_widget_mac_ns_window_host.h"
+ #include "ui/views/interaction/element_tracker_views.h"
+ 
+@@ -92,19 +95,6 @@ bool ShouldHandleKeyboardEvent(const inp
+ 
+ }  // namespace
+ 
+-// NSGlassEffectView intercepts hit testing even when added below the
+-// WebContents NSViews. Returning nil here lets clicks pass through to the
+-// sibling subviews that are supposed to receive them.
+-API_AVAILABLE(macos(26.0))
+-@interface GlassFrameBackgroundView : NSGlassEffectView
+-@end
+-
+-@implementation GlassFrameBackgroundView
+-- (NSView*)hitTest:(NSPoint)point {
+-  return nil;
+-}
+-@end
+-
+ // Bridge Obj-C class for WindowTouchBarDelegate and
+ // BrowserWindowTouchBarController.
+ @interface BrowserWindowTouchBarViewsDelegate
+@@ -149,6 +139,12 @@ BrowserNativeWidgetMac::BrowserNativeWid
+     : views::NativeWidgetMac(browser_widget), browser_view_(browser_view) {
+   CHECK(browser_widget);
+   CHECK(browser_view);
++  pref_change_registrar_.Init(browser_view_->GetProfile()->GetPrefs());
++  pref_change_registrar_.Add(
++      prefs::kHeliumNativeFrameMaterials,
++      base::BindRepeating(
++          &BrowserNativeWidgetMac::OnNativeFrameMaterialsPrefChanged,
++          base::Unretained(this)));
+   if (GetRemoteCocoaApplicationHost()) {
+     // Only add observer on PWA.
+     chrome::AddCommandObserver(browser_view_->browser(), IDC_BACK, this);
+@@ -225,8 +221,9 @@ void BrowserNativeWidgetMac::OnWidgetDes
+   }
+   touch_bar_delegate_ = nullptr;
+   background_view_ = nil;
++  pref_change_registrar_.Reset();
+   browser_view_ = nullptr;
+-  last_preferred_color_scheme_.reset();
++  last_color_mode_.reset();
+   last_theme_color_.reset();
+   NativeWidgetMac::OnWidgetDestroyed(widget);
+ }
+@@ -528,10 +525,8 @@ NativeWidgetMacNSWindow* BrowserNativeWi
+     const remote_cocoa::mojom::CreateWindowParams* params) {
+   CHECK(browser_view_);
+   NativeWidgetMacNSWindow* ns_window = NativeWidgetMac::CreateNSWindow(params);
+-  if (features::IsGlassFrameEnabled()) {
+-    [ns_window setBackgroundColor:[NSColor clearColor]];
+-    [ns_window setOpaque:NO];
+-  }
++  SetNativeFrameMaterialWindowState(
++      ns_window, helium::ShouldUseNativeFrameMaterials(browser_view_));
+   touch_bar_delegate_ = [[BrowserWindowTouchBarViewsDelegate alloc]
+       initWithBrowser:browser_view_->browser()
+                window:ns_window];
+@@ -678,54 +673,71 @@ void BrowserNativeWidgetMac::AnnounceTex
+   }
+ }
+ 
+-void BrowserNativeWidgetMac::UpdateBackground() {
+-  if (!features::IsGlassFrameEnabled()) {
++void BrowserNativeWidgetMac::SetNativeFrameMaterialWindowState(
++    NSWindow* ns_window,
++    bool enabled) {
++  if (!ns_window) {
+     return;
+   }
+ 
+-  if (@available(macOS 26.0, *)) {
+-    auto color_scheme =
+-        browser_view_->GetNativeTheme()->preferred_color_scheme();
+-    auto theme_color =
+-        browser_view_->GetColorProvider()->GetColor(ui::kColorFrameActive);
+-
+-    if (background_view_ && last_preferred_color_scheme_ == color_scheme &&
+-        last_theme_color_ == theme_color) {
+-      return;
+-    }
++  if (enabled) {
++    [ns_window setBackgroundColor:[NSColor clearColor]];
++  } else {
++    [ns_window setBackgroundColor:[NSColor windowBackgroundColor]];
++  }
++  [ns_window setOpaque:!enabled];
++}
+ 
+-    last_preferred_color_scheme_ = color_scheme;
+-    last_theme_color_ = theme_color;
++void BrowserNativeWidgetMac::UpdateBackground() {
++  NSWindow* ns_window = GetNSWindowHost()->GetInProcessNSWindow();
++  const bool should_use_native_frame_materials =
++      helium::ShouldUseNativeFrameMaterials(browser_view_);
++  SetNativeFrameMaterialWindowState(ns_window,
++                                    should_use_native_frame_materials);
+ 
++  if (!should_use_native_frame_materials) {
+     if (background_view_) {
+       [background_view_ removeFromSuperview];
+     }
+     background_view_ = nil;
++    last_color_mode_.reset();
++    last_theme_color_.reset();
++    return;
++  }
++
++  auto color_mode = browser_view_->GetWidget()->GetColorMode();
++  auto theme_color =
++      browser_view_->GetColorProvider()->GetColor(kColorToolbar);
++
++  if (background_view_ && last_color_mode_ == color_mode &&
++      last_theme_color_ == theme_color) {
++    return;
++  }
++
++  last_color_mode_ = color_mode;
++  last_theme_color_ = theme_color;
++
++  if (background_view_) {
++    [background_view_ removeFromSuperview];
++  }
++  background_view_ = nil;
++
++  if (!ns_window) {
++    return;
++  }
+ 
+-    NSWindow* ns_window = GetNSWindowHost()->GetInProcessNSWindow();
+-    if (!ns_window) {
+-      return;
+-    }
+-
+-    NSView* content_view = [ns_window contentView];
+-
+-    NSGlassEffectView* glass_view =
+-        [[GlassFrameBackgroundView alloc] initWithFrame:content_view.bounds];
+-    glass_view.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+-    glass_view.style = NSGlassEffectViewStyleRegular;
+-
+-    CGFloat r = SkColorGetR(theme_color) / 255.0;
+-    CGFloat g = SkColorGetG(theme_color) / 255.0;
+-    CGFloat b = SkColorGetB(theme_color) / 255.0;
+-
+-    glass_view.tintColor = [NSColor colorWithSRGBRed:r
+-                                               green:g
+-                                                blue:b
+-                                               alpha:0.55];
+-
+-    background_view_ = glass_view;
+-    [content_view addSubview:background_view_
+-                  positioned:NSWindowBelow
+-                  relativeTo:nil];
++  NSView* content_view = [ns_window contentView];
++
++  background_view_ = helium::CreateNativeFrameMaterialBackgroundView(
++      content_view.bounds, color_mode, theme_color);
++  [content_view addSubview:background_view_
++                positioned:NSWindowBelow
++                relativeTo:nil];
++}
++
++void BrowserNativeWidgetMac::OnNativeFrameMaterialsPrefChanged() {
++  UpdateBackground();
++  if (browser_view_ && browser_view_->GetWidget()) {
++    browser_view_->GetWidget()->ThemeChanged();
+   }
+ }
+--- a/chrome/browser/ui/views/frame/browser_frame_view_mac.mm
++++ b/chrome/browser/ui/views/frame/browser_frame_view_mac.mm
+@@ -23,7 +23,6 @@
+ #include "chrome/browser/ui/cocoa/fullscreen/fullscreen_menubar_tracker.h"
+ #include "chrome/browser/ui/cocoa/fullscreen/fullscreen_toolbar_controller.h"
+ #include "chrome/browser/ui/color/chrome_color_id.h"
+-#include "chrome/browser/ui/color/chrome_color_provider_utils.h"
+ #include "chrome/browser/ui/exclusive_access/exclusive_access_manager.h"
+ #include "chrome/browser/ui/exclusive_access/fullscreen_controller.h"
+ #include "chrome/browser/ui/fullscreen_util_mac.h"
+@@ -36,6 +35,7 @@
+ #include "chrome/browser/ui/views/frame/caption_button_placeholder_container.h"
+ #include "chrome/browser/ui/views/frame/immersive_mode_controller.h"
+ #include "chrome/browser/ui/views/frame/tab_strip_region_view.h"
++#include "chrome/browser/ui/views/helium/native_frame_materials.h"
+ #include "chrome/browser/ui/views/tabs/tab_strip.h"
+ #include "chrome/browser/ui/views/toolbar/toolbar_view.h"
+ #include "chrome/browser/ui/views/web_apps/frame_toolbar/web_app_frame_toolbar_utils.h"
+@@ -48,10 +48,8 @@
+ #include "components/remote_cocoa/common/native_widget_ns_window.mojom.h"
+ #include "ui/base/hit_test.h"
+ #include "ui/base/theme_provider.h"
+-#include "ui/base/ui_base_features.h"
+ #include "ui/compositor/layer.h"
+ #include "ui/gfx/canvas.h"
+-#include "ui/gfx/color_utils.h"
+ #include "ui/gfx/geometry/insets.h"
+ #include "ui/gfx/geometry/outsets_f.h"
+ #include "ui/gfx/geometry/rect.h"
+@@ -112,7 +110,7 @@ BrowserFrameViewMac::BrowserFrameViewMac
+     }
+   }
+ 
+-  if (features::IsGlassFrameEnabled()) {
++  if (helium::ShouldUseNativeFrameMaterials(browser_view)) {
+     SetPaintToLayer();
+     layer()->SetFillsBoundsOpaquely(false);
+   }
+@@ -327,6 +325,14 @@ void BrowserFrameViewMac::PaintAsActiveC
+ }
+ 
+ void BrowserFrameViewMac::OnThemeChanged() {
++  if (helium::ShouldUseNativeFrameMaterials(GetBrowserView())) {
++    if (!layer()) {
++      SetPaintToLayer();
++    }
++    layer()->SetFillsBoundsOpaquely(false);
++  } else if (layer()) {
++    DestroyLayer();
++  }
+   UpdateCaptionButtonPlaceholderContainerBackground();
+   BrowserFrameView::OnThemeChanged();
+ }
+@@ -489,20 +495,17 @@ void BrowserFrameViewMac::OnPaint(gfx::C
+     return;
+   }
+ 
++  if (helium::ShouldUseNativeFrameMaterials(GetBrowserView())) {
++    return;
++  }
++
+   SkColor frame_color = GetColorProvider()->GetColor(kColorToolbar);
+-  if (features::IsGlassFrameEnabled()) {
+-    const SkAlpha frame_alpha = color_utils::IsDark(frame_color)
+-                                    ? kBrowserFrameAlphaDark
+-                                    : kBrowserFrameAlphaLight;
+-    canvas->DrawColor(SkColorSetA(frame_color, frame_alpha));
+-  } else {
+-    canvas->DrawColor(frame_color);
++  canvas->DrawColor(frame_color);
+ 
+-    auto* theme_service = ThemeServiceFactory::GetForProfile(
+-        GetBrowserView()->browser()->profile());
+-    if (!theme_service->UsingSystemTheme()) {
+-      PaintThemedFrame(canvas);
+-    }
++  auto* theme_service = ThemeServiceFactory::GetForProfile(
++      GetBrowserView()->browser()->profile());
++  if (!theme_service->UsingSystemTheme()) {
++    PaintThemedFrame(canvas);
+   }
+ }
+ 
+@@ -574,7 +577,7 @@ void BrowserFrameViewMac::UpdateCaptionB
+   if (caption_button_placeholder_container_) {
+     caption_button_placeholder_container_->SetBackground(
+         views::CreateSolidBackground(
+-            features::IsGlassFrameEnabled()
++            helium::ShouldUseNativeFrameMaterials(GetBrowserView())
+                 ? SK_ColorTRANSPARENT
+                 : GetColorProvider()->GetColor(kColorToolbar)));
+   }
+--- a/chrome/browser/ui/views/frame/themed_background.cc
++++ b/chrome/browser/ui/views/frame/themed_background.cc
+@@ -11,6 +11,7 @@
+ #include "chrome/browser/ui/color/chrome_color_id.h"
+ #include "chrome/browser/ui/views/frame/browser_view.h"
+ #include "chrome/browser/ui/views/frame/top_container_view.h"
++#include "chrome/browser/ui/views/helium/native_frame_materials.h"
+ #include "chrome/browser/ui/views/tabs/tab_strip.h"
+ #include "chrome/grit/theme_resources.h"
+ #include "ui/base/theme_provider.h"
+@@ -37,6 +38,14 @@ std::pair<int, ui::ColorId> GetThemeChoi
+   }
+ }
+ 
++// Toolbar-themed backgrounds should not paint over native frame materials.
++bool IsTransparentWhenNativeMaterial(
++    const BrowserView* browser_view,
++    ThemedBackground::ThemeChoice theme_choice) {
++  return theme_choice == ThemedBackground::ThemeChoice::kToolbarTheme &&
++         helium::ShouldUseNativeFrameMaterials(browser_view);
++}
++
+ }  // namespace
+ 
+ ThemedBackground::ThemedBackground(BrowserView* browser_view,
+@@ -44,6 +53,10 @@ ThemedBackground::ThemedBackground(Brows
+     : browser_view_(browser_view), theme_choice_(theme_choice) {}
+ 
+ void ThemedBackground::Paint(gfx::Canvas* canvas, views::View* view) const {
++  if (IsTransparentWhenNativeMaterial(browser_view_, theme_choice_)) {
++    return;
++  }
++
+   PaintBackground(canvas, view, browser_view_, theme_choice_);
+ }
+ 
+@@ -113,6 +126,10 @@ std::optional<SkColor> ThemedBackground:
+     ThemeChoice theme_choice) {
+   std::pair<int, ui::ColorId> theme_choice_info =
+       GetThemeChoiceInfo(theme_choice, view);
++  if (IsTransparentWhenNativeMaterial(browser_view, theme_choice)) {
++    return std::nullopt;
++  }
++
+   const bool will_be_painted =
+       WillPaintCustomImage(view, theme_choice_info.first);
+   if (!will_be_painted) {
+--- a/chrome/browser/ui/views/frame/multi_contents_background_view.cc
++++ b/chrome/browser/ui/views/frame/multi_contents_background_view.cc
+@@ -5,6 +5,7 @@
+ #include "chrome/browser/ui/views/frame/multi_contents_background_view.h"
+ 
+ #include "chrome/browser/ui/views/frame/themed_background.h"
++#include "chrome/browser/ui/views/helium/native_frame_materials.h"
+ #include "ui/base/metadata/metadata_impl_macros.h"
+ #include "ui/compositor/layer.h"
+ #include "ui/gfx/geometry/rounded_corners_f.h"
+@@ -12,7 +13,13 @@
+ MultiContentsBackgroundView::MultiContentsBackgroundView(
+     BrowserView* browser_view)
+     : browser_view_(browser_view) {
+-  SetPaintToLayer(ui::LAYER_SOLID_COLOR);
++  const bool use_native_materials =
++      helium::ShouldUseNativeFrameMaterials(browser_view_);
++  SetPaintToLayer(use_native_materials ? ui::LAYER_TEXTURED
++                                       : ui::LAYER_SOLID_COLOR);
++  if (use_native_materials) {
++    layer()->SetFillsBoundsOpaquely(false);
++  }
+ }
+ 
+ MultiContentsBackgroundView::~MultiContentsBackgroundView() = default;
+@@ -30,26 +37,32 @@ const gfx::RoundedCornersF& MultiContent
+ 
+ void MultiContentsBackgroundView::OnThemeChanged() {
+   views::View::OnThemeChanged();
+-  if (auto new_type = CalculateLayerType(); new_type != layer()->type()) {
+-    SetPaintToLayer(new_type);
+-  }
++  SetPaintToLayer(CalculateLayerType());
+ 
+   if (layer()->type() == ui::LAYER_SOLID_COLOR) {
+     UpdateSolidLayerColor();
+   } else {
++    layer()->SetFillsBoundsOpaquely(false);
+     SchedulePaint();
+   }
+ }
+ 
+ void MultiContentsBackgroundView::OnPaint(gfx::Canvas* canvas) {
+   CHECK_EQ(layer()->type(), ui::LAYER_TEXTURED);
++  if (helium::ShouldUseNativeFrameMaterials(browser_view_)) {
++    return;
++  }
+   ThemedBackground::PaintBackground(canvas, this, browser_view_);
+ }
+ 
+ ui::LayerType MultiContentsBackgroundView::CalculateLayerType() const {
++  const bool use_native_materials =
++      helium::ShouldUseNativeFrameMaterials(browser_view_);
+   const bool has_custom_image =
+       !ThemedBackground::GetBackgroundColor(this, browser_view_).has_value();
+-  return has_custom_image ? ui::LAYER_TEXTURED : ui::LAYER_SOLID_COLOR;
++
++  return has_custom_image || use_native_materials ? ui::LAYER_TEXTURED
++                                                  : ui::LAYER_SOLID_COLOR;
+ }
+ 
+ void MultiContentsBackgroundView::UpdateSolidLayerColor() {
+--- a/chrome/browser/ui/views/frame/custom_corners_background.h
++++ b/chrome/browser/ui/views/frame/custom_corners_background.h
+@@ -80,6 +80,10 @@ class CustomCornersBackground : public v
+   // Sets whether the background should be painted.
+   void SetVisible(bool visible);
+ 
++  // Sets whether the background should still be painted when native frame
++  // materials are active.
++  void SetPaintWithNativeFrameMaterials(bool paint);
++
+   // Sets the color to paint the primary area of the view.
+   void SetPrimaryColor(ColorChoice primary_color);
+   ColorChoice primary_color() const { return primary_color_; }
+@@ -128,6 +132,7 @@ class CustomCornersBackground : public v
+   Outline GetMirroredOutline() const;
+ 
+   bool visible_ = true;
++  bool paint_with_native_frame_materials_ = false;
+   float alpha_ = 1.0f;
+   ColorChoice primary_color_;
+   ColorChoice corner_color_;
+--- a/chrome/browser/ui/views/frame/custom_corners_background.cc
++++ b/chrome/browser/ui/views/frame/custom_corners_background.cc
+@@ -14,6 +14,7 @@
+ #include "chrome/browser/ui/views/frame/browser_view.h"
+ #include "chrome/browser/ui/views/frame/browser_widget.h"
+ #include "chrome/browser/ui/views/frame/themed_background.h"
++#include "chrome/browser/ui/views/helium/native_frame_materials.h"
+ #include "third_party/skia/include/core/SkPathBuilder.h"
+ #include "ui/base/ui_base_features.h"
+ #include "ui/color/color_id.h"
+@@ -70,6 +71,15 @@ void CustomCornersBackground::SetVisible
+   view_->SchedulePaint();
+ }
+ 
++void CustomCornersBackground::SetPaintWithNativeFrameMaterials(bool paint) {
++  if (paint_with_native_frame_materials_ == paint) {
++    return;
++  }
++
++  paint_with_native_frame_materials_ = paint;
++  view_->SchedulePaint();
++}
++
+ void CustomCornersBackground::SetPrimaryColor(ColorChoice primary_color) {
+   if (primary_color_ == primary_color) {
+     return;
+@@ -125,6 +135,10 @@ void CustomCornersBackground::Paint(gfx:
+   if (!visible_) {
+     return;
+   }
++  if (helium::ShouldUseNativeFrameMaterials(&browser_view()) &&
++      !paint_with_native_frame_materials_) {
++    return;
++  }
+ 
+   if (alpha_ < 1.0f) {
+     canvas->SaveLayerAlpha(static_cast<uint8_t>(255 * alpha_));
+--- a/chrome/browser/ui/views/frame/vertical_tab_strip_region_view.cc
++++ b/chrome/browser/ui/views/frame/vertical_tab_strip_region_view.cc
+@@ -359,6 +359,7 @@ void VerticalTabStripRegionView::SetZenM
+ 
+   background->SetCorners(corners);
+   background->SetOutline(outline);
++  background->SetPaintWithNativeFrameMaterials(floating);
+ }
+ 
+ bool VerticalTabStripRegionView::WillWrapDueToOverflow(
+--- a/chrome/browser/ui/views/infobars/infobar_container_view.h
++++ b/chrome/browser/ui/views/infobars/infobar_container_view.h
+@@ -34,6 +34,7 @@ class InfoBarContainerView : public view
+   void Layout(PassKey) override;
+   gfx::Size CalculatePreferredSize(
+       const views::SizeBounds& available_size) const override;
++  void OnThemeChanged() override;
+ 
+   // InfobarContainer:
+   void PlatformSpecificAddInfoBar(infobars::InfoBar* infobar,
+@@ -55,6 +56,8 @@ class InfoBarContainerView : public view
+   bool rounded_frame_enabled_ = false;
+   bool leading_side_chrome_attached_ = false;
+   bool trailing_side_chrome_attached_ = false;
++
++  void UpdateBackground();
+ };
+ 
+ #endif  // CHROME_BROWSER_UI_VIEWS_INFOBARS_INFOBAR_CONTAINER_VIEW_H_
+--- a/chrome/browser/ui/views/infobars/infobar_container_view.cc
++++ b/chrome/browser/ui/views/infobars/infobar_container_view.cc
+@@ -9,6 +9,7 @@
+ #include "chrome/browser/ui/browser_element_identifiers.h"
+ #include "chrome/browser/ui/color/chrome_color_id.h"
+ #include "chrome/browser/ui/view_ids.h"
++#include "chrome/browser/ui/views/helium/native_frame_materials.h"
+ #include "chrome/browser/ui/views/infobars/infobar_view.h"
+ #include "chrome/grit/generated_resources.h"
+ #include "ui/accessibility/ax_enums.mojom.h"
+@@ -70,7 +71,8 @@ void ChromeBorder::SetState(bool rounded
+ }
+ 
+ void ChromeBorder::OnPaint(gfx::Canvas* canvas) {
+-  if (rounded_frame_enabled_ || width() <= 0 || height() <= 0) {
++  if (helium::ShouldUseNativeFrameMaterials(this) || rounded_frame_enabled_ ||
++      width() <= 0 || height() <= 0) {
+     return;
+   }
+ 
+@@ -108,8 +110,7 @@ InfoBarContainerView::InfoBarContainerVi
+   AddChildViewRaw(chrome_border_.get());
+   views::SetCascadingColorProviderColor(this, views::kCascadingBackgroundColor,
+                                         kColorToolbar);
+-  SetBackground(
+-      views::CreateSolidBackground(kColorInfoBarContentAreaSeparator));
++  UpdateBackground();
+ 
+   GetViewAccessibility().SetRole(ax::mojom::Role::kGroup);
+   GetViewAccessibility().SetName(
+@@ -140,9 +141,7 @@ void InfoBarContainerView::SetRoundedFra
+   static_cast<ChromeBorder*>(chrome_border_.get())
+       ->SetState(rounded_frame_enabled, leading_side_chrome_attached,
+                  trailing_side_chrome_attached);
+-  SetBackground(views::CreateSolidBackground(
+-      rounded_frame_enabled_ ? kColorToolbar
+-                             : kColorInfoBarContentAreaSeparator));
++  UpdateBackground();
+ }
+ 
+ void InfoBarContainerView::Layout(PassKey) {
+@@ -182,6 +181,11 @@ gfx::Size InfoBarContainerView::Calculat
+   return preferred_size;
+ }
+ 
++void InfoBarContainerView::OnThemeChanged() {
++  views::AccessiblePaneView::OnThemeChanged();
++  UpdateBackground();
++}
++
+ void InfoBarContainerView::PlatformSpecificAddInfoBar(
+     infobars::InfoBar* infobar,
+     size_t position) {
+@@ -255,5 +259,15 @@ void InfoBarContainerView::PlatformSpeci
+   }
+ }
+ 
++void InfoBarContainerView::UpdateBackground() {
++  const ui::ColorId color_id =
++      rounded_frame_enabled_ ? kColorToolbar : kColorInfoBarContentAreaSeparator;
++  if (helium::ShouldUseNativeFrameMaterials(this)) {
++    SetBackground(nullptr);
++    return;
++  }
++  SetBackground(views::CreateSolidBackground(color_id));
++}
++
+ BEGIN_METADATA(InfoBarContainerView)
+ END_METADATA
+--- a/chrome/browser/ui/views/infobars/infobar_view.cc
++++ b/chrome/browser/ui/views/infobars/infobar_view.cc
+@@ -16,7 +16,7 @@
+ #include "chrome/browser/ui/layout_constants.h"
+ #include "chrome/browser/ui/views/chrome_layout_provider.h"
+ #include "chrome/browser/ui/views/chrome_typography.h"
+-#include "chrome/browser/ui/views/frame/browser_view.h"
++#include "chrome/browser/ui/views/helium/native_frame_materials.h"
+ #include "chrome/grit/generated_resources.h"
+ #include "components/infobars/core/infobar_delegate.h"
+ #include "components/strings/grit/components_strings.h"
+@@ -292,8 +292,19 @@ gfx::Size InfoBarView::CalculatePreferre
+ void InfoBarView::OnThemeChanged() {
+   views::View::OnThemeChanged();
+   const auto* cp = GetColorProvider();
+-  const SkColor background_theme_color = cp->GetColor(kColorInfoBarBackground);
+-  SetBackground(views::CreateSolidBackground(background_theme_color));
++  const bool should_use_native_frame_materials =
++      helium::ShouldUseNativeFrameMaterials(this);
++  const SkColor background_theme_color =
++      should_use_native_frame_materials ? SK_ColorTRANSPARENT
++                                        : cp->GetColor(kColorInfoBarBackground);
++  if (should_use_native_frame_materials) {
++    SetBackground(nullptr);
++  } else {
++    SetBackground(views::CreateSolidBackground(background_theme_color));
++  }
++  if (layer()) {
++    layer()->SetFillsBoundsOpaquely(!should_use_native_frame_materials);
++  }
+ 
+   const SkColor text_color = cp->GetColor(kColorInfoBarForeground);
+   for (views::View* child : content_container_->children()) {
+--- a/chrome/browser/ui/views/tabs/new_tab_button.cc
++++ b/chrome/browser/ui/views/tabs/new_tab_button.cc
+@@ -18,12 +18,12 @@
+ #include "chrome/browser/ui/tabs/tab_group_model.h"
+ #include "chrome/browser/ui/tabs/tab_strip_model.h"
+ #include "chrome/browser/ui/ui_features.h"
++#include "chrome/browser/ui/views/helium/native_frame_materials.h"
+ #include "chrome/browser/ui/views/tabs/tab_strip.h"
+ #include "chrome/grit/generated_resources.h"
+ #include "components/tabs/public/tab_group.h"
+ #include "ui/base/interaction/element_identifier.h"
+ #include "ui/base/l10n/l10n_util.h"
+-#include "ui/base/ui_base_features.h"
+ #include "ui/views/view_class_properties.h"
+ 
+ DEFINE_CLASS_ELEMENT_IDENTIFIER_VALUE(NewTabButtonMenuModel, kNewTab);
+@@ -69,7 +69,7 @@ void NewTabButton::ShowContextMenuForVie
+ }
+ 
+ void NewTabButton::UpdateBackground() {
+-  if (features::IsGlassFrameEnabled()) {
++  if (helium::ShouldUseNativeFrameMaterials(browser_)) {
+     SetBackground(views::CreateSolidBackground(SK_ColorTRANSPARENT));
+     return;
+   }
+--- a/chrome/browser/ui/views/tabs/tab_style_views.cc
++++ b/chrome/browser/ui/views/tabs/tab_style_views.cc
+@@ -28,6 +28,7 @@
+ #include "chrome/browser/ui/views/frame/browser_frame_view.h"
+ #include "chrome/browser/ui/views/frame/browser_view.h"
+ #include "chrome/browser/ui/views/frame/themed_background.h"
++#include "chrome/browser/ui/views/helium/native_frame_materials.h"
+ #include "chrome/browser/ui/views/tabs/tab.h"
+ #include "chrome/browser/ui/views/tabs/tab/glow_hover_controller.h"
+ #include "chrome/browser/ui/views/tabs/tab/tab_close_button.h"
+@@ -43,8 +44,8 @@
+ #include "third_party/skia/include/core/SkScalar.h"
+ #include "third_party/skia/include/pathops/SkPathOps.h"
+ #include "ui/base/theme_provider.h"
+-#include "ui/base/ui_base_features.h"
+ #include "ui/gfx/canvas.h"
++#include "ui/gfx/color_utils.h"
+ #include "ui/gfx/favicon_size.h"
+ #include "ui/gfx/font_list.h"
+ #include "ui/gfx/geometry/insets.h"
+@@ -584,7 +585,9 @@ bool TabStyleViewsImpl::IsApparentlyActi
+   if (selection_state == TabStyle::TabSelectionState::kActive) {
+     return true;
+   }
+-  if (!features::IsGlassFrameEnabled() && IsHovering()) {
++  if (!helium::ShouldUseNativeFrameMaterials(
++          tab_->controller()->GetBrowserWindowInterface()) &&
++      IsHovering()) {
+     return GetHoverOpacity() > 0.5f;
+   }
+   return selection_state == TabStyle::TabSelectionState::kSelected;
+@@ -830,7 +833,8 @@ int TabStyleViewsImpl::GetStrokeThicknes
+ bool TabStyleViewsImpl::ShouldPaintTabBackgroundColor(
+     TabStyle::TabSelectionState selection_state,
+     bool has_custom_background) const {
+-  if (features::IsGlassFrameEnabled()) {
++  if (helium::ShouldUseNativeFrameMaterials(
++          tab_->controller()->GetBrowserWindowInterface())) {
+     return selection_state == TabStyle::TabSelectionState::kActive ||
+            GetHoverAnimationValue() > 0.0;
+   }
+@@ -868,7 +872,8 @@ SkColor TabStyleViewsImpl::GetCurrentTab
+       tab()->GetWidget() ? tab()->GetWidget()->ShouldPaintAsActive() : true;
+   const ui::ColorProvider* color_provider = tab()->GetColorProvider();
+ 
+-  if (features::IsGlassFrameEnabled() &&
++  if (helium::ShouldUseNativeFrameMaterials(
++          tab_->controller()->GetBrowserWindowInterface()) &&
+       selection_state != TabStyle::TabSelectionState::kActive) {
+     const SkColor color = tab_style()->GetTabBackgroundColor(
+         selection_state, true, frame_active, color_provider);
+@@ -948,7 +953,8 @@ void TabStyleViewsImpl::PaintTabBackgrou
+   }
+ 
+   if (fill_id.has_value() &&
+-      (!features::IsGlassFrameEnabled() ||
++      (!helium::ShouldUseNativeFrameMaterials(
++           tab_->controller()->GetBrowserWindowInterface()) ||
+        selection_state == TabStyle::TabSelectionState::kActive)) {
+     gfx::ScopedCanvas scale_scoper(canvas);
+     canvas->sk_canvas()->scale(scale, scale);
+--- a/chrome/browser/ui/views/tabs/vertical/vertical_tab_view.h
++++ b/chrome/browser/ui/views/tabs/vertical/vertical_tab_view.h
+@@ -199,6 +199,9 @@ class VerticalTabView : public views::Vi
+ 
+   bool IsFrameActive() const;
+   TabStyle::TabSelectionState GetSelectionState() const;
++  SkColor GetNativeFrameMaterialTabBackgroundColor(
++      TabStyle::TabSelectionState selection_state) const;
++  bool ShouldUseNativeFrameMaterials() const;
+ 
+   bool IsDragging() const;
+ 
+--- a/chrome/browser/ui/views/tabs/vertical/vertical_tab_view.cc
++++ b/chrome/browser/ui/views/tabs/vertical/vertical_tab_view.cc
+@@ -36,6 +36,7 @@
+ #include "chrome/browser/ui/views/frame/browser_view.h"
+ #include "chrome/browser/ui/views/frame/themed_background.h"
+ #include "chrome/browser/ui/views/frame/vertical_tab_strip_region_view.h"
++#include "chrome/browser/ui/views/helium/native_frame_materials.h"
+ #include "chrome/browser/ui/views/tabs/tab/alert_indicator_button.h"
+ #include "chrome/browser/ui/views/tabs/tab/glow_hover_controller.h"
+ #include "chrome/browser/ui/views/tabs/tab/tab_accessibility.h"
+@@ -62,10 +63,10 @@
+ #include "ui/base/metadata/metadata_impl_macros.h"
+ #include "ui/base/models/list_selection_model.h"
+ #include "ui/base/theme_provider.h"
+-#include "ui/base/ui_base_features.h"
+ #include "ui/compositor/layer.h"
+ #include "ui/events/keycodes/keyboard_codes.h"
+ #include "ui/events/types/event_type.h"
++#include "ui/gfx/color_utils.h"
+ #include "ui/gfx/favicon_size.h"
+ #include "ui/gfx/geometry/insets.h"
+ #include "ui/gfx/geometry/rect.h"
+@@ -286,10 +287,19 @@ bool VerticalTabView::IsHoverAnimationAc
+ }
+ 
+ std::optional<SkColor> VerticalTabView::GetBackgroundColor() {
+-  if (active_ || IsHoverAnimationActive() ||
+-      should_fill_background_tab_color_) {
++  const TabStyle::TabSelectionState selection_state = GetSelectionState();
++  const bool hover_animation_active = IsHoverAnimationActive();
++  if (ShouldUseNativeFrameMaterials() &&
++      selection_state != TabStyle::TabSelectionState::kActive) {
++    if (!hover_animation_active) {
++      return std::nullopt;
++    }
++    return GetNativeFrameMaterialTabBackgroundColor(selection_state);
++  }
++
++  if (active_ || hover_animation_active || should_fill_background_tab_color_) {
+     return tab_style_->GetCurrentTabBackgroundColor(
+-        GetSelectionState(), IsHoverAnimationActive(), GetHoverAnimationValue(),
++        selection_state, hover_animation_active, GetHoverAnimationValue(),
+         IsFrameActive(), GetColorProvider());
+   }
+   return std::nullopt;
+@@ -590,9 +600,15 @@ void VerticalTabView::PaintTabBackground
+                                     hovered)) {
+     cc::PaintFlags flags;
+     flags.setAntiAlias(true);
+-    flags.setColor(tab_style_->GetCurrentTabBackgroundColor(
+-        GetSelectionState(), IsHoverAnimationActive(), GetHoverAnimationValue(),
+-        IsFrameActive(), GetColorProvider()));
++    if (ShouldUseNativeFrameMaterials() &&
++        selection_state != TabStyle::TabSelectionState::kActive) {
++      flags.setColor(
++          GetNativeFrameMaterialTabBackgroundColor(selection_state));
++    } else {
++      flags.setColor(tab_style_->GetCurrentTabBackgroundColor(
++          GetSelectionState(), IsHoverAnimationActive(),
++          GetHoverAnimationValue(), IsFrameActive(), GetColorProvider()));
++    }
+     canvas->DrawRect(GetContentsBounds(), flags);
+   }
+ 
+@@ -607,6 +623,11 @@ bool VerticalTabView::ShouldPaintTabBack
+     TabStyle::TabSelectionState selection_state,
+     bool has_custom_background,
+     bool hovered) const {
++  if (ShouldUseNativeFrameMaterials()) {
++    return selection_state == TabStyle::TabSelectionState::kActive ||
++           GetHoverAnimationValue() > 0.0;
++  }
++
+   if (selection_state == TabStyle::TabSelectionState::kActive) {
+     return true;
+   }
+@@ -886,7 +907,7 @@ bool VerticalTabView::IsApparentlyActive
+   if (active_) {
+     return true;
+   }
+-  if (!features::IsGlassFrameEnabled() && hovered_) {
++  if (!ShouldUseNativeFrameMaterials() && hovered_) {
+     return GetHoverOpacity() > 0.5f;
+   }
+   return selected_;
+@@ -1089,6 +1110,13 @@ void VerticalTabView::UpdateThemeColors(
+   if (!tab_interface) {
+     return;
+   }
++  if (helium::ShouldUseNativeFrameMaterials(
++          tab_interface->GetBrowserWindowInterface())) {
++    active_tab_fill_id_.reset();
++    inactive_tab_fill_id_.reset();
++    should_fill_background_tab_color_ = false;
++    return;
++  }
+ 
+   BrowserFrameView* const browser_frame_view =
+       BrowserView::GetBrowserViewForBrowser(
+@@ -1102,10 +1130,8 @@ void VerticalTabView::UpdateThemeColors(
+ 
+   active_tab_fill_id_ = active_tab_fill_id;
+   inactive_tab_fill_id_ = inactive_tab_fill_id;
+-  if (!features::IsGlassFrameEnabled()) {
+-    should_fill_background_tab_color_ = theme_provider->GetDisplayProperty(
+-        ThemeProperties::SHOULD_FILL_BACKGROUND_TAB_COLOR);
+-  }
++  should_fill_background_tab_color_ = theme_provider->GetDisplayProperty(
++      ThemeProperties::SHOULD_FILL_BACKGROUND_TAB_COLOR);
+ }
+ 
+ void VerticalTabView::UpdateColors() {
+@@ -1205,6 +1231,27 @@ TabStyle::TabSelectionState VerticalTabV
+                               : TabStyle::TabSelectionState::kInactive);
+ }
+ 
++// Inactive native-material tabs stay transparent until hover, then blend their
++// hover fill over the material background.
++SkColor VerticalTabView::GetNativeFrameMaterialTabBackgroundColor(
++    TabStyle::TabSelectionState selection_state) const {
++  const SkColor color = tab_style_->GetTabBackgroundColor(
++      selection_state, true, IsFrameActive(), GetColorProvider());
++  return color_utils::AlphaBlend(
++      color, SK_ColorTRANSPARENT,
++      static_cast<float>(GetHoverAnimationValue()));
++}
++
++bool VerticalTabView::ShouldUseNativeFrameMaterials() const {
++  if (!collection_node_) {
++    return false;
++  }
++
++  const tabs::TabInterface* tab_interface = GetTabInterface();
++  return tab_interface && helium::ShouldUseNativeFrameMaterials(
++                              tab_interface->GetBrowserWindowInterface());
++}
++
+ bool VerticalTabView::IsDragging() const {
+   return collection_node_ && collection_node_->GetController() &&
+          collection_node_->GetController()->GetDragHandler().IsViewDragging(

--- a/patches/series
+++ b/patches/series
@@ -315,3 +315,4 @@ helium/ui/hide-pip-live-caption-button.patch
 helium/ui/disable-ink-ripple-effect.patch
 helium/ui/dont-antialias-rects.patch
 helium/ui/fix-windows-ui-position.patch
+helium/ui/native-frame-materials.patch


### PR DESCRIPTION
adds a flagged option for using system's native materials for the browser frame instead of an opaque color. still experimental and will improve in the future.

partially addresses #325

<img width="1454" height="904" alt="image" src="https://github.com/user-attachments/assets/f002e89d-b3cf-4e77-9896-c306259f56bb" />
<img width="1454" height="904" alt="image" src="https://github.com/user-attachments/assets/00e7b20c-ce74-4fb2-a8da-0377469005c3" />

https://github.com/user-attachments/assets/976a290d-45d9-4567-8b04-38b7de5960ff

