### PR TITLE
helium/ui: fix macOS hit test guard during teardown

### DIFF
--- a/patches/helium/ui/toolbar-window-frame-hit-test.patch
+++ b/patches/helium/ui/toolbar-window-frame-hit-test.patch
@@ -5,8 +5,8 @@
  int BrowserView::NonClientHitTest(const gfx::Point& point) {
  #if BUILDFLAG(IS_MAC)
 +  // AppKit can re-enter hit testing while the browser widget is being torn
-+  // down, after this view has been detached from its widget.
-+  if (!GetWidget()) {
++  // down, either before or after this view has been detached from its widget.
++  if (!browser_widget_ || !GetWidget()) {
 +    return HTNOWHERE;
 +  }
 +


### PR DESCRIPTION
AppKit can re-enter hit testing while `BrowserWidget` is being destroyed. At that point `browser_widget_` has already been cleared, but `BrowserView` may still be attached, so `GetWidget()` remains non-null.

Also check `browser_widget_` to avoid dereferencing it during teardown.

fixes #2129