### PR TITLE
helium/ui/layout: fix VTS resize area visibility

### DIFF
--- a/patches/helium/ui/layout/vertical.patch
+++ b/patches/helium/ui/layout/vertical.patch
@@ -1027,7 +1027,7 @@
  bool BrowserView::ShouldDrawWebAppFrameToolbar() const {
    return !IsUnframedModeEnabled() &&
           GetFrameView()->ShouldShowWebAppFrameToolbar();
-@@ -1601,7 +1587,20 @@ void BrowserView::OnVerticalTabStripMode
+@@ -1601,7 +1587,21 @@ void BrowserView::OnVerticalTabStripMode
          std::move(selection_state));
    }
  
@@ -1041,6 +1041,7 @@
 +  const bool should_be_vertical = controller->ShouldDisplayVerticalTabs();
 +  if (vertical_initialized == should_be_vertical) {
 +    // Mode is unchanged; just re-layout so alignment-dependent views update.
++    vertical_tab_strip_region_view_->InvalidateLayout();
 +    InvalidateLayout();
 +    return;
 +  }
@@ -1049,7 +1050,7 @@
      horizontal_tab_strip_region_view_->ResetTabStrip();
      vertical_tab_strip_region_view_->InitializeTabStrip();
    } else {
-@@ -4234,13 +4233,23 @@ const views::Widget* BrowserView::GetWid
+@@ -4234,13 +4234,23 @@ const views::Widget* BrowserView::GetWid
  }
  
  void BrowserView::CreateTabSearchBubble() {
@@ -1075,7 +1076,7 @@
      tab_search_host->CloseTabSearchBubble();
    }
  }
-@@ -4280,34 +4289,21 @@ void BrowserView::UpdateTabSearchBubbleH
+@@ -4280,34 +4290,21 @@ void BrowserView::UpdateTabSearchBubbleH
      return;
    }
  
@@ -1125,7 +1126,7 @@
    }
  }
  
-@@ -5088,9 +5084,6 @@ void BrowserView::AddedToWidget() {
+@@ -5088,9 +5085,6 @@ void BrowserView::AddedToWidget() {
    layout_views.horizontal_tab_strip_region_view =
        horizontal_tab_strip_region_view_;
    layout_views.vertical_tab_strip_region_view = vertical_tab_strip_region_view_;

--- a/patches/helium/ui/layout/zen-mode.patch
+++ b/patches/helium/ui/layout/zen-mode.patch
@@ -157,10 +157,10 @@
    if (vertical_initialized == should_be_vertical) {
      // Mode is unchanged; just re-layout so alignment-dependent views update.
 +    UpdateZenCollapseButtonVisibility();
+     vertical_tab_strip_region_view_->InvalidateLayout();
      InvalidateLayout();
      return;
-   }
-@@ -1603,6 +1691,7 @@ void BrowserView::OnVerticalTabStripMode
+@@ -1604,6 +1692,7 @@ void BrowserView::OnVerticalTabStripMode
    if (should_be_vertical) {
      horizontal_tab_strip_region_view_->ResetTabStrip();
      vertical_tab_strip_region_view_->InitializeTabStrip();
@@ -168,7 +168,7 @@
    } else {
      vertical_tab_strip_region_view_->ResetTabStrip();
      horizontal_tab_strip_region_view_->InitializeTabStrip();
-@@ -1635,10 +1724,428 @@ void BrowserView::OnToolbarTabStripState
+@@ -1636,10 +1725,428 @@ void BrowserView::OnToolbarTabStripState
      toolbar_->UpdateToolbarLayout();
    }
  
@@ -597,7 +597,7 @@
  void BrowserView::OnProjectsPanelStateChanged(
      ProjectsPanelStateController* controller) {
    projects_panel_container_->OnProjectsPanelStateChanged(controller);
-@@ -2350,6 +2857,8 @@ void BrowserView::FullscreenStateChanged
+@@ -2351,6 +2858,8 @@ void BrowserView::FullscreenStateChanged
                      !GetFocusManager()->GetFocusedView());
      }
    }
@@ -606,7 +606,7 @@
  }
  
  ToolbarButtonProvider* BrowserView::toolbar_button_provider() {
-@@ -2400,6 +2909,13 @@ void BrowserView::SetFocusToLocationBar(
+@@ -2401,6 +2910,13 @@ void BrowserView::SetFocusToLocationBar(
      return;
    }
  
@@ -620,7 +620,7 @@
    LocationBar* location_bar = GetLocationBar();
    location_bar->FocusLocation(is_user_initiated,
                                /*clear_focus_if_failed=*/true);
-@@ -3083,7 +3599,7 @@ bool BrowserView::IsToolbarVisible() con
+@@ -3084,7 +3600,7 @@ bool BrowserView::IsToolbarVisible() con
  }
  
  bool BrowserView::IsToolbarShowing() const {
@@ -629,7 +629,7 @@
  }
  
  bool BrowserView::IsLocationBarVisible() const {
-@@ -4171,6 +4687,11 @@ void BrowserView::OnWidgetActivationChan
+@@ -4172,6 +4688,11 @@ void BrowserView::OnWidgetActivationChan
      }
    }
  
@@ -641,7 +641,7 @@
    browser_->GetFeatures()
        .extension_keybinding_registry()
        ->OnHostActivationChanged(active);
-@@ -5019,6 +5540,8 @@ void BrowserView::AddedToWidget() {
+@@ -5020,6 +5541,8 @@ void BrowserView::AddedToWidget() {
              base::BindRepeating(&BrowserView::OnToolbarTabStripStateChanged,
                                  base::Unretained(this)));
      OnToolbarTabStripStateChanged(helium_layout_controller);
@@ -650,7 +650,7 @@
    }
  
    UpdateTabSearchBubbleHost();
-@@ -5103,6 +5626,9 @@ void BrowserView::AddedToWidget() {
+@@ -5104,6 +5627,9 @@ void BrowserView::AddedToWidget() {
    // once per browser instance.
    auto* toolbar_button_provider = ToolbarButtonProvider::From(browser_);
    CHECK(toolbar_button_provider);
@@ -660,7 +660,7 @@
  
    // `AutofillBubbleHandlerImpl` depends on the ToolbarButtonProvider so it must
    // be constructed following the check above.
-@@ -5147,6 +5673,7 @@ void BrowserView::AddedToWidget() {
+@@ -5148,6 +5674,7 @@ void BrowserView::AddedToWidget() {
            tabs::VerticalTabStripStateController::From(browser_)) {
      if (vertical_tab_strip_state_controller->ShouldDisplayVerticalTabs()) {
        vertical_tab_strip_region_view_->InitializeTabStrip();
@@ -668,7 +668,7 @@
      } else {
        horizontal_tab_strip_region_view_->InitializeTabStrip();
      }
-@@ -5159,6 +5686,8 @@ void BrowserView::AddedToWidget() {
+@@ -5160,6 +5687,8 @@ void BrowserView::AddedToWidget() {
  }
  
  void BrowserView::RemovedFromWidget() {
@@ -677,7 +677,7 @@
    CHECK(GetFocusManager());
    focus_manager_observation_.Reset();
  }
-@@ -5187,6 +5716,14 @@ void BrowserView::OnThemeChanged() {
+@@ -5188,6 +5717,14 @@ void BrowserView::OnThemeChanged() {
    }
  
    FrameColorsChanged();
@@ -692,7 +692,7 @@
  }
  
  bool BrowserView::GetDropFormats(
-@@ -5450,6 +5987,9 @@ void BrowserView::UpdateFastResizeForCon
+@@ -5451,6 +5988,9 @@ void BrowserView::UpdateFastResizeForCon
  }
  
  int BrowserView::GetClientAreaTop() {
@@ -702,7 +702,7 @@
    views::View* top_view = toolbar_;
  
    // Get the top of the top view in browser view coordinates.
-@@ -6061,6 +6601,56 @@ void BrowserView::OnWillChangeFocus(View
+@@ -6062,6 +6602,56 @@ void BrowserView::OnWillChangeFocus(View
  }
  void BrowserView::OnDidChangeFocus(View* focused_before, View* focused_now) {
    UpdateAccessibleNameForRootView();
@@ -1727,7 +1727,7 @@
  #include "chrome/browser/ui/views/tabs/shared/drop_arrow.h"
  #include "chrome/browser/ui/views/tabs/vertical/root_tab_collection_node.h"
  #include "chrome/browser/ui/views/tabs/vertical/tab_collection_node.h"
-@@ -319,7 +320,45 @@ void VerticalTabStripRegionView::SetHasL
+@@ -319,7 +320,46 @@ void VerticalTabStripRegionView::SetHasL
  }
  
  void VerticalTabStripRegionView::SetIsExitingExpandOnHoverForLayout(
@@ -1740,6 +1740,7 @@
 +    return;
 +  }
 +  zen_mode_floating_style_ = floating;
++  UpdateResizeAreaVisibility();
 +  SetClipLayerToVisibleBounds(floating);
 +  UpdateInteriorMargin();
 +
@@ -1774,6 +1775,16 @@
  }
  
  bool VerticalTabStripRegionView::WillWrapDueToOverflow(
+@@ -837,8 +877,7 @@ void VerticalTabStripRegionView::OnResiz
+   }
+ 
+   if (done_resizing) {
+-    resize_area_->SetVisible(!state_controller_->IsCollapsed() ||
+-                             !state_controller_->IsExpandOnHoverEnabled());
++    UpdateResizeAreaVisibility();
+     base::RecordAction(base::UserMetricsAction(
+         new_state.collapsed ? "VerticalTabs_TabStrip_ResizeToCollapsed"
+                             : "VerticalTabs_TabStrip_ResizeToUncollapsed"));
 @@ -979,7 +1018,21 @@ void VerticalTabStripRegionView::ClearTa
  void VerticalTabStripRegionView::UpdateInteriorMargin() {
    const int padding = GetLayoutConstant(
@@ -1797,6 +1808,53 @@
  }
  
  void VerticalTabStripRegionView::OnCollapseStateChanged(
+@@ -988,9 +1041,7 @@ void VerticalTabStripRegionView::OnColla
+   // the collapsing state.
+   bool collapsed = state != tabs::VerticalTabStripCollapseState::kExpanded;
+ 
+-  resize_area_->SetVisible(!collapsed ||
+-                           !state_controller_->IsExpandOnHoverEnabled() ||
+-                           resize_area_->is_resizing());
++  UpdateResizeAreaVisibility();
+ 
+   resize_area_width_ = collapsed ? kCollapsedResizeAreaWidth : kResizeAreaWidth;
+ 
+@@ -1004,6 +1055,22 @@ void VerticalTabStripRegionView::OnColla
+   }
+ }
+ 
++void VerticalTabStripRegionView::UpdateResizeAreaVisibility() {
++  if (zen_mode_floating_style_) {
++    resize_area_->SetVisible(false);
++    return;
++  }
++
++  const bool is_fully_expanded =
++      state_controller_->GetCollapseState() ==
++      tabs::VerticalTabStripCollapseState::kExpanded;
++  const bool can_resize_collapsed_tab_strip =
++      !state_controller_->IsExpandOnHoverEnabled() ||
++      resize_area_->is_resizing();
++
++  resize_area_->SetVisible(is_fully_expanded || can_resize_collapsed_tab_strip);
++}
++
+ void VerticalTabStripRegionView::UpdateColors() {
+   SchedulePaint();
+ }
+@@ -1049,9 +1116,9 @@ void VerticalTabStripRegionView::OnChild
+   hover_tab_selector_->CancelTabTransition();
+ }
+ 
+-void VerticalTabStripRegionView::OnExpandOnHoverEnabledChanged(bool enabled) {
+-  resize_area_->SetVisible(!state_controller_->IsCollapsed() || !enabled ||
+-                           resize_area_->is_resizing());
++void VerticalTabStripRegionView::OnExpandOnHoverEnabledChanged(
++    bool /*enabled*/) {
++  UpdateResizeAreaVisibility();
+   UpdateExpandOnHoverState();
+ }
+ 
 --- a/chrome/browser/ui/views/frame/vertical_tab_strip_region_view.h
 +++ b/chrome/browser/ui/views/frame/vertical_tab_strip_region_view.h
 @@ -99,8 +99,11 @@ class VerticalTabStripRegionView final
@@ -1811,7 +1869,7 @@
    TabDragTarget* GetTabDragTarget(const gfx::Point& point_in_screen);
  
    // views::View:
-@@ -229,8 +232,6 @@ class VerticalTabStripRegionView final
+@@ -229,10 +232,9 @@ class VerticalTabStripRegionView final
    views::View* SetTabStripView(std::unique_ptr<views::View> view);
    void ClearTabStripView(views::View* view);
  
@@ -1819,8 +1877,11 @@
 -
    void OnCollapseStateChanged(
        tabs::VerticalTabStripCollapseState collapse_state);
++  void UpdateResizeAreaVisibility();
  
-@@ -294,6 +295,7 @@ class VerticalTabStripRegionView final
+   void UpdateColors();
+ 
+@@ -294,6 +296,7 @@ class VerticalTabStripRegionView final
  
    // Whether a leading exclusion exists due to window controls.
    bool has_leading_exclusion_ = false;

--- a/patches/helium/ui/native-frame-materials.patch
+++ b/patches/helium/ui/native-frame-materials.patch
@@ -936,7 +936,7 @@
      canvas->SaveLayerAlpha(static_cast<uint8_t>(255 * alpha_));
 --- a/chrome/browser/ui/views/frame/vertical_tab_strip_region_view.cc
 +++ b/chrome/browser/ui/views/frame/vertical_tab_strip_region_view.cc
-@@ -359,6 +359,7 @@ void VerticalTabStripRegionView::SetZenM
+@@ -360,6 +360,7 @@ void VerticalTabStripRegionView::SetZenM
  
    background->SetCorners(corners);
    background->SetOutline(outline);


### PR DESCRIPTION
this PR:
- invalidates the VTS layout when its alignment changes, allowing for the resize area to change sides
- centralizes resize area visibility updates
- explicitly hides the resize area for floating zen-mode VTS and restores it when pinned
- as a result of fixes above, prevents unexpected resizing and collapsing of floating VTS

fixes #2097


https://github.com/user-attachments/assets/881ae1d7-c9e0-4b66-bc89-b042ba2f85c0

