### PR TITLE
helium/bangs: fix dangling callbacks in bang loading

### DIFF
--- a/patches/helium/core/add-native-bangs.patch
+++ b/patches/helium/core/add-native-bangs.patch
@@ -153,7 +153,7 @@
    switch (t_url->policy_origin()) {
      case TemplateURLData::PolicyOrigin::kDefaultSearchProvider:
        return false;
-@@ -1644,11 +1658,37 @@ void TemplateURLService::Load() {
+@@ -1644,11 +1658,39 @@ void TemplateURLService::Load() {
  
    if (web_data_service_) {
      load_handle_ = web_data_service_->GetKeywords(this);
@@ -165,8 +165,10 @@
  
 +void TemplateURLService::LoadBangs() {
 +  VLOG(2) << "LoadBangs() called";
-+  bang_manager_->LoadBangs(url_loader_factory_, prefs_.get(),
-+    base::BindOnce(&TemplateURLService::BangsLoadedCallback, base::Unretained(this)));
++  bang_manager_->LoadBangs(
++      url_loader_factory_, prefs_.get(),
++      base::BindOnce(&TemplateURLService::BangsLoadedCallback,
++                     weak_ptr_factory_.GetWeakPtr()));
 +}
 +
 +void TemplateURLService::BangsLoadedCallback() {
@@ -191,7 +193,7 @@
  base::CallbackListSubscription TemplateURLService::RegisterOnLoadedCallback(
      base::OnceClosure callback) {
    return loaded_ ? base::CallbackListSubscription()
-@@ -2636,6 +2676,13 @@ void TemplateURLService::Init() {
+@@ -2636,6 +2678,13 @@ void TemplateURLService::Init() {
            &TemplateURLService::OnDefaultSearchProviderGUIDChanged,
            base::Unretained(this)));
  
@@ -377,7 +379,8 @@
 +
 +    url_loader_->DownloadToString(
 +        url_loader_factory.get(),
-+        base::BindOnce(&BangManager::OnSimpleLoaderComplete, base::Unretained(this)),
++        base::BindOnce(&BangManager::OnSimpleLoaderComplete,
++                       weak_ptr_factory_.GetWeakPtr()),
 +        5e6 /* 5 MB */
 +    );
 +}
@@ -484,11 +487,10 @@
 +    return bangs_;
 +}
 +
-+}
-+
++}  // namespace Bangs
 --- /dev/null
 +++ b/components/search_engines/template_url_bang_manager.h
-@@ -0,0 +1,75 @@
+@@ -0,0 +1,76 @@
 +// Copyright 2025 The Helium Authors
 +// You can use, redistribute, and/or modify this source code under
 +// the terms of the GPL-3.0 license that can be found in the LICENSE file.
@@ -550,15 +552,16 @@
 +        void LoadManifestFromString(const std::string& manifest);
 +        BangCategory GetCategoryFromJSONObject(std::string_view sc) const;
 +
-+        // Weak factory for callbacks.
-+        base::WeakPtrFactory<BangManager> weak_ptr_factory_{this};
 +        // SimpleURLLoader instance.
 +        std::unique_ptr<network::SimpleURLLoader> url_loader_;
 +
 +        std::vector<Bang> bangs_;
-+        bool load_pending_;
++        bool load_pending_ = false;
 +        std::vector<base::OnceClosure> callbacks_;
 +        std::map<size_t, BangCategory> category_map_;
++
++        // Weak factory for callbacks.
++        base::WeakPtrFactory<BangManager> weak_ptr_factory_{this};
 +    };
 +}
 +


### PR DESCRIPTION
use weak pointers async callbacks instead of base::Unretained(this), and move BangManager's weakptrfactory to the end of the class so callbacks are invalidated before other members are destroyed

fixes #1030
