### PR TITLE
helium/zen: don't expand floating VTS before initialization

### DIFF
--- a/patches/helium/ui/layout/zen-mode.patch
+++ b/patches/helium/ui/layout/zen-mode.patch
@@ -168,7 +168,7 @@
    } else {
      vertical_tab_strip_region_view_->ResetTabStrip();
      horizontal_tab_strip_region_view_->InitializeTabStrip();
-@@ -1635,10 +1724,425 @@ void BrowserView::OnToolbarTabStripState
+@@ -1635,10 +1724,428 @@ void BrowserView::OnToolbarTabStripState
      toolbar_->UpdateToolbarLayout();
    }
  
@@ -226,8 +226,11 @@
 +// Unpinned sidebar floats in zen mode, so we make sure that VTS is usable
 +// in that state by expanding it when it's attached, not pinned, and collapsed.
 +void BrowserView::MaybeExpandVerticalTabStripForZenMode() {
++  const bool vertical_initialized =
++      vertical_tab_strip_region_view_ &&
++      vertical_tab_strip_region_view_->GetTabStripView() != nullptr;
 +  if (!zen_mode_enabled_ || IsZenModeSideChromePinned() ||
-+      !ShouldDrawVerticalTabStrip()) {
++      !ShouldDrawVerticalTabStrip() || !vertical_initialized) {
 +    return;
 +  }
 +
@@ -594,7 +597,7 @@
  void BrowserView::OnProjectsPanelStateChanged(
      ProjectsPanelStateController* controller) {
    projects_panel_container_->OnProjectsPanelStateChanged(controller);
-@@ -2350,6 +2854,8 @@ void BrowserView::FullscreenStateChanged
+@@ -2350,6 +2857,8 @@ void BrowserView::FullscreenStateChanged
                      !GetFocusManager()->GetFocusedView());
      }
    }
@@ -603,7 +606,7 @@
  }
  
  ToolbarButtonProvider* BrowserView::toolbar_button_provider() {
-@@ -2400,6 +2906,13 @@ void BrowserView::SetFocusToLocationBar(
+@@ -2400,6 +2909,13 @@ void BrowserView::SetFocusToLocationBar(
      return;
    }
  
@@ -617,7 +620,7 @@
    LocationBar* location_bar = GetLocationBar();
    location_bar->FocusLocation(is_user_initiated,
                                /*clear_focus_if_failed=*/true);
-@@ -3083,7 +3596,7 @@ bool BrowserView::IsToolbarVisible() con
+@@ -3083,7 +3599,7 @@ bool BrowserView::IsToolbarVisible() con
  }
  
  bool BrowserView::IsToolbarShowing() const {
@@ -626,7 +629,7 @@
  }
  
  bool BrowserView::IsLocationBarVisible() const {
-@@ -4171,6 +4684,11 @@ void BrowserView::OnWidgetActivationChan
+@@ -4171,6 +4687,11 @@ void BrowserView::OnWidgetActivationChan
      }
    }
  
@@ -638,7 +641,7 @@
    browser_->GetFeatures()
        .extension_keybinding_registry()
        ->OnHostActivationChanged(active);
-@@ -5019,6 +5537,8 @@ void BrowserView::AddedToWidget() {
+@@ -5019,6 +5540,8 @@ void BrowserView::AddedToWidget() {
              base::BindRepeating(&BrowserView::OnToolbarTabStripStateChanged,
                                  base::Unretained(this)));
      OnToolbarTabStripStateChanged(helium_layout_controller);
@@ -647,7 +650,7 @@
    }
  
    UpdateTabSearchBubbleHost();
-@@ -5103,6 +5623,9 @@ void BrowserView::AddedToWidget() {
+@@ -5103,6 +5626,9 @@ void BrowserView::AddedToWidget() {
    // once per browser instance.
    auto* toolbar_button_provider = ToolbarButtonProvider::From(browser_);
    CHECK(toolbar_button_provider);
@@ -657,7 +660,15 @@
  
    // `AutofillBubbleHandlerImpl` depends on the ToolbarButtonProvider so it must
    // be constructed following the check above.
-@@ -5159,6 +5682,8 @@ void BrowserView::AddedToWidget() {
+@@ -5147,6 +5673,7 @@ void BrowserView::AddedToWidget() {
+           tabs::VerticalTabStripStateController::From(browser_)) {
+     if (vertical_tab_strip_state_controller->ShouldDisplayVerticalTabs()) {
+       vertical_tab_strip_region_view_->InitializeTabStrip();
++      MaybeExpandVerticalTabStripForZenMode();
+     } else {
+       horizontal_tab_strip_region_view_->InitializeTabStrip();
+     }
+@@ -5159,6 +5686,8 @@ void BrowserView::AddedToWidget() {
  }
  
  void BrowserView::RemovedFromWidget() {
@@ -666,7 +677,7 @@
    CHECK(GetFocusManager());
    focus_manager_observation_.Reset();
  }
-@@ -5187,6 +5712,14 @@ void BrowserView::OnThemeChanged() {
+@@ -5187,6 +5716,14 @@ void BrowserView::OnThemeChanged() {
    }
  
    FrameColorsChanged();
@@ -681,7 +692,7 @@
  }
  
  bool BrowserView::GetDropFormats(
-@@ -5450,6 +5983,9 @@ void BrowserView::UpdateFastResizeForCon
+@@ -5450,6 +5987,9 @@ void BrowserView::UpdateFastResizeForCon
  }
  
  int BrowserView::GetClientAreaTop() {
@@ -691,7 +702,7 @@
    views::View* top_view = toolbar_;
  
    // Get the top of the top view in browser view coordinates.
-@@ -6061,6 +6597,56 @@ void BrowserView::OnWillChangeFocus(View
+@@ -6061,6 +6601,56 @@ void BrowserView::OnWillChangeFocus(View
  }
  void BrowserView::OnDidChangeFocus(View* focused_before, View* focused_now) {
    UpdateAccessibleNameForRootView();


### PR DESCRIPTION
follow up to #2068:

the VTS region may be attached before its tab strip view is initialized, so ShouldDrawVerticalTabStrip() alone does not make an expansion attempt safe.

now we check whether VTS was initialized, and re-evaluate expansion after initialization.

fixes #2059
