### PR TITLE
ci/i18n-notify: skip if running in fork pr

### DIFF
--- a/.github/workflows/i18n-notify.yml
+++ b/.github/workflows/i18n-notify.yml
@@ -11,6 +11,8 @@ permissions:
 jobs:
   notify:
     runs-on: ubuntu-latest
+    # skip if the PR is from a fork
+    if: github.event.pull_request.head.repo.full_name == github.repository
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       PR: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
on: pull_request token has only readonly permissions when running in a fork, and i don't want to ever use pull_request_target, so just kill this workflow if it's running in a pr which comes from a fork

