### PR TITLE
helium/ui/native-frame: fix GMeet PiP crash and PWA titlebar

### DIFF
--- a/patches/helium/ui/native-frame-materials.patch
+++ b/patches/helium/ui/native-frame-materials.patch
@@ -560,7 +560,7 @@
    touch_bar_delegate_ = [[BrowserWindowTouchBarViewsDelegate alloc]
        initWithBrowser:browser_view_->browser()
                 window:ns_window];
-@@ -678,54 +673,71 @@ void BrowserNativeWidgetMac::AnnounceTex
+@@ -678,54 +673,75 @@ void BrowserNativeWidgetMac::AnnounceTex
    }
  }
  
@@ -609,27 +609,6 @@
 +    last_theme_color_.reset();
 +    return;
 +  }
-+
-+  auto color_mode = browser_view_->GetWidget()->GetColorMode();
-+  auto theme_color =
-+      browser_view_->GetColorProvider()->GetColor(kColorToolbar);
-+
-+  if (background_view_ && last_color_mode_ == color_mode &&
-+      last_theme_color_ == theme_color) {
-+    return;
-+  }
-+
-+  last_color_mode_ = color_mode;
-+  last_theme_color_ = theme_color;
-+
-+  if (background_view_) {
-+    [background_view_ removeFromSuperview];
-+  }
-+  background_view_ = nil;
-+
-+  if (!ns_window) {
-+    return;
-+  }
  
 -    NSWindow* ns_window = GetNSWindowHost()->GetInProcessNSWindow();
 -    if (!ns_window) {
@@ -656,6 +635,31 @@
 -    [content_view addSubview:background_view_
 -                  positioned:NSWindowBelow
 -                  relativeTo:nil];
++  views::Widget* widget = GetWidget();
++  if (!widget) {
++    return;
++  }
++
++  auto color_mode = widget->GetColorMode();
++  auto theme_color = widget->GetColorProvider()->GetColor(kColorToolbar);
++
++  if (background_view_ && last_color_mode_ == color_mode &&
++      last_theme_color_ == theme_color) {
++    return;
++  }
++
++  last_color_mode_ = color_mode;
++  last_theme_color_ = theme_color;
++
++  if (background_view_) {
++    [background_view_ removeFromSuperview];
++  }
++  background_view_ = nil;
++
++  if (!ns_window) {
++    return;
++  }
++
 +  NSView* content_view = [ns_window contentView];
 +
 +  background_view_ = helium::CreateNativeFrameMaterialBackgroundView(

--- a/patches/helium/ui/native-frame-materials.patch
+++ b/patches/helium/ui/native-frame-materials.patch
@@ -210,7 +210,7 @@
 +#endif  // CHROME_BROWSER_UI_VIEWS_HELIUM_NATIVE_FRAME_MATERIALS_H_
 --- /dev/null
 +++ b/chrome/browser/ui/views/helium/native_frame_materials.cc
-@@ -0,0 +1,46 @@
+@@ -0,0 +1,51 @@
 +// Copyright 2026 The Helium Authors
 +// You can use, redistribute, and/or modify this source code under
 +// the terms of the GPL-3.0 license that can be found in the LICENSE file.
@@ -232,6 +232,11 @@
 +bool ShouldUseNativeFrameMaterials(const BrowserView* browser_view) {
 +#if BUILDFLAG(IS_MAC)
 +  if (!features::HeliumNativeFrameAvailable() || !browser_view) {
++    return false;
++  }
++
++  // Web app windows use their app-defined frame appearance.
++  if (browser_view->GetIsWebAppType()) {
 +    return false;
 +  }
 +


### PR DESCRIPTION
gmeet pip no longer crashes the browser:

https://github.com/user-attachments/assets/66ffa931-35fc-41db-ae10-fb376124f57c

pwa titlebar is no longer transparent:

<img width="1491" height="976" alt="image" src="https://github.com/user-attachments/assets/762a3091-aa11-4b2d-a791-9b8bf96f952c" />

fixes imputnet/helium-macos#284
fixes imputnet/helium-macos#285
