### PR TITLE
helium/core/search: add url for reverse image search with google

### DIFF
--- a/patches/helium/core/search/add-kagi-image-search.patch
+++ b/patches/helium/core/search/add-kagi-image-search.patch
@@ -1,6 +1,6 @@
 --- a/third_party/search_engines_data/resources/definitions/prepopulated_engines.json
 +++ b/third_party/search_engines_data/resources/definitions/prepopulated_engines.json
-@@ -197,6 +197,8 @@
+@@ -199,6 +199,8 @@
        "keyword": "kagi.com",
        "search_url": "https://kagi.com/search?q={searchTerms}",
        "suggest_url": "https://kagisuggest.com/api/autosuggest?q={searchTerms}",

--- a/patches/helium/core/search/break-favicons.patch
+++ b/patches/helium/core/search/break-favicons.patch
@@ -36,7 +36,7 @@
        "base_builtin_resource_id": "SEARCH_ENGINE_GOOGLE",
        "search_url": "https://www.google.com/search?q={searchTerms}",
        "suggest_url": "https://www.google.com/complete/search?client=chrome&q={searchTerms}",
-@@ -198,7 +198,7 @@
+@@ -200,7 +200,7 @@
        "search_url": "https://kagi.com/search?q={searchTerms}",
        "suggest_url": "https://kagisuggest.com/api/autosuggest?q={searchTerms}",
        "new_tab_url": "https://kagi.com/",
@@ -45,7 +45,7 @@
        "base_builtin_resource_id": "SEARCH_ENGINE_KAGI",
        "type": "SEARCH_ENGINE_KAGI",
        "id": 115
-@@ -340,7 +340,7 @@
+@@ -342,7 +342,7 @@
      "qwant": {
        "name": "Qwant",
        "keyword": "qwant.com",

--- a/patches/helium/core/search/restore-google.patch
+++ b/patches/helium/core/search/restore-google.patch
@@ -1,6 +1,6 @@
 --- a/third_party/search_engines_data/resources/definitions/prepopulated_engines.json
 +++ b/third_party/search_engines_data/resources/definitions/prepopulated_engines.json
-@@ -171,31 +171,14 @@
+@@ -171,31 +171,16 @@
        "id": 114
      },
  
@@ -32,6 +32,8 @@
 -      "send_x_geo_header": true,
 +      "search_url": "https://www.google.com/search?q={searchTerms}",
 +      "suggest_url": "https://www.google.com/complete/search?client=chrome&q={searchTerms}",
++      "image_url": "https://www.google.com/searchbyimage/upload",
++      "image_url_post_params": "encoded_image={google:imageThumbnail}",
 +      "type": "SEARCH_ENGINE_OTHER",
        "id": 1
      },


### PR DESCRIPTION
closes #339

https://github.com/user-attachments/assets/365f8f87-5a6a-475d-b6f8-ab1e06486490
