### PR TITLE
helium/zen: don't force floating VTS to expand when not attached

### DIFF
--- a/patches/helium/ui/layout/vertical.patch
+++ b/patches/helium/ui/layout/vertical.patch
@@ -1037,7 +1037,7 @@
 +  // when the vertical-vs-horizontal state actually changes; for in-vertical
 +  // property changes (e.g. right-alignment) a layout pass is sufficient.
 +  const bool vertical_initialized =
-+      vertical_tab_strip_region_view_->root_node_for_testing() != nullptr;
++      vertical_tab_strip_region_view_->GetTabStripView() != nullptr;
 +  const bool should_be_vertical = controller->ShouldDisplayVerticalTabs();
 +  if (vertical_initialized == should_be_vertical) {
 +    // Mode is unchanged; just re-layout so alignment-dependent views update.

--- a/patches/helium/ui/layout/zen-mode.patch
+++ b/patches/helium/ui/layout/zen-mode.patch
@@ -160,7 +160,15 @@
      InvalidateLayout();
      return;
    }
-@@ -1635,10 +1723,424 @@ void BrowserView::OnToolbarTabStripState
+@@ -1603,6 +1691,7 @@ void BrowserView::OnVerticalTabStripMode
+   if (should_be_vertical) {
+     horizontal_tab_strip_region_view_->ResetTabStrip();
+     vertical_tab_strip_region_view_->InitializeTabStrip();
++    MaybeExpandVerticalTabStripForZenMode();
+   } else {
+     vertical_tab_strip_region_view_->ResetTabStrip();
+     horizontal_tab_strip_region_view_->InitializeTabStrip();
+@@ -1635,10 +1724,425 @@ void BrowserView::OnToolbarTabStripState
      toolbar_->UpdateToolbarLayout();
    }
  
@@ -174,16 +182,10 @@
 +    return;
 +  }
 +
-+  const bool side_chrome_pinned = IsZenModeSideChromePinned();
-+  if (side_chrome_pinned) {
++  if (IsZenModeSideChromePinned()) {
 +    zen_side_chrome_animation_.Reset(1);
-+  } else if (auto* controller =
-+                 tabs::VerticalTabStripStateController::From(browser_);
-+             controller && controller->IsCollapsed()) {
-+    controller->RequestCollapse(false);
-+  }
-+
-+  if (!side_chrome_pinned) {
++  } else {
++    MaybeExpandVerticalTabStripForZenMode();
 +    UpdateZenModeRevealFromCursor();
 +  }
 +
@@ -221,6 +223,20 @@
 +  InvalidateLayout();
 +}
 +
++// Unpinned sidebar floats in zen mode, so we make sure that VTS is usable
++// in that state by expanding it when it's attached, not pinned, and collapsed.
++void BrowserView::MaybeExpandVerticalTabStripForZenMode() {
++  if (!zen_mode_enabled_ || IsZenModeSideChromePinned() ||
++      !ShouldDrawVerticalTabStrip()) {
++    return;
++  }
++
++  auto* controller = tabs::VerticalTabStripStateController::From(browser_);
++  if (controller && controller->IsCollapsed()) {
++    controller->RequestCollapse(false);
++  }
++}
++
 +void BrowserView::UpdateZenModeState() {
 +  const bool zen_mode_enabled = IsZenModeEnabled();
 +  UpdateZenModeEventMonitor();
@@ -251,14 +267,7 @@
 +    UpdateZenModeReveal(/*reveal_top=*/false, /*reveal_side=*/false);
 +  }
 +
-+  // Force the vertical tab strip expanded when not pinned.
-+  if (auto* controller =
-+          tabs::VerticalTabStripStateController::From(browser_)) {
-+    if (zen_mode_enabled_ && !IsZenModeSideChromePinned() &&
-+        controller->IsCollapsed()) {
-+      controller->RequestCollapse(false);
-+    }
-+  }
++  MaybeExpandVerticalTabStripForZenMode();
 +  UpdateZenCollapseButtonVisibility();
 +
 +  if (!zen_mode_enabled_) {
@@ -585,7 +594,7 @@
  void BrowserView::OnProjectsPanelStateChanged(
      ProjectsPanelStateController* controller) {
    projects_panel_container_->OnProjectsPanelStateChanged(controller);
-@@ -2350,6 +2852,8 @@ void BrowserView::FullscreenStateChanged
+@@ -2350,6 +2854,8 @@ void BrowserView::FullscreenStateChanged
                      !GetFocusManager()->GetFocusedView());
      }
    }
@@ -594,7 +603,7 @@
  }
  
  ToolbarButtonProvider* BrowserView::toolbar_button_provider() {
-@@ -2400,6 +2904,13 @@ void BrowserView::SetFocusToLocationBar(
+@@ -2400,6 +2906,13 @@ void BrowserView::SetFocusToLocationBar(
      return;
    }
  
@@ -608,7 +617,7 @@
    LocationBar* location_bar = GetLocationBar();
    location_bar->FocusLocation(is_user_initiated,
                                /*clear_focus_if_failed=*/true);
-@@ -3083,7 +3594,7 @@ bool BrowserView::IsToolbarVisible() con
+@@ -3083,7 +3596,7 @@ bool BrowserView::IsToolbarVisible() con
  }
  
  bool BrowserView::IsToolbarShowing() const {
@@ -617,7 +626,7 @@
  }
  
  bool BrowserView::IsLocationBarVisible() const {
-@@ -4171,6 +4682,11 @@ void BrowserView::OnWidgetActivationChan
+@@ -4171,6 +4684,11 @@ void BrowserView::OnWidgetActivationChan
      }
    }
  
@@ -629,7 +638,7 @@
    browser_->GetFeatures()
        .extension_keybinding_registry()
        ->OnHostActivationChanged(active);
-@@ -5019,6 +5535,8 @@ void BrowserView::AddedToWidget() {
+@@ -5019,6 +5537,8 @@ void BrowserView::AddedToWidget() {
              base::BindRepeating(&BrowserView::OnToolbarTabStripStateChanged,
                                  base::Unretained(this)));
      OnToolbarTabStripStateChanged(helium_layout_controller);
@@ -638,7 +647,7 @@
    }
  
    UpdateTabSearchBubbleHost();
-@@ -5103,6 +5621,9 @@ void BrowserView::AddedToWidget() {
+@@ -5103,6 +5623,9 @@ void BrowserView::AddedToWidget() {
    // once per browser instance.
    auto* toolbar_button_provider = ToolbarButtonProvider::From(browser_);
    CHECK(toolbar_button_provider);
@@ -648,7 +657,7 @@
  
    // `AutofillBubbleHandlerImpl` depends on the ToolbarButtonProvider so it must
    // be constructed following the check above.
-@@ -5159,6 +5680,8 @@ void BrowserView::AddedToWidget() {
+@@ -5159,6 +5682,8 @@ void BrowserView::AddedToWidget() {
  }
  
  void BrowserView::RemovedFromWidget() {
@@ -657,7 +666,7 @@
    CHECK(GetFocusManager());
    focus_manager_observation_.Reset();
  }
-@@ -5187,6 +5710,14 @@ void BrowserView::OnThemeChanged() {
+@@ -5187,6 +5712,14 @@ void BrowserView::OnThemeChanged() {
    }
  
    FrameColorsChanged();
@@ -672,7 +681,7 @@
  }
  
  bool BrowserView::GetDropFormats(
-@@ -5450,6 +5981,9 @@ void BrowserView::UpdateFastResizeForCon
+@@ -5450,6 +5983,9 @@ void BrowserView::UpdateFastResizeForCon
  }
  
  int BrowserView::GetClientAreaTop() {
@@ -682,7 +691,7 @@
    views::View* top_view = toolbar_;
  
    // Get the top of the top view in browser view coordinates.
-@@ -6061,6 +6595,56 @@ void BrowserView::OnWillChangeFocus(View
+@@ -6061,6 +6597,56 @@ void BrowserView::OnWillChangeFocus(View
  }
  void BrowserView::OnDidChangeFocus(View* focused_before, View* focused_now) {
    UpdateAccessibleNameForRootView();
@@ -830,7 +839,7 @@
    // Testing interface:
    views::View* GetContentsContainerForTest() { return contents_container_; }
    BrowserViewLayout* GetBrowserViewLayoutForTesting() {
-@@ -915,6 +950,26 @@ class BrowserView : public BrowserWindow
+@@ -915,6 +950,27 @@ class BrowserView : public BrowserWindow
  
    void OnProjectsPanelStateChanged(ProjectsPanelStateController* controller);
  
@@ -838,6 +847,7 @@
 +  void OnZenModeSideChromePinnedPrefChanged();
 +  void OnZenModeTopChromePinnedPrefChanged();
 +  void UpdateZenModeState();
++  void MaybeExpandVerticalTabStripForZenMode();
 +  void UpdateZenCollapseButtonVisibility();
 +  void UpdateZenModeEventMonitor();
 +  void StartZenCollapseTimer(base::TimeDelta delay);
@@ -857,7 +867,7 @@
    // Callback for the loading animation(s) associated with this view.
    void LoadingAnimationTimerCallback();
    void LoadingAnimationCallback(base::TimeTicks timestamp);
-@@ -1363,6 +1418,9 @@ class BrowserView : public BrowserWindow
+@@ -1363,6 +1419,9 @@ class BrowserView : public BrowserWindow
    base::ScopedObservation<views::Widget, views::WidgetObserver>
        widget_observation_{this};
  
@@ -867,7 +877,7 @@
    bool interactive_resize_in_progress_ = false;
  
    // The last bounds we notified about in TryNotifyWindowBoundsChanged().
-@@ -1417,6 +1475,14 @@ class BrowserView : public BrowserWindow
+@@ -1417,6 +1476,14 @@ class BrowserView : public BrowserWindow
  
    std::unique_ptr<TabCyclingEventHandler> tab_cycling_event_handler_;
  


### PR DESCRIPTION
and also drop usage of a testing method from vertical patch

fixes #2059