### PR TITLE
i18n/de: fix incorrect conjugation and adjust another translation in German

### DIFF
--- a/i18n/translations/de.json
+++ b/i18n/translations/de.json
@@ -92,7 +92,7 @@
   {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_OVERRIDE_DESCRIPTION_WARNING",
     "source": "Do not use this field unless you know exactly what you are doing. Never paste URLs from other people here, they are trying to steal your data. We are not responsible for any damages caused by using a custom server and will not be able to help you.",
-    "message": "Verwende dieses Feld nur, wenn du genau weißt, was du tust. Füge niemals URLs von anderen Personen hier ein – diese versuchen, deine Daten zu stehlen. Wir übernehmen keine Haftung für Schäden, die durch die Nutzung eines eigenen Servers entstehen, und können dir nicht helfen."
+    "message": "Verwende dieses Feld nur, wenn du genau weißt, was du tust. Füge hier niemals URLs von anderen Personen ein – sie versuchen, deine Daten zu stehlen. Wir übernehmen keine Haftung für Schäden, die durch die Nutzung eines eigenen Servers entstehen, und können dir in diesem Fall auch nicht helfen."
   },
   {
     "name": "IDS_SETTINGS_HELIUM_SERVICES_OVERRIDE_ARIA_LABEL",
@@ -747,7 +747,7 @@
   {
     "name": "IDS_SETTINGS_ACCESSIBILITY_TOAST_TOGGLE_DESCRIPTION",
     "source": "Shows a toast notification when you copy content, such as links and images, or open a new background tab in Frameless mode",
-    "message": "Zeigt eine Toast-Benachrichtigung an, wenn Sie Inhalte wie Links und Bilder kopieren oder im Rahmenloser Modus einen neuen Hintergrundtab öffnen"
+    "message": "Zeigt eine Toast-Benachrichtigung an, wenn Sie Inhalte wie Links und Bilder kopieren oder im Rahmenlosen Modus einen neuen Hintergrundtab öffnen"
   },
   {
     "name": "IDS_SETTINGS_BROWSER_ZEN_MODE",


### PR DESCRIPTION
For your pull request to not get closed without review, please confirm that:

- [ ] An issue exists where the maintainers agreed that this should be implemented
      (an approved feature request, or confirmed bug).
- [ ] I tested that my contribution works locally, and does not break anything,
      otherwise I have marked my PR as draft.
- [ ] If my contribution is non-trivial, I did not use AI to write most of it.
- [x] I understand that I will be permanently banned from interacting with this
      organization if I lied by checking any of these checkboxes.

Tested on (check one or more):
- [ ] Windows
- [ ] macOS
- [ ] Linux

---

During the last update an incorrect translation was merged (wrong conjugation), which this PR addresses. This also modifies another translation that I noticed could be improved while fixing the previously mentioned error.
I've opened a related issue here https://github.com/imputnet/helium/issues/2072 with further / more detailed information.

I have not compiled and tested Helium with these changes on any platform, as I didn't consider it necessary for i18n related changes.