### PR TITLE
helium/core/kb-shortcuts: preserve delayed macOS shortcuts

### DIFF
--- a/patches/helium/core/custom-keyboard-shortcuts.patch
+++ b/patches/helium/core/custom-keyboard-shortcuts.patch
@@ -1741,35 +1741,17 @@
    // clang-format off
    static base::NoDestructor<std::vector<KeyboardShortcutData>> keys({
      // cmd    shift  cntrl  option vkeycode               command
-@@ -183,6 +183,39 @@ const std::vector<KeyboardShortcutData>&
+@@ -183,6 +183,21 @@ const std::vector<KeyboardShortcutData>&
    return *keys;
  }
  
-+namespace {
-+
-+const std::vector<KeyboardShortcutData>&
-+GetShortcutsNotPresentInMainMenuForShortcutSettings() {
-+  static const base::NoDestructor<std::vector<KeyboardShortcutData>> keys([]() {
-+    std::vector<KeyboardShortcutData> result =
-+        GetShortcutsNotPresentInMainMenu();
-+    const std::vector<KeyboardShortcutData>& delayed_shortcuts =
-+        GetDelayedShortcutsNotPresentInMainMenuImpl();
-+    result.insert(result.end(), delayed_shortcuts.begin(),
-+                  delayed_shortcuts.end());
-+    return result;
-+  }());
-+  return *keys;
-+}
-+
-+}  // namespace
-+
 +const std::vector<KeyboardShortcutAcceleratorData>&
 +GetShortcutSettingsAcceleratorsNotPresentInMainMenu() {
 +  static const base::NoDestructor<std::vector<KeyboardShortcutAcceleratorData>>
 +      accelerators([]() {
 +        std::vector<KeyboardShortcutAcceleratorData> result;
 +        for (const KeyboardShortcutData& shortcut :
-+             GetShortcutsNotPresentInMainMenuForShortcutSettings()) {
++             GetShortcutsNotPresentInMainMenu()) {
 +          result.push_back(
 +              {shortcut.chrome_command, AcceleratorFromShortcut(shortcut)});
 +        }
@@ -1781,7 +1763,7 @@
  const std::vector<NSMenuItem*>& GetMenuItemsNotPresentInMainMenu() {
    static base::NoDestructor<std::vector<NSMenuItem*>> menu_items([]() {
      std::vector<NSMenuItem*> menu_items;
-@@ -241,7 +274,7 @@ int DelayedWebContentsCommandForKeyEvent
+@@ -241,7 +256,7 @@ int DelayedWebContentsCommandForKeyEvent
  
    // Scan through keycodes and see if it corresponds to one of the non-menu
    // shortcuts.


### PR DESCRIPTION
and exclude delayed macOS shortcuts (such as Cmd+Left/Cmd+Right) from the default accelerator map

fixes imputnet/helium-macos#254


https://github.com/user-attachments/assets/d050b217-afb5-4e56-903c-101e2ee34211

