### PR TITLE
helium/settings: fix indents and separators on appearance page

### DIFF
--- a/patches/helium/settings/setup-behavior-settings-page.patch
+++ b/patches/helium/settings/setup-behavior-settings-page.patch
@@ -188,7 +188,19 @@
          <div
              class="hr"
              hidden="[[!showHr_(
-@@ -250,12 +228,6 @@
+@@ -160,11 +138,6 @@
+             </settings-radio-group>
+           </div>
+         </template>
+-        <div
+-            class="hr"
+-            hidden="[[!showHr_(
+-                pageVisibility.homeButton, pageVisibility.bookmarksBar)]]">
+-        </div>
+         <template is="dom-if"
+             if="[[!ntpSimplificationBookmarksBarEnabled_]]">
+           <settings-toggle-button id="showBookmarksBar"
+@@ -250,12 +223,6 @@
              hidden="[[showProjectsPanelEnabled_]]">
          </settings-toggle-button>
  
@@ -201,7 +213,7 @@
          <template is="dom-if" if="[[showCtrlTabMru_]]">
            <settings-toggle-button class="hr" id="ctrlTabMru"
                pref="{{prefs.browser.ctrl_tab_mru}}"
-@@ -370,10 +342,6 @@
+@@ -370,10 +337,6 @@
          </settings-toggle-button>
  </if>
        </div>

--- a/patches/helium/ui/layout/centered-address-bar.patch
+++ b/patches/helium/ui/layout/centered-address-bar.patch
@@ -243,7 +243,7 @@
                pref="{{prefs.helium.browser.vertical_right_aligned}}"
                label="$i18n{tabStripRightAlign}">
            </settings-toggle-button>
-+          <settings-toggle-button
++          <settings-toggle-button class="hr"
 +              hidden="[[!showCenteredLocationBarSetting_(
 +                  prefs.helium.browser.layout.value)]]"
 +              pref="{{prefs.helium.browser.centered_location_bar}}"

--- a/patches/helium/ui/layout/minimal-location-bar.patch
+++ b/patches/helium/ui/layout/minimal-location-bar.patch
@@ -280,7 +280,7 @@
                pref="{{prefs.helium.browser.centered_location_bar}}"
                label="$i18n{centeredLocationBar}">
            </settings-toggle-button>
-+          <settings-toggle-button
++          <settings-toggle-button class="hr"
 +              pref="{{prefs.helium.browser.minimal_location_bar}}"
 +              label="$i18n{minimalLocationBar}">
 +          </settings-toggle-button>

--- a/patches/helium/ui/layout/settings.patch
+++ b/patches/helium/ui/layout/settings.patch
@@ -162,8 +162,8 @@
 +              menu-options="[[browserLayoutOptions_]]">
 +          </settings-dropdown-menu>
 +        </div>
-+        <div class="list-frame hover-card-toggles">
-+          <settings-toggle-button
++        <div class="list-frame indented-toggles">
++          <settings-toggle-button class="hr"
 +              hidden="[[!showVerticalSettings_]]"
 +              pref="{{prefs.helium.browser.vertical_right_aligned}}"
 +              label="$i18n{tabStripRightAlign}">
@@ -173,7 +173,7 @@
          <div
              class="hr"
              hidden="[[!showHr_(
-@@ -171,61 +190,6 @@
+@@ -166,61 +185,6 @@
            </div>
          </template>
  

--- a/patches/helium/ui/layout/zen-mode-wiring.patch
+++ b/patches/helium/ui/layout/zen-mode-wiring.patch
@@ -77,19 +77,19 @@
            </settings-toggle-button>
          </div>
  
-+        <settings-toggle-button
++        <settings-toggle-button class="hr"
 +            pref="{{prefs.helium.browser.zen_mode}}"
 +            label="$i18n{browserZenMode}"
 +            sub-label="$i18n{browserZenModeDescription}">
 +        </settings-toggle-button>
-+        <div class="list-frame hover-card-toggles"
++        <div class="list-frame indented-toggles"
 +            hidden="[[!prefs.helium.browser.zen_mode.value]]">
-+          <settings-toggle-button
++          <settings-toggle-button class="hr"
 +              pref="{{prefs.helium.browser.zen_mode_sidebar_pinned}}"
 +              hidden="[[!showVerticalSettings_]]"
 +              label="$i18n{zenModePinSidebar}">
 +          </settings-toggle-button>
-+          <settings-toggle-button
++          <settings-toggle-button class="hr"
 +              pref="{{prefs.helium.browser.zen_mode_top_chrome_pinned}}"
 +              label="$i18n{zenModePinToolbar}">
 +          </settings-toggle-button>


### PR DESCRIPTION
- made indented toggles for layout/frameless options use the `indented-toggles` class to align with the rest of the page.
- added separators between toggles where it makes sense. 
- removed an extra separator before the bookmark bar row.

before:
<img width="1300" height="820" alt="image" src="https://github.com/user-attachments/assets/fc838b89-654a-43d2-8322-171cfa3a9f49" />

after:
<img width="1254" height="885" alt="image" src="https://github.com/user-attachments/assets/903e50b9-428b-40be-8d6b-4fd71cb27192" />

