### PR TITLE
helium/noise: add settings for fingerprinting protection

### DIFF
--- a/i18n/source.gen.json
+++ b/i18n/source.gen.json
@@ -787,6 +787,54 @@
     "message": "Send automatically"
   },
   {
+    "name": "IDS_SETTINGS_NOISE",
+    "source": "chrome/app/settings_strings.grdp",
+    "context": "Title of the settings page for Helium's fingerprinting protection feature.",
+    "message": "Fingerprinting protection"
+  },
+  {
+    "name": "IDS_SETTINGS_NOISE_LINK_DESCRIPTION",
+    "source": "chrome/app/settings_strings.grdp",
+    "context": "Description of the fingerprinting protection link on the Privacy and security settings page.",
+    "message": "Manage how Helium protects you against fingerprinting"
+  },
+  {
+    "name": "IDS_SETTINGS_NOISE_TOGGLE_DESCRIPTION",
+    "source": "chrome/app/settings_strings.grdp",
+    "context": "Description of the global fingerprinting protection toggle.",
+    "message": "Make it harder for sites to fingerprint your browser and device"
+  },
+  {
+    "name": "IDS_SETTINGS_NOISE_DESCRIPTION",
+    "source": "chrome/app/settings_strings.grdp",
+    "context": "Description of how Helium protects against browser fingerprinting.",
+    "message": "When fingerprinting protection is enabled, Helium adds noise to certain browser features to make it harder for sites to track and profile you. Each site sees consistent randomized information during your browsing session to reduce the chances of detection."
+  },
+  {
+    "name": "IDS_SETTINGS_NOISE_DISCLAIMER",
+    "source": "chrome/app/settings_strings.grdp",
+    "context": "Disclaimer shown below the fingerprinting protection description explaining that Helium makes fingerprint recovery harder but cannot prevent fingerprinting completely.",
+    "message": "Fingerprinting cannot be fully prevented, but Helium's analysis defenses make it harder to recover the original fingerprint."
+  },
+  {
+    "name": "IDS_SETTINGS_NOISE_CUSTOM_DESCRIPTION",
+    "source": "chrome/app/settings_strings.grdp",
+    "context": "General explanation of fingerprinting protection site rules and wildcard behavior.",
+    "message": "When the general fingerprinting protection feature is enabled, sites listed below follow a custom setting. Inserting \"[*.]\" before a domain name applies it to the entire domain."
+  },
+  {
+    "name": "IDS_SETTINGS_NOISE_EXCEPTIONS_TITLE",
+    "source": "chrome/app/settings_strings.grdp",
+    "context": "Title above the list of sites where fingerprinting protection is disabled.",
+    "message": "Sites without fingerprinting protection"
+  },
+  {
+    "name": "IDS_SETTINGS_NOISE_ALLOW_OVERRIDES_TITLE",
+    "source": "chrome/app/settings_strings.grdp",
+    "context": "Title above the list of sites where fingerprinting protection is explicitly allowed, overriding broader site exceptions.",
+    "message": "Overrides to allow fingerprinting protection"
+  },
+  {
     "name": "IDS_POLICY_SOURCE_HOP",
     "source": "components/policy_strings.grdp",
     "context": "Indicates that the policy originates from Helium defaults.",
@@ -1073,6 +1121,42 @@
     "source": "chrome/app/settings_strings.grdp",
     "context": "Label for the checkbox which shows the current page zoom percentage in the address bar.",
     "message": "Show the zoom indicator in the address bar"
+  },
+  {
+    "name": "IDS_PAGE_INFO_HELIUM_NOISE_HEADER",
+    "source": "components/page_info_strings.grdp",
+    "context": "The title of the fingerprinting protection row and subpage in Page Info.",
+    "message": "Fingerprinting protection"
+  },
+  {
+    "name": "IDS_PAGE_INFO_HELIUM_NOISE_TOOLTIP",
+    "source": "components/page_info_strings.grdp",
+    "context": "Tooltip for the fingerprinting protection row in Page Info.",
+    "message": "Manage fingerprinting protection for this site"
+  },
+  {
+    "name": "IDS_PAGE_INFO_HELIUM_NOISE_DESCRIPTION",
+    "source": "components/page_info_strings.grdp",
+    "context": "Explanation of how Helium fingerprinting protection works.",
+    "message": "When fingerprinting protection is enabled, Helium adds noise to certain browser features to make it harder for sites to track and profile you."
+  },
+  {
+    "name": "IDS_PAGE_INFO_HELIUM_NOISE_BREAKAGE",
+    "source": "components/page_info_strings.grdp",
+    "context": "Explanation of how disabling Helium's fingerprinting protection may fix privacy-invasive websites, but will reduce user's privacy.",
+    "message": "Turning off the protection will reduce your privacy, but may fix site features that require fingerprinting."
+  },
+  {
+    "name": "IDS_PAGE_INFO_HELIUM_NOISE_GLOBALLY_DISABLED",
+    "source": "components/page_info_strings.grdp",
+    "context": "Explanation shown when the site toggle is unavailable because fingerprinting protection is disabled globally.",
+    "message": "Fingerprinting protection is turned off in Helium settings."
+  },
+  {
+    "name": "IDS_PAGE_INFO_HELIUM_NOISE_SETTINGS_BUTTON",
+    "source": "components/page_info_strings.grdp",
+    "context": "A button label that opens Helium's global fingerprinting protection settings page.",
+    "message": "Manage fingerprinting protection"
   },
   {
     "name": "IDS_CONTENT_CONTEXT_SYSTEM_TRANSLATE",

--- a/patches/helium/core/noise/core.patch
+++ b/patches/helium/core/noise/core.patch
@@ -82,7 +82,7 @@
  BLINK_COMMON_EXPORT BASE_DECLARE_FEATURE(kAIPageContentIncludePopupWindows);
 --- /dev/null
 +++ b/content/browser/helium_noise/noise_token_data.cc
-@@ -0,0 +1,112 @@
+@@ -0,0 +1,106 @@
 +// Copyright 2026 The Helium Authors
 +// You can use, redistribute, and/or modify this source code under
 +// the terms of the GPL-3.0 license that can be found in the LICENSE file.
@@ -93,25 +93,19 @@
 +
 +#include "content/browser/helium_noise/noise_token_data.h"
 +
++#include <array>
 +#include <cstdint>
 +#include <memory>
++#include <string>
 +#include <string_view>
 +
 +#include "base/containers/span.h"
-+#include "base/hash/hash.h"
 +#include "base/numerics/byte_conversions.h"
-+#include "base/strings/strcat.h"
-+#include "base/strings/string_number_conversions.h"
-+#include "base/supports_user_data.h"
-+#include "base/types/pass_key.h"
++#include "base/rand_util.h"
 +#include "base/unguessable_token.h"
 +#include "content/public/browser/browser_context.h"
 +#include "crypto/hash.h"
-+#include "net/base/network_anonymization_key.h"
-+#include "net/base/schemeful_site.h"
-+#include "third_party/blink/public/common/features.h"
 +#include "url/origin.h"
-+#include "url/scheme_host_port.h"
 +
 +namespace content {
 +
@@ -197,7 +191,7 @@
 +}  // namespace content
 --- /dev/null
 +++ b/content/browser/helium_noise/noise_token_data.h
-@@ -0,0 +1,50 @@
+@@ -0,0 +1,53 @@
 +// Copyright 2026 The Helium Authors
 +// You can use, redistribute, and/or modify this source code under
 +// the terms of the GPL-3.0 license that can be found in the LICENSE file.
@@ -209,15 +203,18 @@
 +#ifndef CONTENT_BROWSER_HELIUM_NOISE_NOISE_TOKEN_DATA_H_
 +#define CONTENT_BROWSER_HELIUM_NOISE_NOISE_TOKEN_DATA_H_
 +
-+#include <cstdint>
-+
 +#include "base/containers/flat_map.h"
-+#include "base/rand_util.h"
-+#include "content/public/browser/browser_context.h"
++#include "base/supports_user_data.h"
++#include "content/common/content_export.h"
 +#include "third_party/blink/public/common/helium_noise/noise_token.h"
-+#include "url/origin.h"
++
++namespace url {
++class Origin;
++}  // namespace url
 +
 +namespace content {
++
++class BrowserContext;
 +
 +// A user data class that generates and stores BrowserContext-associated noise
 +// tokens used for noising fingerprintable data.
@@ -311,7 +308,7 @@
 +}  // namespace blink
 --- /dev/null
 +++ b/third_party/blink/renderer/core/helium_noise/helium_noise_hash.h
-@@ -0,0 +1,44 @@
+@@ -0,0 +1,43 @@
 +// Copyright 2026 The Helium Authors
 +// You can use, redistribute, and/or modify this source code under
 +// the terms of the GPL-3.0 license that can be found in the LICENSE file.
@@ -326,7 +323,6 @@
 +#include <cstdint>
 +
 +#include "third_party/blink/renderer/core/core_export.h"
-+#include "third_party/blink/renderer/platform/wtf/text/wtf_string.h"
 +
 +namespace blink {
 +
@@ -471,7 +467,7 @@
 +};
 --- /dev/null
 +++ b/third_party/blink/public/common/helium_noise/noise_token_mojom_traits.h
-@@ -0,0 +1,63 @@
+@@ -0,0 +1,66 @@
 +// Copyright 2026 The Helium Authors
 +// You can use, redistribute, and/or modify this source code under
 +// the terms of the GPL-3.0 license that can be found in the LICENSE file.
@@ -483,8 +479,11 @@
 +#ifndef THIRD_PARTY_BLINK_PUBLIC_COMMON_HELIUM_NOISE_NOISE_TOKEN_MOJOM_TRAITS_H_
 +#define THIRD_PARTY_BLINK_PUBLIC_COMMON_HELIUM_NOISE_NOISE_TOKEN_MOJOM_TRAITS_H_
 +
-+#include "base/notreached.h"
++#include <cstdint>
 +
++#include "base/notreached.h"
++#include "mojo/public/cpp/bindings/enum_traits.h"
++#include "mojo/public/cpp/bindings/struct_traits.h"
 +#include "third_party/blink/public/common/common_export.h"
 +#include "third_party/blink/public/common/helium_noise/noise_token.h"
 +#include "third_party/blink/public/mojom/helium_noise/noise_token.mojom-shared.h"
@@ -506,7 +505,7 @@
 +  }
 +
 +  static blink::HeliumNoiseFeature FromMojom(
-+                        blink::mojom::HeliumNoiseFeature input) {
++      blink::mojom::HeliumNoiseFeature input) {
 +    switch (input) {
 +      case blink::mojom::HeliumNoiseFeature::kCanvas:
 +        return blink::HeliumNoiseFeature::kCanvas;
@@ -535,6 +534,17 @@
 +}  // namespace mojo
 +
 +#endif  // THIRD_PARTY_BLINK_PUBLIC_COMMON_HELIUM_NOISE_NOISE_TOKEN_MOJOM_TRAITS_H_
+--- a/third_party/blink/public/common/BUILD.gn
++++ b/third_party/blink/public/common/BUILD.gn
+@@ -161,6 +161,8 @@ source_set("headers") {
+     "frame/user_activation_state.h",
+     "frame/user_activation_update_source.h",
+     "frame/view_transition_state.h",
++    "helium_noise/noise_token.h",
++    "helium_noise/noise_token_mojom_traits.h",
+     "history/session_history_constants.h",
+     "indexeddb/indexed_db_default_mojom_traits.h",
+     "indexeddb/indexeddb_key.h",
 --- /dev/null
 +++ b/third_party/blink/public/mojom/helium_noise/BUILD.gn
 @@ -0,0 +1,40 @@
@@ -580,14 +590,14 @@
 +}
 --- a/third_party/blink/public/mojom/BUILD.gn
 +++ b/third_party/blink/public/mojom/BUILD.gn
-@@ -325,6 +325,7 @@ mojom("mojom_platform") {
-     "//skia/public/mojom",
+@@ -326,6 +326,7 @@ mojom("mojom_platform") {
      "//third_party/blink/public/mojom/content_extraction",
      "//third_party/blink/public/mojom/fingerprinting_protection",
-+    "//third_party/blink/public/mojom/helium_noise",
      "//third_party/blink/public/mojom/gpu",
++    "//third_party/blink/public/mojom/helium_noise",
      "//third_party/blink/public/mojom/origin_trials:origin_trial_feature",
      "//third_party/blink/public/mojom/origin_trials:origin_trial_state",
+     "//third_party/blink/public/mojom/quota",
 @@ -1400,6 +1401,7 @@ mojom("mojom_core") {
      "//services/viz/public/mojom",
      "//skia/public/mojom",
@@ -1005,7 +1015,15 @@
  }
 --- a/content/browser/renderer_host/navigation_request.h
 +++ b/content/browser/renderer_host/navigation_request.h
-@@ -1529,6 +1529,16 @@ class CONTENT_EXPORT NavigationRequest
+@@ -80,6 +80,7 @@
+ #include "services/network/public/mojom/shared_dictionary_access_observer.mojom.h"
+ #include "services/network/public/mojom/trust_token_access_observer.mojom-shared.h"
+ #include "services/network/public/mojom/web_sandbox_flags.mojom-shared.h"
++#include "third_party/blink/public/common/helium_noise/noise_token.h"
+ #include "third_party/blink/public/common/runtime_feature_state/runtime_feature_state_context.h"
+ #include "third_party/blink/public/common/tokens/tokens.h"
+ #include "third_party/blink/public/mojom/confidence_level.mojom.h"
+@@ -1529,6 +1530,16 @@ class CONTENT_EXPORT NavigationRequest
  
    bool is_ad_tagged() const { return is_ad_tagged_; }
  
@@ -1022,7 +1040,7 @@
    // Called when the browser process is about to process beforeunload handlers
    // for this navigation, including sending an IPC to the renderer process to
    // run beforeunload handlers when necessary.
-@@ -3612,6 +3622,10 @@ class CONTENT_EXPORT NavigationRequest
+@@ -3612,6 +3623,10 @@ class CONTENT_EXPORT NavigationRequest
    blink::mojom::ConfidenceLevel confidence_level_ =
        blink::mojom::ConfidenceLevel::kHigh;
  
@@ -1075,7 +1093,15 @@
    std::optional<SkColor> main_document_theme_color_;
 --- a/content/browser/renderer_host/render_frame_host_impl.cc
 +++ b/content/browser/renderer_host/render_frame_host_impl.cc
-@@ -12801,6 +12801,22 @@ void RenderFrameHostImpl::CommitNavigati
+@@ -284,6 +284,7 @@
+ #include "third_party/blink/public/common/frame/fenced_frame_sandbox_flags.h"
+ #include "third_party/blink/public/common/frame/frame_owner_element_type.h"
+ #include "third_party/blink/public/common/frame/frame_policy.h"
++#include "third_party/blink/public/common/helium_noise/noise_token.h"
+ #include "third_party/blink/public/common/loader/inter_process_time_ticks_converter.h"
+ #include "third_party/blink/public/common/loader/resource_type_util.h"
+ #include "third_party/blink/public/common/messaging/transferable_message.h"
+@@ -12801,6 +12802,22 @@ void RenderFrameHostImpl::CommitNavigati
      }
    }
  
@@ -1098,7 +1124,7 @@
    bool is_srcdoc = common_params->url.IsAboutSrcdoc();
    if (is_srcdoc) {
      // TODO(wjmaclean): initialize this in NavigationRequest's constructor
-@@ -16409,6 +16425,15 @@ bool RenderFrameHostImpl::DidCommitNavig
+@@ -16409,6 +16426,15 @@ bool RenderFrameHostImpl::DidCommitNavig
      document_associated_data_->owned_page()->set_last_main_document_source_id(
          ukm::ConvertToSourceId(navigation_request->GetNavigationId(),
                                 ukm::SourceIdType::NAVIGATION_ID));
@@ -1116,7 +1142,15 @@
  #if BUILDFLAG(IS_ANDROID)
 --- a/content/browser/renderer_host/render_view_host_impl.cc
 +++ b/content/browser/renderer_host/render_view_host_impl.cc
-@@ -453,6 +453,17 @@ bool RenderViewHostImpl::CreateRenderVie
+@@ -87,6 +87,7 @@
+ #include "services/network/public/cpp/features.h"
+ #include "third_party/abseil-cpp/absl/container/flat_hash_map.h"
+ #include "third_party/blink/public/common/features.h"
++#include "third_party/blink/public/common/helium_noise/noise_token.h"
+ #include "third_party/blink/public/common/web_preferences/web_preferences.h"
+ #include "third_party/blink/public/mojom/page/prerender_page_param.mojom.h"
+ #include "third_party/perfetto/include/perfetto/tracing/traced_value.h"
+@@ -453,6 +454,17 @@ bool RenderViewHostImpl::CreateRenderVie
    DCHECK_EQ(&frame_tree_node->frame_tree(), frame_tree_);
    params->navigation_metrics_token = navigation_metrics_token;
  
@@ -1148,7 +1182,15 @@
    web_view->SetWebPreferences(params->web_preferences);
 --- a/components/printing/renderer/print_render_frame_helper.cc
 +++ b/components/printing/renderer/print_render_frame_helper.cc
-@@ -683,7 +683,8 @@ class HeaderAndFooterContext {
+@@ -60,6 +60,7 @@
+ #include "third_party/blink/public/common/associated_interfaces/associated_interface_registry.h"
+ #include "third_party/blink/public/common/css/page_orientation.h"
+ #include "third_party/blink/public/common/frame/frame_owner_element_type.h"
++#include "third_party/blink/public/common/helium_noise/noise_token.h"
+ #include "third_party/blink/public/common/tokens/tokens.h"
+ #include "third_party/blink/public/common/web_preferences/web_preferences.h"
+ #include "third_party/blink/public/mojom/fenced_frame/fenced_frame.mojom.h"
+@@ -683,7 +684,8 @@ class HeaderAndFooterContext {
          /*browsing_context_group_token=*/base::UnguessableToken::Create(),
          /*color_provider_colors=*/nullptr,
          /*history_index=*/-1,
@@ -1158,7 +1200,7 @@
      view->GetSettings()->SetJavaScriptEnabled(true);
      return view;
    }
-@@ -976,7 +977,8 @@ void PrepareFrameAndViewForPrint::CopySe
+@@ -976,7 +978,8 @@ void PrepareFrameAndViewForPrint::CopySe
        /*browsing_context_group_token=*/base::UnguessableToken::Create(),
        /*color_provider_colors=*/nullptr,
        /*history_index=*/-1,
@@ -1170,7 +1212,15 @@
        web_view, this, nullptr, mojo::NullRemote(), blink::LocalFrameToken(),
 --- a/components/plugins/renderer/webview_plugin.cc
 +++ b/components/plugins/renderer/webview_plugin.cc
-@@ -279,7 +279,8 @@ WebViewPlugin::WebViewHelper::WebViewHel
+@@ -18,6 +18,7 @@
+ #include "gin/converter.h"
+ #include "mojo/public/cpp/bindings/pending_remote.h"
+ #include "skia/ext/platform_canvas.h"
++#include "third_party/blink/public/common/helium_noise/noise_token.h"
+ #include "third_party/blink/public/common/input/web_coalesced_input_event.h"
+ #include "third_party/blink/public/common/page/page_zoom.h"
+ #include "third_party/blink/public/common/tokens/tokens.h"
+@@ -279,7 +280,8 @@ WebViewPlugin::WebViewHelper::WebViewHel
        /*browsing_context_group_token=*/base::UnguessableToken(),
        /*color_provider_colors=*/nullptr,
        /*history_index=*/-1,
@@ -1180,3 +1230,302 @@
    // ApplyWebPreferences before making a WebLocalFrame so that the frame sees a
    // consistent view of our preferences.
    blink::WebView::ApplyWebPreferences(parent_web_preferences, web_view_);
+--- a/chrome/common/pref_names.h
++++ b/chrome/common/pref_names.h
+@@ -3275,6 +3275,9 @@ inline constexpr char kSharedWorkerExten
+ inline constexpr char kImportDialogExtensions[] =
+     "import_dialog_extensions";
+ 
++// Whether Helium Noise is enabled globally.
++inline constexpr char kHeliumNoiseEnabled[] = "helium.noise.enabled";
++
+ // Boolean indicating whether clearing window.name when the navigation is
+ // top-level, cross-site and swaps BrowsingContextGroup is allowed or not.
+ inline constexpr char kClearWindowNameForNewBrowsingContextGroup[] =
+--- a/chrome/browser/BUILD.gn
++++ b/chrome/browser/BUILD.gn
+@@ -333,6 +333,10 @@ source_set("chrome_content_browser_clien
+   ]
+ }
+ 
++source_set("helium_noise_settings_headers") {
++  public = [ "helium_noise/helium_noise_settings.h" ]
++}
++
+ source_set("command_updater_impl") {
+   public = [
+     "command_observer.h",
+@@ -635,6 +639,8 @@ source_set("core") {
+     "font_family_cache.cc",
+     "font_family_cache.h",
+     "global_features.cc",
++    "helium_noise/helium_noise_settings.cc",
++    "helium_noise/helium_noise_settings.h",
+     "icon_manager.cc",
+     "memory_details.cc",
+     "net_benchmarking.cc",
+--- /dev/null
++++ b/chrome/browser/helium_noise/helium_noise_settings.cc
+@@ -0,0 +1,117 @@
++// Copyright 2026 The Helium Authors
++// You can use, redistribute, and/or modify this source code under
++// the terms of the GPL-3.0 license that can be found in the LICENSE file.
++
++#include "chrome/browser/helium_noise/helium_noise_settings.h"
++
++#include "base/feature_list.h"
++#include "chrome/browser/content_settings/host_content_settings_map_factory.h"
++#include "chrome/browser/profiles/profile.h"
++#include "chrome/common/pref_names.h"
++#include "components/content_settings/core/browser/host_content_settings_map.h"
++#include "components/content_settings/core/common/content_settings.h"
++#include "components/content_settings/core/common/content_settings_types.h"
++#include "components/prefs/pref_service.h"
++#include "third_party/blink/public/common/features.h"
++#include "url/gurl.h"
++#include "url/origin.h"
++
++namespace helium_noise {
++
++namespace {
++
++Profile* GetProfile(content::BrowserContext* browser_context) {
++  if (!browser_context) {
++    return nullptr;
++  }
++  return Profile::FromBrowserContext(browser_context);
++}
++
++GURL GetOriginUrl(const GURL& url) {
++  return url::Origin::Create(url).GetURL();
++}
++
++}  // namespace
++
++HeliumNoiseState GetHeliumNoiseState(
++    content::BrowserContext* browser_context,
++    const GURL& url) {
++  if (!base::FeatureList::IsEnabled(blink::features::kHeliumNoise)) {
++    return HeliumNoiseState::kUnavailable;
++  }
++
++  Profile* profile = GetProfile(browser_context);
++  if (!profile) {
++    return HeliumNoiseState::kUnavailable;
++  }
++
++  if (!profile->GetPrefs()->GetBoolean(prefs::kHeliumNoiseEnabled)) {
++    return HeliumNoiseState::kGloballyDisabled;
++  }
++
++  if (!CanSetHeliumNoiseForOrigin(url)) {
++    return HeliumNoiseState::kEnabled;
++  }
++
++  HostContentSettingsMap* settings_map =
++      HostContentSettingsMapFactory::GetForProfile(profile);
++  if (!settings_map) {
++    return HeliumNoiseState::kEnabled;
++  }
++
++  const ContentSetting noise_setting = settings_map->GetContentSetting(
++      url, GURL(), ContentSettingsType::HELIUM_NOISE);
++  if (noise_setting == CONTENT_SETTING_BLOCK) {
++    return HeliumNoiseState::kDisabledForSite;
++  }
++
++  return HeliumNoiseState::kEnabled;
++}
++
++bool IsHeliumNoiseEnabled(content::BrowserContext* browser_context,
++                          const GURL& url) {
++  return GetHeliumNoiseState(browser_context, url) ==
++         HeliumNoiseState::kEnabled;
++}
++
++bool CanSetHeliumNoiseForOrigin(const GURL& url) {
++  return url.is_valid() && url.SchemeIsHTTPOrHTTPS() &&
++         !url::Origin::Create(url).opaque();
++}
++
++void SetHeliumNoiseEnabledForOrigin(content::BrowserContext* browser_context,
++                                    const GURL& url,
++                                    bool enabled) {
++  Profile* profile = GetProfile(browser_context);
++  if (!profile || !CanSetHeliumNoiseForOrigin(url)) {
++    return;
++  }
++
++  HostContentSettingsMap* settings_map =
++      HostContentSettingsMapFactory::GetForProfile(profile);
++  if (!settings_map) {
++    return;
++  }
++
++  if (!enabled) {
++    settings_map->SetNarrowestContentSetting(
++        url, GURL(), ContentSettingsType::HELIUM_NOISE,
++        CONTENT_SETTING_BLOCK);
++    return;
++  }
++
++  settings_map->SetNarrowestContentSetting(
++      url, GURL(), ContentSettingsType::HELIUM_NOISE,
++      CONTENT_SETTING_DEFAULT);
++
++  // If a broader exception still applies, override it for this origin only.
++  const ContentSetting noise_setting = settings_map->GetContentSetting(
++      url, GURL(), ContentSettingsType::HELIUM_NOISE);
++  if (noise_setting == CONTENT_SETTING_BLOCK) {
++    settings_map->SetNarrowestContentSetting(
++        url, GURL(), ContentSettingsType::HELIUM_NOISE,
++        CONTENT_SETTING_ALLOW);
++  }
++}
++
++}  // namespace helium_noise
+--- /dev/null
++++ b/chrome/browser/helium_noise/helium_noise_settings.h
+@@ -0,0 +1,38 @@
++// Copyright 2026 The Helium Authors
++// You can use, redistribute, and/or modify this source code under
++// the terms of the GPL-3.0 license that can be found in the LICENSE file.
++
++#ifndef CHROME_BROWSER_HELIUM_NOISE_HELIUM_NOISE_SETTINGS_H_
++#define CHROME_BROWSER_HELIUM_NOISE_HELIUM_NOISE_SETTINGS_H_
++
++class GURL;
++
++namespace content {
++class BrowserContext;
++}
++
++namespace helium_noise {
++
++enum class HeliumNoiseState {
++  kUnavailable,
++  kGloballyDisabled,
++  kDisabledForSite,
++  kEnabled,
++};
++
++HeliumNoiseState GetHeliumNoiseState(
++    content::BrowserContext* browser_context,
++    const GURL& url);
++
++bool IsHeliumNoiseEnabled(content::BrowserContext* browser_context,
++                          const GURL& url);
++
++bool CanSetHeliumNoiseForOrigin(const GURL& url);
++
++void SetHeliumNoiseEnabledForOrigin(content::BrowserContext* browser_context,
++                                    const GURL& url,
++                                    bool enabled);
++
++}  // namespace helium_noise
++
++#endif  // CHROME_BROWSER_HELIUM_NOISE_HELIUM_NOISE_SETTINGS_H_
+--- a/chrome/browser/chrome_content_browser_client.cc
++++ b/chrome/browser/chrome_content_browser_client.cc
+@@ -94,6 +94,7 @@
+ #include "chrome/browser/favicon/favicon_utils.h"
+ #include "chrome/browser/font_family_cache.h"
+ #include "chrome/browser/headless/headless_mode_util.h"
++#include "chrome/browser/helium_noise/helium_noise_settings.h"
+ #include "chrome/browser/hid/chrome_hid_delegate.h"
+ #include "chrome/browser/history/history_service_factory.h"
+ #include "chrome/browser/interstitials/enterprise_util.h"
+@@ -1548,6 +1549,7 @@ void ChromeContentBrowserClient::Registe
+     user_prefs::PrefRegistrySyncable* registry) {
+   registry->RegisterBooleanPref(prefs::kDisable3DAPIs, false);
+   registry->RegisterBooleanPref(prefs::kEnableHyperlinkAuditing, false);
++  registry->RegisterBooleanPref(prefs::kHeliumNoiseEnabled, true);
+   // Register user prefs for mapping SitePerProcess and IsolateOrigins in
+   // user policy in addition to the same named ones in Local State (which are
+   // used for mapping the command-line flags).
+@@ -9420,6 +9422,12 @@ ChromeContentBrowserClient::GetClipboard
+   return std::nullopt;
+ }
+ 
++bool ChromeContentBrowserClient::HeliumNoiseEnabled(
++    content::BrowserContext* browser_context,
++    const GURL& origin) {
++  return helium_noise::IsHeliumNoiseEnabled(browser_context, origin);
++}
++
+ bool ChromeContentBrowserClient::UsePrefetchPrerenderIntegration() {
+   return base::FeatureList::IsEnabled(features::kBookmarkTriggerForPrefetch) ||
+          base::FeatureList::IsEnabled(
+--- a/chrome/browser/chrome_content_browser_client.h
++++ b/chrome/browser/chrome_content_browser_client.h
+@@ -1217,6 +1217,9 @@ class ChromeContentBrowserClient : publi
+   std::optional<std::vector<std::u16string>> GetClipboardTypesIfPolicyApplied(
+       const ui::ClipboardSequenceNumberToken& seqno) override;
+ 
++  bool HeliumNoiseEnabled(content::BrowserContext* browser_context,
++                          const GURL& origin) override;
++
+   bool UsePrefetchPrerenderIntegration() override;
+ 
+ #if !BUILDFLAG(IS_ANDROID)
+--- a/components/content_settings/core/common/content_settings_types.mojom
++++ b/components/content_settings/core/common/content_settings_types.mojom
+@@ -487,5 +487,8 @@ enum ContentSettingsType {
+   // - ALLOW: Skip the prompt and allow adding sub apps.
+   // - BLOCK: Skip the prompt and block adding sub apps.
+   SUB_APPS_WITHOUT_PROMPTS,
++
++  // Whether Helium Noise is enabled for a top-level origin.
++  HELIUM_NOISE,
+ };
+ // LINT.ThenChange(//components/content_settings/core/browser/content_settings_uma_util.cc:kHistogramValue)
+--- a/components/content_settings/core/browser/content_settings_registry.cc
++++ b/components/content_settings/core/browser/content_settings_registry.cc
+@@ -843,6 +843,17 @@ void ContentSettingsRegistry::Init() {
+            WebsiteSettingsRegistry::DESKTOP,
+            ContentSettingsInfo::DONT_INHERIT_IN_INCOGNITO,
+            PermissionSettingsInfo::EXCEPTIONS_ON_SECURE_ORIGINS_ONLY);
++
++  Register(ContentSettingsType::HELIUM_NOISE, "helium-noise",
++           CONTENT_SETTING_ALLOW, WebsiteSettingsInfo::UNSYNCABLE,
++           /*allowlisted_primary_schemes=*/{},
++           /*valid_settings=*/
++           {CONTENT_SETTING_ALLOW, CONTENT_SETTING_BLOCK},
++           WebsiteSettingsInfo::TOP_ORIGIN_ONLY_SCOPE,
++           WebsiteSettingsRegistry::DESKTOP |
++               WebsiteSettingsRegistry::PLATFORM_ANDROID,
++           ContentSettingsInfo::DONT_INHERIT_IN_INCOGNITO,
++           PermissionSettingsInfo::EXCEPTIONS_ON_SECURE_AND_INSECURE_ORIGINS);
+ }
+ 
+ void ContentSettingsRegistry::Register(
+--- a/chrome/browser/ui/webui/settings/site_settings_helper.cc
++++ b/chrome/browser/ui/webui/settings/site_settings_helper.cc
+@@ -260,6 +260,7 @@ constexpr auto kContentSettingsTypeGroup
+     {ContentSettingsType::SUSPICIOUS_NOTIFICATION_SHOW_ORIGINAL, nullptr},
+     {ContentSettingsType::LOCAL_NETWORK_ACCESS, nullptr},
+     {ContentSettingsType::SUB_APPS_WITHOUT_PROMPTS, nullptr},
++    {ContentSettingsType::HELIUM_NOISE, nullptr},
+ });
+ 
+ static_assert(
+--- a/components/content_settings/core/browser/content_settings_uma_util.cc
++++ b/components/content_settings/core/browser/content_settings_uma_util.cc
+@@ -166,6 +166,7 @@ constexpr auto kHistogramValue = base::M
+     {ContentSettingsType::LOCAL_NETWORK, 143},
+     {ContentSettingsType::LOOPBACK_NETWORK, 144},
+     {ContentSettingsType::SUB_APPS_WITHOUT_PROMPTS, 145},
++    {ContentSettingsType::HELIUM_NOISE, 146},
+ 
+     // As mentioned at the top, please don't forget to update ContentType in
+     // enums.xml when you add entries here!
+--- a/tools/metrics/histograms/enums.xml
++++ b/tools/metrics/histograms/enums.xml
+@@ -2496,6 +2496,7 @@ Called by update_net_error_codes.py.-->
+   <int value="143" label="Local network access - Local"/>
+   <int value="144" label="Local network access - Loopback"/>
+   <int value="145" label="Add Sub Apps without prompts"/>
++  <int value="146" label="Helium Noise"/>
+ </enum>
+ 
+ <!-- LINT.ThenChange(//components/content_settings/core/browser/content_settings_uma_util.cc:kHistogramValue) -->

--- a/patches/helium/core/noise/hardware-concurrency.patch
+++ b/patches/helium/core/noise/hardware-concurrency.patch
@@ -23,7 +23,7 @@
  #endif  /* CHROME_BROWSER_HELIUM_FLAG_ENTRIES_H_ */
 --- a/content/browser/helium_noise/noise_token_data.cc
 +++ b/content/browser/helium_noise/noise_token_data.cc
-@@ -65,6 +65,8 @@ HeliumNoiseTokenData::HeliumNoiseTokenDa
+@@ -59,6 +59,8 @@ HeliumNoiseTokenData::HeliumNoiseTokenDa
        blink::HeliumNoiseToken(base::RandUint64());
    session_tokens_[blink::HeliumNoiseFeature::kAudio] =
        blink::HeliumNoiseToken(base::RandUint64());
@@ -148,7 +148,7 @@
  ExecutionContext* NavigatorBase::GetUAExecutionContext() const {
 --- a/third_party/blink/public/common/helium_noise/noise_token_mojom_traits.h
 +++ b/third_party/blink/public/common/helium_noise/noise_token_mojom_traits.h
-@@ -27,6 +27,8 @@ struct BLINK_COMMON_EXPORT
+@@ -30,6 +30,8 @@ struct BLINK_COMMON_EXPORT
          return blink::mojom::HeliumNoiseFeature::kCanvas;
        case blink::HeliumNoiseFeature::kAudio:
          return blink::mojom::HeliumNoiseFeature::kAudio;
@@ -157,7 +157,7 @@
      }
      NOTREACHED();
    }
-@@ -38,6 +40,8 @@ struct BLINK_COMMON_EXPORT
+@@ -41,6 +43,8 @@ struct BLINK_COMMON_EXPORT
          return blink::HeliumNoiseFeature::kCanvas;
        case blink::mojom::HeliumNoiseFeature::kAudio:
          return blink::HeliumNoiseFeature::kAudio;

--- a/patches/helium/core/shift-right-click-context-menu.patch
+++ b/patches/helium/core/shift-right-click-context-menu.patch
@@ -140,7 +140,7 @@
    out->loads_images_automatically = data.loads_images_automatically();
 --- a/chrome/browser/chrome_content_browser_client.cc
 +++ b/chrome/browser/chrome_content_browser_client.cc
-@@ -4734,6 +4734,8 @@ void ChromeContentBrowserClient::Overrid
+@@ -4736,6 +4736,8 @@ void ChromeContentBrowserClient::Overrid
    web_prefs->javascript_can_access_clipboard =
        prefs->GetBoolean(prefs::kWebKitJavascriptCanAccessClipboard);
    web_prefs->tabs_to_links = prefs->GetBoolean(prefs::kWebkitTabsToLinks);

--- a/patches/helium/settings/helium-noise-settings.patch
+++ b/patches/helium/settings/helium-noise-settings.patch
@@ -1,0 +1,377 @@
+--- a/chrome/browser/resources/settings/site_settings/constants.ts
++++ b/chrome/browser/resources/settings/site_settings/constants.ts
+@@ -30,6 +30,7 @@ export enum ContentSettingsTypes {
+   FILE_SYSTEM_WRITE = 'file-system-write',
+   GEOLOCATION = 'location',
+   HAND_TRACKING = 'hand-tracking',
++  HELIUM_NOISE = 'helium-noise',
+   HID_DEVICES = 'hid-devices',
+   IDLE_DETECTION = 'idle-detection',
+   IMAGES = 'images',
+--- a/chrome/browser/ui/webui/settings/site_settings_helper.cc
++++ b/chrome/browser/ui/webui/settings/site_settings_helper.cc
+@@ -260,7 +260,7 @@ constexpr auto kContentSettingsTypeGroup
+     {ContentSettingsType::SUSPICIOUS_NOTIFICATION_SHOW_ORIGINAL, nullptr},
+     {ContentSettingsType::LOCAL_NETWORK_ACCESS, nullptr},
+     {ContentSettingsType::SUB_APPS_WITHOUT_PROMPTS, nullptr},
+-    {ContentSettingsType::HELIUM_NOISE, nullptr},
++    {ContentSettingsType::HELIUM_NOISE, "helium-noise"},
+ });
+ 
+ static_assert(
+--- a/chrome/app/settings_strings.grdp
++++ b/chrome/app/settings_strings.grdp
+@@ -2301,6 +2301,32 @@
+     <message name="IDS_SETTINGS_CLEAR_DATA_DESCRIPTION" desc="Description for delete browsing data button in Privacy options. 'History' refers to browsing history. 'Cookies' refers to the technical meaning of a cookie, i.e. data saved by a website on the user's computer, as in when a website saves your preferences.">
+       Delete history, cookies, cache, and more
+     </message>
++
++    <!-- Helium Noise -->
++    <message name="IDS_SETTINGS_NOISE" desc="Title of the settings page for Helium's fingerprinting protection feature.">
++      Fingerprinting protection
++    </message>
++    <message name="IDS_SETTINGS_NOISE_LINK_DESCRIPTION" desc="Description of the fingerprinting protection link on the Privacy and security settings page.">
++      Manage how Helium protects you against fingerprinting
++    </message>
++    <message name="IDS_SETTINGS_NOISE_TOGGLE_DESCRIPTION" desc="Description of the global fingerprinting protection toggle.">
++      Make it harder for sites to fingerprint your browser and device
++    </message>
++    <message name="IDS_SETTINGS_NOISE_DESCRIPTION" desc="Description of how Helium protects against browser fingerprinting.">
++      When fingerprinting protection is enabled, Helium adds noise to certain browser features to make it harder for sites to track and profile you. Each site sees consistent randomized information during your browsing session to reduce the chances of detection.
++    </message>
++    <message name="IDS_SETTINGS_NOISE_DISCLAIMER" desc="Disclaimer shown below the fingerprinting protection description explaining that Helium makes fingerprint recovery harder but cannot prevent fingerprinting completely.">
++      Fingerprinting cannot be fully prevented, but Helium's analysis defenses make it harder to recover the original fingerprint.
++    </message>
++    <message name="IDS_SETTINGS_NOISE_CUSTOM_DESCRIPTION" desc="General explanation of fingerprinting protection site rules and wildcard behavior.">
++      When the general fingerprinting protection feature is enabled, sites listed below follow a custom setting. Inserting "[*.]" before a domain name applies it to the entire domain.
++    </message>
++    <message name="IDS_SETTINGS_NOISE_EXCEPTIONS_TITLE" desc="Title above the list of sites where fingerprinting protection is disabled.">
++      Sites without fingerprinting protection
++    </message>
++    <message name="IDS_SETTINGS_NOISE_ALLOW_OVERRIDES_TITLE" desc="Title above the list of sites where fingerprinting protection is explicitly allowed, overriding broader site exceptions.">
++      Overrides to allow fingerprinting protection
++    </message>
+     <message name="IDS_SETTINGS_TITLE_AND_COUNT" desc="The title of a section in the settings page with a count of the total number of items in the section">
+       <ph name="TITLE">$1<ex>Block</ex></ph> - <ph name="COUNT">$2<ex>42</ex></ph>
+     </message>
+--- a/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
++++ b/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
+@@ -126,6 +126,7 @@
+ #include "net/base/url_util.h"
+ #include "net/net_buildflags.h"
+ #include "services/device/public/cpp/device_features.h"
++#include "third_party/blink/public/common/features.h"
+ #include "third_party/blink/public/common/features_generated.h"
+ #include "ui/accessibility/accessibility_features.h"
+ #include "ui/accessibility/accessibility_switches.h"
+@@ -2347,6 +2348,14 @@ void AddPrivacyStrings(content::WebUIDat
+       {"siteSettingsSublabel", IDS_SETTINGS_PERMISSIONS_DESCRIPTION_NORMAL},
+       {"securityPageTitle", IDS_SETTINGS_SECURITY},
+       {"securityPageDescription", IDS_SETTINGS_SECURITY_DESCRIPTION_NORMAL},
++      {"noiseTitle", IDS_SETTINGS_NOISE},
++      {"noiseLinkDescription", IDS_SETTINGS_NOISE_LINK_DESCRIPTION},
++      {"noiseToggleDescription", IDS_SETTINGS_NOISE_TOGGLE_DESCRIPTION},
++      {"noiseDescription", IDS_SETTINGS_NOISE_DESCRIPTION},
++      {"noiseDisclaimer", IDS_SETTINGS_NOISE_DISCLAIMER},
++      {"noiseExceptionsTitle", IDS_SETTINGS_NOISE_EXCEPTIONS_TITLE},
++      {"noiseCustomDescription", IDS_SETTINGS_NOISE_CUSTOM_DESCRIPTION},
++      {"noiseAllowOverridesTitle", IDS_SETTINGS_NOISE_ALLOW_OVERRIDES_TITLE},
+       {"heliumServicesTitle", IDS_SETTINGS_HELIUM_SERVICES},
+       {"heliumServicesDescription", IDS_SETTINGS_HELIUM_SERVICES_DESCRIPTION},
+       {"heliumCrashReportingTitle",
+@@ -2664,6 +2673,9 @@ void AddPrivacyStrings(content::WebUIDat
+       {"securityJavascriptGuardrailsManageSiteExceptionsDesc",
+        IDS_SETTINGS_SECURITY_JAVASCRIPT_GUARDRAILS_MANAGE_SITE_EXCEPTIONS_DESCRIPTION}};
+   html_source->AddLocalizedStrings(kLocalizedStrings);
++  html_source->AddBoolean(
++      "heliumNoiseAvailable",
++      base::FeatureList::IsEnabled(blink::features::kHeliumNoise));
+ 
+   html_source->AddString("cookiesSettingsHelpCenterURL",
+                          chrome::kCookiesSettingsHelpCenterURL);
+--- a/chrome/browser/extensions/api/settings_private/prefs_util.cc
++++ b/chrome/browser/extensions/api/settings_private/prefs_util.cc
+@@ -575,6 +575,8 @@ const PrefsUtil::TypedPrefMap& PrefsUtil
+       settings_api::PrefType::kBoolean;
+   (*s_allowlist)[safety_hub_prefs::kUnusedSitePermissionsRevocationEnabled] =
+       settings_api::PrefType::kBoolean;
++  (*s_allowlist)[::prefs::kHeliumNoiseEnabled] =
++      settings_api::PrefType::kBoolean;
+ 
+ #if BUILDFLAG(ENABLE_COMPOSE)
+   (*s_allowlist)[prefs::kEnableProactiveNudge] =
+--- /dev/null
++++ b/chrome/browser/resources/settings/privacy_page/noise_page.html
+@@ -0,0 +1,38 @@
++<!-- Copyright 2026 The Helium Authors
++     You can use, redistribute, and/or modify this source code under
++     the terms of the GPL-3.0 license that can be found in the LICENSE file. -->
++
++<style include="cr-shared-style settings-shared">
++  #description {
++    padding: var(--cr-section-vertical-padding) var(--cr-section-padding);
++  }
++
++  #description p {
++    margin: 0;
++  }
++
++  #description p + p {
++    margin-top: var(--cr-section-vertical-padding);
++  }
++</style>
++
++<settings-subpage page-title="$i18n{noiseTitle}"
++    route-path$="[[routePath]]">
++  <settings-toggle-button id="noiseToggle"
++      pref="{{prefs.helium.noise.enabled}}"
++      label="$i18n{noiseTitle}"
++      sub-label="$i18n{noiseToggleDescription}">
++  </settings-toggle-button>
++
++  <div id="description" class="cr-secondary-text">
++    <p>$i18n{noiseDescription}</p>
++    <p id="disclaimer">$i18n{noiseDisclaimer}</p>
++  </div>
++
++  <category-setting-exceptions
++      category="[[contentSettingsTypesEnum_.HELIUM_NOISE]]"
++      description="$i18n{noiseCustomDescription}"
++      allow-header="$i18n{noiseAllowOverridesTitle}"
++      block-header="$i18n{noiseExceptionsTitle}">
++  </category-setting-exceptions>
++</settings-subpage>
+--- /dev/null
++++ b/chrome/browser/resources/settings/privacy_page/noise_page.ts
+@@ -0,0 +1,51 @@
++// Copyright 2026 The Helium Authors
++// You can use, redistribute, and/or modify this source code under
++// the terms of the GPL-3.0 license that can be found in the LICENSE file.
++
++import '/shared/settings/prefs/prefs.js';
++import '../controls/settings_toggle_button.js';
++import '../settings_page/settings_subpage.js';
++import '../settings_shared.css.js';
++import '../site_settings/category_setting_exceptions.js';
++
++import {PrefsMixin} from '/shared/settings/prefs/prefs_mixin.js';
++import {PolymerElement} from 'chrome://resources/polymer/v3_0/polymer/polymer_bundled.min.js';
++
++import {SettingsViewMixin} from '../settings_page/settings_view_mixin.js';
++import {ContentSettingsTypes} from '../site_settings/constants.js';
++
++import {getTemplate} from './noise_page.html.js';
++
++const SettingsNoisePageElementBase =
++    SettingsViewMixin(PrefsMixin(PolymerElement));
++
++export class SettingsNoisePageElement extends SettingsNoisePageElementBase {
++  static get is() {
++    return 'settings-noise-page';
++  }
++
++  static get template() {
++    return getTemplate();
++  }
++
++  static get properties() {
++    return {
++      contentSettingsTypesEnum_: {
++        type: Object,
++        value: ContentSettingsTypes,
++      },
++    };
++  }
++
++  override focusBackButton() {
++    this.shadowRoot!.querySelector('settings-subpage')!.focusBackButton();
++  }
++}
++
++declare global {
++  interface HTMLElementTagNameMap {
++    'settings-noise-page': SettingsNoisePageElement;
++  }
++}
++
++customElements.define(SettingsNoisePageElement.is, SettingsNoisePageElement);
+--- a/chrome/browser/resources/settings/BUILD.gn
++++ b/chrome/browser/resources/settings/BUILD.gn
+@@ -134,6 +134,7 @@ build_webui("build") {
+     "performance_page/tab_discard/exception_tabbed_add_dialog.ts",
+     "privacy_page/cookies_page.ts",
+     "privacy_page/do_not_track_toggle.ts",
++    "privacy_page/noise_page.ts",
+     "privacy_page/personalization_options.ts",
+     "privacy_page/privacy_guide/privacy_guide_ad_topics_fragment.ts",
+     "privacy_page/privacy_guide/privacy_guide_completion_fragment.ts",
+--- a/chrome/browser/resources/settings/lazy_load.ts
++++ b/chrome/browser/resources/settings/lazy_load.ts
+@@ -23,6 +23,7 @@ import './clear_browsing_data_dialog/cle
+ import './clear_browsing_data_dialog/clear_browsing_data_time_picker.js';
+ import './glic_page/glic_login_permissions_page.js';
+ import './privacy_page/cookies_page.js';
++import './privacy_page/noise_page.js';
+ import './privacy_page/privacy_guide/privacy_guide_dialog.js';
+ import './privacy_page/privacy_guide/privacy_guide_page.js';
+ import './privacy_page/security/security_keys_subpage.js';
+@@ -247,6 +248,7 @@ export {SettingsSyncEncryptionOptionsEle
+ export {NetworkPredictionOptions} from './performance_page/constants.js';
+ export {SettingsCookiesPageElement} from './privacy_page/cookies_page.js';
+ export {SettingsDoNotTrackToggleElement} from './privacy_page/do_not_track_toggle.js';
++export {SettingsNoisePageElement} from './privacy_page/noise_page.js';
+ export {SettingsPersonalizationOptionsElement} from './privacy_page/personalization_options.js';
+ export {PrivacyGuideStep} from './privacy_page/privacy_guide/constants.js';
+ export {PrivacyGuideAdTopicsFragmentElement} from './privacy_page/privacy_guide/privacy_guide_ad_topics_fragment.js';
+--- a/chrome/browser/resources/settings/router.ts
++++ b/chrome/browser/resources/settings/router.ts
+@@ -30,6 +30,7 @@ export interface SettingsRoutes {
+   DEFAULT_BROWSER: Route;
+   DOWNLOADS: Route;
+   EDIT_DICTIONARY: Route;
++  NOISE: Route;
+   FONTS: Route;
+   GEMINI: Route;
+   GEMINI_LOGIN: Route;
+--- a/chrome/browser/resources/settings/route.ts
++++ b/chrome/browser/resources/settings/route.ts
+@@ -18,6 +18,10 @@ function addPrivacyChildRoutes(r: Partia
+   r.CLEAR_BROWSER_DATA = r.PRIVACY.createChild('/clearBrowserData');
+   r.CLEAR_BROWSER_DATA.isNavigableDialog = true;
+ 
++  if (loadTimeData.getBoolean('heliumNoiseAvailable')) {
++    r.NOISE = r.PRIVACY.createChild('noise');
++  }
++
+   r.HELIUM_SERVICES = r.PRIVACY.createChild('services');
+ 
+   const visibility = pageVisibility || {};
+--- a/chrome/browser/resources/settings/privacy_page/privacy_page.html
++++ b/chrome/browser/resources/settings/privacy_page/privacy_page.html
+@@ -16,6 +16,16 @@
+         label="$i18n{clearBrowsingData}"
+         sub-label="$i18n{clearBrowsingDataDescription}"
+         on-click="onClearBrowsingDataClick_"></cr-link-row>
++    <template is="dom-if" if="[[heliumNoiseAvailable_]]">
++      <cr-link-row id="noiseLinkRow"
++          start-icon="settings20:shield"
++          class="hr"
++          label="$i18n{noiseTitle}"
++          sub-label="$i18n{noiseLinkDescription}"
++          on-click="onNoiseClick_"
++          role-description="$i18n{subpageArrowRoleDescription}">
++      </cr-link-row>
++    </template>
+     <template is="dom-if" if="[[false]]">
+     <cr-link-row id="thirdPartyCookiesLinkRow"
+         start-icon="privacy:cookie"
+--- a/chrome/browser/resources/settings/privacy_page/privacy_page.ts
++++ b/chrome/browser/resources/settings/privacy_page/privacy_page.ts
+@@ -81,6 +81,11 @@ export class SettingsPrivacyPageElement
+         value: () => loadTimeData.getBoolean('isAdPrivacyAvailable'),
+       },
+ 
++      heliumNoiseAvailable_: {
++        type: Boolean,
++        value: () => loadTimeData.getBoolean('heliumNoiseAvailable'),
++      },
++
+       // The label of the confirmation toast that is displayed after deletion
+       // from 'Delete Browsing data' is completed.
+       dbdDeletionConfirmationToastLabel_: {
+@@ -100,6 +105,7 @@ export class SettingsPrivacyPageElement
+   declare private isPrivacySandboxRestricted_: boolean;
+   declare private isPrivacySandboxRestrictedNoticeEnabled_: boolean;
+   declare private isAdPrivacyAvailable_: boolean;
++  declare private heliumNoiseAvailable_: boolean;
+   declare private dbdDeletionConfirmationToastLabel_: string;
+   declare private shouldShowDbdDeletionConfirmationToast_: boolean;
+ 
+@@ -128,6 +134,12 @@ export class SettingsPrivacyPageElement
+     Router.getInstance().navigateTo(routes.COOKIES);
+   }
+ 
++  private onNoiseClick_() {
++    this.interactedWithPage_();
++
++    Router.getInstance().navigateTo(routes.NOISE);
++  }
++
+   private onCbdDialogClosed_() {
+     Router.getInstance().navigateTo(routes.CLEAR_BROWSER_DATA.parent!);
+ 
+@@ -233,6 +245,10 @@ export class SettingsPrivacyPageElement
+   override getFocusConfig() {
+     const map = new Map();
+ 
++    if (routes.NOISE) {
++      map.set(routes.NOISE.path, '#noiseLinkRow');
++    }
++
+     if (routes.HELIUM_SERVICES) {
+       map.set(routes.HELIUM_SERVICES.path, '#heliumServicesLinkRow');
+     }
+@@ -264,6 +280,9 @@ export class SettingsPrivacyPageElement
+   override getAssociatedControlFor(childViewId: string): HTMLElement {
+     let triggerId: string|null = null;
+     switch (childViewId) {
++      case 'noise':
++        triggerId = 'noiseLinkRow';
++        break;
+       case 'heliumServices':
+         triggerId = 'heliumServicesLinkRow';
+         break;
+--- a/chrome/browser/resources/settings/privacy_page/privacy_page_index.html
++++ b/chrome/browser/resources/settings/privacy_page/privacy_page_index.html
+@@ -93,6 +93,18 @@
+     </settings-cookies-page>
+   </template>
+ 
++  <template is="dom-if" if="[[heliumNoiseAvailable_]]" restamp>
++    <template is="dom-if" if="[[renderView_(
++        routes_.NOISE, currentRoute, inSearchMode)]]"
++        update-when-false>
++      <settings-noise-page slot="view"
++          id="noise" data-parent-view-id="privacy"
++          prefs="{{prefs}}"
++          route-path$="[[routes_.NOISE.path]]">
++      </settings-noise-page>
++    </template>
++  </template>
++
+   <template is="dom-if" if="[[!enableBundledSecuritySettings_]]">
+     <template is="dom-if" if="[[renderView_(
+         routes_.SECURITY, currentRoute, inSearchMode)]]" update-when-false>
+--- a/chrome/browser/resources/settings/privacy_page/privacy_page_index.ts
++++ b/chrome/browser/resources/settings/privacy_page/privacy_page_index.ts
+@@ -178,6 +178,12 @@ export class SettingsPrivacyPageIndexEle
+         value: () => loadTimeData.getBoolean('isAdPrivacyAvailable'),
+       },
+ 
++      heliumNoiseAvailable_: {
++        type: Boolean,
++        readOnly: true,
++        value: () => loadTimeData.getBoolean('heliumNoiseAvailable'),
++      },
++
+       isPrivacySandboxTopicsAndFledgeAvailable_: {
+         type: Boolean,
+         readOnly: true,
+@@ -217,6 +223,7 @@ export class SettingsPrivacyPageIndexEle
+   declare private enableWebAppInstallation_: boolean;
+   declare private enableWebBluetoothNewPermissionsBackend_: boolean;
+   declare private isAdPrivacyAvailable_: boolean;
++  declare private heliumNoiseAvailable_: boolean;
+   declare private isPrivacySandboxTopicsAndFledgeAvailable_: boolean;
+ 
+   private pendingViewSwitching_: PromiseResolver<void> = new PromiseResolver();
+--- a/chrome/common/webui_url_constants.h
++++ b/chrome/common/webui_url_constants.h
+@@ -590,6 +590,7 @@ inline constexpr char kExperimentalAISet
+ inline constexpr char kFileSystemSettingsSubpage[] =
+     "content/filesystem/siteDetails";
+ inline constexpr char kFileSystemSubpage[] = "content/filesystem";
++inline constexpr char kNoiseSubPage[] = "privacy/noise";
+ inline constexpr char kGlicSettingsSubpage[] = "ai/gemini";
+ inline constexpr char kGlicLoginSettingsSubpage[] = "ai/gemini/login";
+ inline constexpr char kGoogleServicesSubpage[] = "googleServices";

--- a/patches/helium/ui/helium-noise-page-info.patch
+++ b/patches/helium/ui/helium-noise-page-info.patch
@@ -1,0 +1,659 @@
+--- a/chrome/browser/ui/page_info/chrome_page_info_ui_delegate.cc
++++ b/chrome/browser/ui/page_info/chrome_page_info_ui_delegate.cc
+@@ -20,6 +20,7 @@
+ #include "chrome/browser/ui/ui_features.h"
+ #include "chrome/common/chrome_features.h"
+ #include "chrome/common/pref_names.h"
++#include "chrome/common/webui_url_constants.h"
+ #include "components/content_settings/core/common/content_settings_types.h"
+ #include "components/content_settings/core/common/features.h"
+ #include "components/page_info/core/about_this_site_service.h"
+@@ -200,6 +201,12 @@ void ChromePageInfoUiDelegate::ShowPriva
+   chrome::ShowPrivacySandboxSettings(browser);
+ }
+ 
++void ChromePageInfoUiDelegate::ShowNoiseSettings() {
++  BrowserWindowInterface* browser =
++      GlobalBrowserCollection::GetInstance()->FindBrowserWithTab(web_contents_);
++  chrome::ShowSettingsSubPage(browser, chrome::kNoiseSubPage);
++}
++
+ std::u16string ChromePageInfoUiDelegate::GetPermissionDetail(
+     ContentSettingsType type) {
+   switch (type) {
+--- a/chrome/browser/ui/page_info/chrome_page_info_ui_delegate.h
++++ b/chrome/browser/ui/page_info/chrome_page_info_ui_delegate.h
+@@ -76,6 +76,9 @@ class ChromePageInfoUiDelegate : public
+   // Opens Privacy Sandbox settings page.
+   void ShowPrivacySandboxSettings();
+ 
++  // Opens Noise settings page.
++  void ShowNoiseSettings();
++
+   // PageInfoUiDelegate implementation
+   bool IsBlockAutoPlayEnabled() override;
+   bool IsMultipleTabsOpen() override;
+--- a/components/page_info/page_info.cc
++++ b/components/page_info/page_info.cc
+@@ -843,6 +843,10 @@ void PageInfo::OnSitePermissionChanged(
+   PresentSitePermissions();
+ }
+ 
++void PageInfo::OnHeliumNoiseSettingChanged() {
++  show_info_bar_ = true;
++}
++
+ void PageInfo::OnSiteChosenObjectDeleted(const ChooserUIInfo& ui_info,
+                                          const base::Value& object) {
+   permissions::ObjectPermissionContextBase* context =
+--- a/components/page_info/page_info.h
++++ b/components/page_info/page_info.h
+@@ -203,6 +203,10 @@ class PageInfo : private content_setting
+                                std::optional<url::Origin> requesting_origin,
+                                bool is_one_time);
+ 
++  // Marks the current page for a reload prompt after its Helium Noise setting
++  // changes. The setting itself is owned by the Chrome-layer Noise helper.
++  void OnHeliumNoiseSettingChanged();
++
+   // This method is called whenever access to an object is revoked.
+   void OnSiteChosenObjectDeleted(const ChooserUIInfo& ui_info,
+                                  const base::Value& object);
+--- a/components/page_info_strings.grdp
++++ b/components/page_info_strings.grdp
+@@ -1015,6 +1015,26 @@
+     Your organization has blocked this site because it violates a policy.
+   </message>
+ 
++  <!-- Helium Noise strings -->
++  <message name="IDS_PAGE_INFO_HELIUM_NOISE_HEADER" desc="The title of the fingerprinting protection row and subpage in Page Info.">
++    Fingerprinting protection
++  </message>
++  <message name="IDS_PAGE_INFO_HELIUM_NOISE_TOOLTIP" desc="Tooltip for the fingerprinting protection row in Page Info.">
++    Manage fingerprinting protection for this site
++  </message>
++  <message name="IDS_PAGE_INFO_HELIUM_NOISE_DESCRIPTION" desc="Explanation of how Helium fingerprinting protection works.">
++    When fingerprinting protection is enabled, Helium adds noise to certain browser features to make it harder for sites to track and profile you.
++  </message>
++  <message name="IDS_PAGE_INFO_HELIUM_NOISE_BREAKAGE" desc="Explanation of how disabling Helium's fingerprinting protection may fix privacy-invasive websites, but will reduce user's privacy.">
++    Turning off the protection will reduce your privacy, but may fix site features that require fingerprinting.
++  </message>
++  <message name="IDS_PAGE_INFO_HELIUM_NOISE_GLOBALLY_DISABLED" desc="Explanation shown when the site toggle is unavailable because fingerprinting protection is disabled globally.">
++    Fingerprinting protection is turned off in Helium settings.
++  </message>
++  <message name="IDS_PAGE_INFO_HELIUM_NOISE_SETTINGS_BUTTON" desc="A button label that opens Helium's global fingerprinting protection settings page.">
++    Manage fingerprinting protection
++  </message>
++
+   <!-- Ad privacy strings -->
+   <message name="IDS_PAGE_INFO_AD_PRIVACY_HEADER" desc="A label that represents the new ad-related settings. 1) Navigate to any site. 2) Click the icon (often a lock) to the left of the URL in the address bar. Information about the page you're viewing appears. The 'Ad privacy' label will appear above the 'Site settings' button.">
+     Ad privacy
+--- /dev/null
++++ b/chrome/browser/ui/views/page_info/page_info_noise_content_view.cc
+@@ -0,0 +1,160 @@
++// Copyright 2026 The Helium Authors
++// You can use, redistribute, and/or modify this source code under
++// the terms of the GPL-3.0 license that can be found in the LICENSE file.
++
++#include "chrome/browser/ui/views/page_info/page_info_noise_content_view.h"
++
++#include <memory>
++
++#include "base/check.h"
++#include "base/functional/bind.h"
++#include "base/functional/callback_helpers.h"
++#include "chrome/browser/helium_noise/helium_noise_settings.h"
++#include "chrome/browser/ui/color/chrome_color_id.h"
++#include "chrome/browser/ui/layout_constants.h"
++#include "chrome/browser/ui/page_info/chrome_page_info_ui_delegate.h"
++#include "chrome/browser/ui/views/chrome_layout_provider.h"
++#include "chrome/browser/ui/views/controls/rich_controls_container_view.h"
++#include "chrome/browser/ui/views/controls/rich_hover_button.h"
++#include "chrome/browser/ui/views/page_info/page_info_view_factory.h"
++#include "components/page_info/page_info.h"
++#include "components/strings/grit/components_strings.h"
++#include "content/public/browser/web_contents.h"
++#include "ui/base/l10n/l10n_util.h"
++#include "ui/gfx/geometry/insets.h"
++#include "ui/views/accessibility/view_accessibility.h"
++#include "ui/views/controls/button/toggle_button.h"
++#include "ui/views/controls/label.h"
++#include "ui/views/controls/styled_label.h"
++#include "ui/views/layout/box_layout_view.h"
++#include "ui/views/style/typography.h"
++
++PageInfoNoiseContentView::PageInfoNoiseContentView(
++    PageInfo* presenter,
++    ChromePageInfoUiDelegate* ui_delegate)
++    : presenter_(presenter), ui_delegate_(ui_delegate),
++      web_contents_(ui_delegate_->GetWebContents()->GetWeakPtr()) {
++
++  ChromeLayoutProvider* layout_provider = ChromeLayoutProvider::Get();
++  SetOrientation(views::LayoutOrientation::kVertical);
++  SetProperty(
++      views::kMarginsKey,
++      gfx::Insets::TLBR(
++          0, 0,
++          layout_provider->GetDistanceMetric(
++              DISTANCE_CONTENT_LIST_VERTICAL_MULTI),
++          0));
++
++  const helium_noise::HeliumNoiseState noise_state =
++      helium_noise::GetHeliumNoiseState(web_contents_->GetBrowserContext(),
++                                        presenter_->site_url());
++
++  const auto button_insets = layout_provider->GetInsetsMetric(
++      ChromeInsetsMetric::INSETS_PAGE_INFO_HOVER_BUTTON);
++  auto* description_label =
++      AddChildView(std::make_unique<views::StyledLabel>());
++  description_label->SetText(
++      l10n_util::GetStringUTF16(IDS_PAGE_INFO_HELIUM_NOISE_DESCRIPTION));
++  description_label->SetDefaultTextStyle(views::style::STYLE_BODY_3);
++  description_label->SetDefaultEnabledColorId(kColorPageInfoForeground);
++  description_label->SetProperty(views::kMarginsKey, button_insets);
++  description_label->SizeToFit(PageInfoViewFactory::kMinBubbleWidth -
++                               button_insets.width());
++
++  const int vertical_margin = layout_provider->GetDistanceMetric(
++      DISTANCE_CONTENT_LIST_VERTICAL_MULTI);
++  const int side_margin =
++      layout_provider->GetInsetsMetric(views::INSETS_DIALOG).left();
++  if (noise_state == helium_noise::HeliumNoiseState::kGloballyDisabled) {
++    auto* globally_disabled_label = AddChildView(std::make_unique<views::Label>(
++        l10n_util::GetStringUTF16(
++            IDS_PAGE_INFO_HELIUM_NOISE_GLOBALLY_DISABLED),
++        views::style::CONTEXT_LABEL, views::style::STYLE_BODY_4));
++    globally_disabled_label->SetEnabledColor(
++        kColorPageInfoSubtitleForeground);
++    globally_disabled_label->SetHorizontalAlignment(gfx::ALIGN_LEFT);
++    globally_disabled_label->SetMultiLine(true);
++    globally_disabled_label->SetMaximumWidth(
++        PageInfoViewFactory::kMinBubbleWidth - side_margin * 2);
++    globally_disabled_label->SetProperty(
++        views::kMarginsKey, gfx::Insets::VH(vertical_margin, side_margin));
++  } else {
++    auto* breakage_container =
++        AddChildView(std::make_unique<views::BoxLayoutView>());
++    breakage_container->SetOrientation(views::LayoutOrientation::kVertical);
++    breakage_container->SetProperty(
++        views::kMarginsKey, gfx::Insets::VH(vertical_margin, side_margin));
++
++    auto* breakage_title = breakage_container->AddChildView(
++        std::make_unique<views::Label>(
++            l10n_util::GetStringUTF16(
++                IDS_PAGE_INFO_COOKIES_SITE_NOT_WORKING_TITLE),
++            views::style::CONTEXT_DIALOG_BODY_TEXT,
++            views::style::STYLE_BODY_3_MEDIUM));
++    breakage_title->SetEnabledColor(kColorPageInfoForeground);
++    breakage_title->SetHorizontalAlignment(gfx::ALIGN_LEFT);
++
++    auto* breakage_description = breakage_container->AddChildView(
++        std::make_unique<views::Label>(
++            l10n_util::GetStringUTF16(IDS_PAGE_INFO_HELIUM_NOISE_BREAKAGE),
++            views::style::CONTEXT_LABEL, views::style::STYLE_BODY_4));
++    breakage_description->SetEnabledColor(kColorPageInfoSubtitleForeground);
++    breakage_description->SetHorizontalAlignment(gfx::ALIGN_LEFT);
++    breakage_description->SetMultiLine(true);
++    breakage_description->SetMaximumWidth(
++        PageInfoViewFactory::kMinBubbleWidth - side_margin * 2);
++
++    setting_row_ =
++        AddChildView(std::make_unique<RichControlsContainerView>());
++    setting_row_->SetIcon(PageInfoViewFactory::GetNoiseIcon(
++        noise_state == helium_noise::HeliumNoiseState::kEnabled));
++    setting_row_->SetTitle(
++        l10n_util::GetStringUTF16(IDS_PAGE_INFO_HELIUM_NOISE_HEADER));
++
++    toggle_button_ = setting_row_->AddControl(
++        std::make_unique<views::ToggleButton>(base::BindRepeating(
++            &PageInfoNoiseContentView::OnToggleButtonPressed,
++            base::Unretained(this))));
++    toggle_button_->SetID(
++        PageInfoViewFactory::VIEW_ID_PAGE_INFO_HELIUM_NOISE_TOGGLE);
++    toggle_button_->GetViewAccessibility().SetName(
++        l10n_util::GetStringUTF16(IDS_PAGE_INFO_HELIUM_NOISE_HEADER));
++    toggle_button_->SetIsOn(noise_state ==
++                            helium_noise::HeliumNoiseState::kEnabled);
++    toggle_button_->SetEnabled(
++        noise_state != helium_noise::HeliumNoiseState::kUnavailable);
++    toggle_button_->SetPreferredSize(gfx::Size(
++        toggle_button_->GetPreferredSize().width(),
++        setting_row_->GetFirstLineHeight()));
++  }
++
++  AddChildView(PageInfoViewFactory::CreateSeparator(
++      layout_provider->GetDistanceMetric(
++          DISTANCE_HORIZONTAL_SEPARATOR_PADDING_PAGE_INFO_VIEW)));
++  auto* settings_button = AddChildView(std::make_unique<RichHoverButton>(
++      base::BindRepeating(&ChromePageInfoUiDelegate::ShowNoiseSettings,
++                          base::Unretained(ui_delegate_)),
++      PageInfoViewFactory::GetSiteSettingsIcon(),
++      l10n_util::GetStringUTF16(IDS_PAGE_INFO_HELIUM_NOISE_SETTINGS_BUTTON),
++      std::u16string(), PageInfoViewFactory::GetLaunchIcon()));
++  settings_button->SetTitleTextStyleAndColor(
++      views::style::STYLE_BODY_3_MEDIUM, kColorPageInfoForeground);
++
++  presenter_->InitializeUiState(this, base::DoNothing());
++}
++
++PageInfoNoiseContentView::~PageInfoNoiseContentView() = default;
++
++void PageInfoNoiseContentView::OnToggleButtonPressed() {
++  if (!web_contents_ || !setting_row_ || !toggle_button_ ||
++      !toggle_button_->GetEnabled()) {
++    return;
++  }
++
++  helium_noise::SetHeliumNoiseEnabledForOrigin(
++      web_contents_->GetBrowserContext(), presenter_->site_url(),
++      toggle_button_->GetIsOn());
++  setting_row_->SetIcon(
++      PageInfoViewFactory::GetNoiseIcon(toggle_button_->GetIsOn()));
++  presenter_->OnHeliumNoiseSettingChanged();
++}
+--- /dev/null
++++ b/chrome/browser/ui/views/page_info/page_info_noise_content_view.h
+@@ -0,0 +1,43 @@
++// Copyright 2026 The Helium Authors
++// You can use, redistribute, and/or modify this source code under
++// the terms of the GPL-3.0 license that can be found in the LICENSE file.
++
++#ifndef CHROME_BROWSER_UI_VIEWS_PAGE_INFO_PAGE_INFO_NOISE_CONTENT_VIEW_H_
++#define CHROME_BROWSER_UI_VIEWS_PAGE_INFO_PAGE_INFO_NOISE_CONTENT_VIEW_H_
++
++#include "base/memory/raw_ptr.h"
++#include "base/memory/weak_ptr.h"
++#include "components/page_info/page_info_ui.h"
++#include "ui/views/layout/flex_layout_view.h"
++
++class ChromePageInfoUiDelegate;
++class PageInfo;
++class RichControlsContainerView;
++
++namespace content {
++class WebContents;
++}
++
++namespace views {
++class ToggleButton;
++}
++
++// Content for the Helium Noise subpage in Page Info.
++class PageInfoNoiseContentView : public views::FlexLayoutView,
++                                 public PageInfoUI {
++ public:
++  PageInfoNoiseContentView(PageInfo* presenter,
++                           ChromePageInfoUiDelegate* ui_delegate);
++  ~PageInfoNoiseContentView() override;
++
++ private:
++  void OnToggleButtonPressed();
++
++  const raw_ptr<PageInfo, DanglingUntriaged> presenter_;
++  const raw_ptr<ChromePageInfoUiDelegate, DanglingUntriaged> ui_delegate_;
++  base::WeakPtr<content::WebContents> web_contents_;
++  raw_ptr<RichControlsContainerView> setting_row_ = nullptr;
++  raw_ptr<views::ToggleButton> toggle_button_ = nullptr;
++};
++
++#endif  // CHROME_BROWSER_UI_VIEWS_PAGE_INFO_PAGE_INFO_NOISE_CONTENT_VIEW_H_
+--- a/chrome/browser/ui/BUILD.gn
++++ b/chrome/browser/ui/BUILD.gn
+@@ -203,6 +203,7 @@ static_library("ui") {
+     "//chrome/browser:flags",
+     "//chrome/browser:font_pref",
+     "//chrome/browser:global_features",
++    "//chrome/browser:helium_noise_settings_headers",
+     "//chrome/browser:icon_manager",
+     "//chrome/browser:renderer_preferences_util",
+     "//chrome/browser:resources_util",
+@@ -4139,6 +4140,8 @@ static_library("ui") {
+       "views/page_info/page_info_merchant_trust_controller.h",
+       "views/page_info/page_info_merchant_trust_coordinator.cc",
+       "views/page_info/page_info_merchant_trust_coordinator.h",
++      "views/page_info/page_info_noise_content_view.cc",
++      "views/page_info/page_info_noise_content_view.h",
+       "views/page_info/page_info_permission_content_view.cc",
+       "views/page_info/page_info_permission_content_view.h",
+       "views/page_info/page_info_security_content_view.cc",
+--- /dev/null
++++ b/components/vector_icons/shield_check.icon
+@@ -0,0 +1,52 @@
++// Copyright 2026 The Helium Authors
++// You can use, redistribute, and/or modify this source code under
++// the terms of the GPL-3.0 license that can be found in the LICENSE file.
++
++CANVAS_DIMENSIONS, 20,
++FILL_RULE_NONZERO,
++MOVE_TO, 9.13f, 10.81f,
++LINE_TO, 7.88f, 9.56f,
++CUBIC_TO, 7.73f, 9.41f, 7.55f, 9.33f, 7.36f, 9.33f,
++CUBIC_TO, 7.16f, 9.33f, 6.99f, 9.41f, 6.83f, 9.56f,
++CUBIC_TO, 6.68f, 9.72f, 6.6f, 9.89f, 6.6f, 10.1f,
++CUBIC_TO, 6.6f, 10.3f, 6.68f, 10.48f, 6.83f, 10.63f,
++LINE_TO, 8.58f, 12.4f,
++CUBIC_TO, 8.73f, 12.55f, 8.91f, 12.63f, 9.11f, 12.63f,
++CUBIC_TO, 9.32f, 12.63f, 9.49f, 12.55f, 9.65f, 12.4f,
++LINE_TO, 13.19f, 8.85f,
++CUBIC_TO, 13.34f, 8.7f, 13.42f, 8.53f, 13.42f, 8.33f,
++CUBIC_TO, 13.42f, 8.14f, 13.34f, 7.97f, 13.19f, 7.81f,
++CUBIC_TO, 13.03f, 7.66f, 12.86f, 7.58f, 12.65f, 7.58f,
++CUBIC_TO, 12.45f, 7.58f, 12.27f, 7.66f, 12.13f, 7.81f,
++LINE_TO, 9.13f, 10.81f,
++CLOSE,
++MOVE_TO, 9.75f, 17.91f,
++CUBIC_TO, 9.67f, 17.9f, 9.59f, 17.88f, 9.52f, 17.85f,
++CUBIC_TO, 7.7f, 17.26f, 6.24f, 16.15f, 5.15f, 14.54f,
++CUBIC_TO, 4.05f, 12.93f, 3.5f, 11.17f, 3.5f, 9.27f,
++V_LINE_TO, 5.52f,
++CUBIC_TO, 3.5f, 5.21f, 3.59f, 4.92f, 3.76f, 4.67f,
++CUBIC_TO, 3.93f, 4.42f, 4.17f, 4.24f, 4.46f, 4.13f,
++LINE_TO, 9.46f, 2.21f,
++CUBIC_TO, 9.64f, 2.14f, 9.82f, 2.1f, 10, 2.1f,
++CUBIC_TO, 10.18f, 2.1f, 10.36f, 2.14f, 10.54f, 2.21f,
++LINE_TO, 15.54f, 4.13f,
++CUBIC_TO, 15.83f, 4.24f, 16.07f, 4.42f, 16.24f, 4.67f,
++CUBIC_TO, 16.41f, 4.92f, 16.5f, 5.21f, 16.5f, 5.52f,
++V_LINE_TO, 9.27f,
++CUBIC_TO, 16.5f, 11.17f, 15.95f, 12.93f, 14.85f, 14.54f,
++CUBIC_TO, 13.76f, 16.15f, 12.3f, 17.26f, 10.48f, 17.85f,
++CUBIC_TO, 10.41f, 17.88f, 10.33f, 17.9f, 10.25f, 17.91f,
++CUBIC_TO, 10.17f, 17.91f, 10.08f, 17.92f, 10, 17.92f,
++CUBIC_TO, 9.92f, 17.92f, 9.83f, 17.91f, 9.75f, 17.91f,
++CLOSE,
++MOVE_TO, 10, 16.44f,
++CUBIC_TO, 11.44f, 15.99f, 12.64f, 15.09f, 13.58f, 13.75f,
++CUBIC_TO, 14.53f, 12.41f, 15, 10.91f, 15, 9.27f,
++V_LINE_TO, 5.52f,
++LINE_TO, 10, 3.6f,
++LINE_TO, 5, 5.52f,
++V_LINE_TO, 9.27f,
++CUBIC_TO, 5, 10.91f, 5.47f, 12.41f, 6.42f, 13.75f,
++CUBIC_TO, 7.36f, 15.09f, 8.56f, 15.99f, 10, 16.44f,
++CLOSE
+--- /dev/null
++++ b/components/vector_icons/shield_cross.icon
+@@ -0,0 +1,62 @@
++// Copyright 2026 The Helium Authors
++// You can use, redistribute, and/or modify this source code under
++// the terms of the GPL-3.0 license that can be found in the LICENSE file.
++
++CANVAS_DIMENSIONS, 20,
++FILL_RULE_NONZERO,
++MOVE_TO, 10, 11.04f,
++LINE_TO, 11.18f, 12.23f,
++CUBIC_TO, 11.34f, 12.38f, 11.51f, 12.46f, 11.71f, 12.46f,
++CUBIC_TO, 11.9f, 12.46f, 12.08f, 12.38f, 12.23f, 12.23f,
++CUBIC_TO, 12.38f, 12.08f, 12.46f, 11.9f, 12.46f, 11.71f,
++CUBIC_TO, 12.46f, 11.51f, 12.38f, 11.34f, 12.23f, 11.18f,
++LINE_TO, 11.04f, 10,
++LINE_TO, 12.23f, 8.82f,
++CUBIC_TO, 12.38f, 8.66f, 12.46f, 8.49f, 12.46f, 8.29f,
++CUBIC_TO, 12.46f, 8.1f, 12.38f, 7.92f, 12.23f, 7.77f,
++CUBIC_TO, 12.08f, 7.62f, 11.9f, 7.54f, 11.71f, 7.54f,
++CUBIC_TO, 11.51f, 7.54f, 11.34f, 7.62f, 11.18f, 7.77f,
++LINE_TO, 10, 8.96f,
++LINE_TO, 8.82f, 7.77f,
++CUBIC_TO, 8.66f, 7.62f, 8.49f, 7.54f, 8.29f, 7.54f,
++CUBIC_TO, 8.1f, 7.54f, 7.92f, 7.62f, 7.77f, 7.77f,
++CUBIC_TO, 7.62f, 7.92f, 7.54f, 8.1f, 7.54f, 8.29f,
++CUBIC_TO, 7.54f, 8.49f, 7.62f, 8.66f, 7.77f, 8.82f,
++LINE_TO, 8.96f, 10,
++LINE_TO, 7.77f, 11.18f,
++CUBIC_TO, 7.62f, 11.34f, 7.54f, 11.51f, 7.54f, 11.71f,
++CUBIC_TO, 7.54f, 11.9f, 7.62f, 12.08f, 7.77f, 12.23f,
++CUBIC_TO, 7.92f, 12.38f, 8.1f, 12.46f, 8.29f, 12.46f,
++CUBIC_TO, 8.49f, 12.46f, 8.66f, 12.38f, 8.82f, 12.23f,
++LINE_TO, 10, 11.04f,
++CLOSE,
++MOVE_TO, 9.75f, 17.91f,
++CUBIC_TO, 9.67f, 17.9f, 9.59f, 17.88f, 9.52f, 17.85f,
++CUBIC_TO, 7.7f, 17.26f, 6.24f, 16.15f, 5.15f, 14.54f,
++CUBIC_TO, 4.05f, 12.93f, 3.5f, 11.17f, 3.5f, 9.27f,
++V_LINE_TO, 5.52f,
++CUBIC_TO, 3.5f, 5.21f, 3.59f, 4.92f, 3.76f, 4.67f,
++CUBIC_TO, 3.93f, 4.42f, 4.17f, 4.24f, 4.46f, 4.13f,
++LINE_TO, 9.46f, 2.21f,
++CUBIC_TO, 9.64f, 2.14f, 9.82f, 2.1f, 10, 2.1f,
++CUBIC_TO, 10.18f, 2.1f, 10.36f, 2.14f, 10.54f, 2.21f,
++LINE_TO, 15.54f, 4.13f,
++CUBIC_TO, 15.83f, 4.24f, 16.07f, 4.42f, 16.24f, 4.67f,
++CUBIC_TO, 16.41f, 4.92f, 16.5f, 5.21f, 16.5f, 5.52f,
++V_LINE_TO, 9.27f,
++CUBIC_TO, 16.5f, 11.17f, 15.95f, 12.93f, 14.85f, 14.54f,
++CUBIC_TO, 13.76f, 16.15f, 12.3f, 17.26f, 10.48f, 17.85f,
++CUBIC_TO, 10.41f, 17.88f, 10.33f, 17.9f, 10.25f, 17.91f,
++CUBIC_TO, 10.17f, 17.91f, 10.08f, 17.92f, 10, 17.92f,
++CUBIC_TO, 9.92f, 17.92f, 9.83f, 17.91f, 9.75f, 17.91f,
++CLOSE,
++MOVE_TO, 10, 16.44f,
++CUBIC_TO, 11.44f, 15.99f, 12.64f, 15.09f, 13.58f, 13.75f,
++CUBIC_TO, 14.53f, 12.41f, 15, 10.91f, 15, 9.27f,
++V_LINE_TO, 5.52f,
++LINE_TO, 10, 3.6f,
++LINE_TO, 5, 5.52f,
++V_LINE_TO, 9.27f,
++CUBIC_TO, 5, 10.91f, 5.47f, 12.41f, 6.42f, 13.75f,
++CUBIC_TO, 7.36f, 15.09f, 8.56f, 15.99f, 10, 16.44f,
++CLOSE
+--- a/components/vector_icons/BUILD.gn
++++ b/components/vector_icons/BUILD.gn
+@@ -405,6 +405,8 @@ if (current_toolchain == default_toolcha
+       "settings_old.icon",
+       "settings_outline_old.icon",
+       "shield.icon",
++      "shield_check.icon",
++      "shield_cross.icon",
+       "shopping_bag.icon",
+       "shopping_bag_old.icon",
+       "shopping_bag_refresh_old.icon",
+--- a/chrome/browser/ui/views/page_info/page_info_view_factory.cc
++++ b/chrome/browser/ui/views/page_info/page_info_view_factory.cc
+@@ -24,6 +24,7 @@
+ #include "chrome/browser/ui/views/page_info/page_info_main_view.h"
+ #include "chrome/browser/ui/views/page_info/page_info_merchant_trust_content_view.h"
+ #include "chrome/browser/ui/views/page_info/page_info_navigation_handler.h"
++#include "chrome/browser/ui/views/page_info/page_info_noise_content_view.h"
+ #include "chrome/browser/ui/views/page_info/page_info_permission_content_view.h"
+ #include "chrome/browser/ui/views/page_info/page_info_security_content_view.h"
+ #include "components/content_settings/core/browser/permission_settings_registry.h"
+@@ -187,6 +188,14 @@ std::unique_ptr<views::View> PageInfoVie
+       std::make_unique<PageInfoCookiesContentView>(presenter_));
+ }
+ 
++std::unique_ptr<views::View> PageInfoViewFactory::CreateNoisePageView() {
++  return std::make_unique<PageInfoSubpageView>(
++      CreateSubpageHeader(
++          l10n_util::GetStringUTF16(IDS_PAGE_INFO_HELIUM_NOISE_HEADER),
++          presenter_->GetSubjectNameForDisplay()),
++      std::make_unique<PageInfoNoiseContentView>(presenter_, ui_delegate_));
++}
++
+ std::unique_ptr<views::View>
+ PageInfoViewFactory::CreateMerchantTrustPageView() {
+   return std::make_unique<PageInfoSubpageView>(
+@@ -903,6 +912,12 @@ const ui::ImageModel PageInfoViewFactory
+ }
+ 
+ // static
++const ui::ImageModel PageInfoViewFactory::GetNoiseIcon(bool enabled) {
++  return GetImageModel(enabled ? vector_icons::kShieldCheckIcon
++                               : vector_icons::kShieldCrossIcon);
++}
++
++// static
+ const ui::ImageModel PageInfoViewFactory::GetOpenSubpageIcon() {
+   // GetIconSize() does not work for subpage icons because the default size of
+   // features::IsRoundedIconsEnabled() ? vector_icons::kArrowRightFlippableIcon
+--- a/chrome/browser/ui/views/page_info/page_info_view_factory.h
++++ b/chrome/browser/ui/views/page_info/page_info_view_factory.h
+@@ -42,6 +42,7 @@ class PageInfoViewFactory {
+     VIEW_ID_PAGE_INFO_BLOCK_THIRD_PARTY_COOKIES_SUBTITLE,
+     VIEW_ID_PAGE_INFO_LINK_OR_BUTTON_COOKIE_DIALOG,
+     VIEW_ID_PAGE_INFO_LINK_OR_BUTTON_COOKIES_SUBPAGE,
++    VIEW_ID_PAGE_INFO_LINK_OR_BUTTON_NOISE_SUBPAGE,
+     VIEW_ID_PAGE_INFO_LINK_OR_BUTTON_PRIVACY_SITE_DATA_SUBPAGE,
+     VIEW_ID_PAGE_INFO_COOKIES_DESCRIPTION_LABEL,
+     VIEW_ID_PAGE_INFO_LINK_OR_BUTTON_RWS_SETTINGS,
+@@ -76,6 +77,7 @@ class PageInfoViewFactory {
+     VIEW_ID_PAGE_INFO_EXTENDED_SITE_INFO_SECTION,
+     VIEW_ID_PAGE_INFO_COOKIES_SYNC,
+     VIEW_ID_PAGE_INFO_PERMISSION_SUBTITLE_LABEL,
++    VIEW_ID_PAGE_INFO_HELIUM_NOISE_TOGGLE,
+   };
+ 
+   // Creates a separator view with padding on top and bottom. Use with flex
+@@ -114,6 +116,9 @@ class PageInfoViewFactory {
+   // Returns the icon for the secure connection button.
+   static const ui::ImageModel GetConnectionSecureIcon();
+ 
++  // Returns the Helium Noise icon for the given enabled state.
++  static const ui::ImageModel GetNoiseIcon(bool enabled);
++
+   // Returns the icon for a button which opens a subpage within page info.
+   static const ui::ImageModel GetOpenSubpageIcon();
+ 
+@@ -134,6 +139,7 @@ class PageInfoViewFactory {
+       content::WebContents* web_contents);
+   [[nodiscard]] std::unique_ptr<views::View> CreateAdPersonalizationPageView();
+   [[nodiscard]] std::unique_ptr<views::View> CreateCookiesPageView();
++  [[nodiscard]] std::unique_ptr<views::View> CreateNoisePageView();
+   [[nodiscard]] std::unique_ptr<views::View> CreateMerchantTrustPageView();
+ 
+  private:
+--- a/chrome/browser/ui/views/page_info/page_info_navigation_handler.h
++++ b/chrome/browser/ui/views/page_info/page_info_navigation_handler.h
+@@ -20,6 +20,7 @@ class PageInfoNavigationHandler {
+   virtual void OpenPermissionPage(ContentSettingsType type) = 0;
+   virtual void OpenAdPersonalizationPage() = 0;
+   virtual void OpenCookiesPage() = 0;
++  virtual void OpenNoisePage() = 0;
+   virtual void OpenMerchantTrustPage() = 0;
+   virtual void CloseBubble() = 0;
+ };
+--- a/chrome/browser/ui/views/page_info/page_info_bubble_view.cc
++++ b/chrome/browser/ui/views/page_info/page_info_bubble_view.cc
+@@ -318,6 +318,15 @@ void PageInfoBubbleView::OpenCookiesPage
+   AnnouncePageOpened(l10n_util::GetStringUTF16(IDS_PAGE_INFO_COOKIES));
+ }
+ 
++void PageInfoBubbleView::OpenNoisePage() {
++  std::unique_ptr<views::View> noise_page_view =
++      view_factory_->CreateNoisePageView();
++  noise_page_view->SetID(PageInfoViewFactory::VIEW_ID_PAGE_INFO_CURRENT_VIEW);
++  page_container_->SwitchToPage(std::move(noise_page_view));
++  AnnouncePageOpened(
++      l10n_util::GetStringUTF16(IDS_PAGE_INFO_HELIUM_NOISE_HEADER));
++}
++
+ void PageInfoBubbleView::OpenMerchantTrustPage() {
+   CHECK(merchant_trust_coordinator_);
+   auto title = l10n_util::GetStringUTF16(IDS_PAGE_INFO_MERCHANT_TRUST_HEADER);
+--- a/chrome/browser/ui/views/page_info/page_info_bubble_view.h
++++ b/chrome/browser/ui/views/page_info/page_info_bubble_view.h
+@@ -45,6 +45,7 @@ class PageInfoBubbleView : public PageIn
+   void OpenPermissionPage(ContentSettingsType type) override;
+   void OpenAdPersonalizationPage() override;
+   void OpenCookiesPage() override;
++  void OpenNoisePage() override;
+   void OpenMerchantTrustPage() override;
+   void CloseBubble() override;
+ 
+--- a/chrome/browser/ui/views/page_info/page_info_main_view.cc
++++ b/chrome/browser/ui/views/page_info/page_info_main_view.cc
+@@ -12,6 +12,7 @@
+ #include "base/strings/utf_string_conversions.h"
+ #include "build/build_config.h"
+ #include "chrome/browser/browser_process.h"
++#include "chrome/browser/helium_noise/helium_noise_settings.h"
+ #include "chrome/browser/lookalikes/safety_tip_ui_helper.h"
+ #include "chrome/browser/page_info/page_info_features.h"
+ #include "chrome/browser/ui/color/chrome_color_id.h"
+@@ -40,6 +41,7 @@
+ #include "components/vector_icons/vector_icons.h"
+ #include "content/public/browser/browser_task_traits.h"
+ #include "content/public/browser/browser_thread.h"
++#include "content/public/browser/web_contents.h"
+ #include "ui/base/l10n/l10n_util.h"
+ #include "ui/base/metadata/metadata_impl_macros.h"
+ #include "ui/base/models/image_model.h"
+@@ -131,6 +133,7 @@ PageInfoMainView::PageInfoMainView(
+ #endif
+ 
+   security_container_view_ = AddChildView(CreateContainerView());
++  MaybeAddNoiseButton();
+ 
+   permissions_view_ = AddChildView(std::make_unique<views::View>());
+   permissions_view_->SetLayoutManager(std::make_unique<views::FlexLayout>())
+@@ -218,6 +221,39 @@ void PageInfoMainView::SetCookieInfo(con
+       views::style::STYLE_BODY_4, kColorPageInfoSubtitleForeground);
+ }
+ 
++void PageInfoMainView::MaybeAddNoiseButton() {
++  content::WebContents* web_contents = ui_delegate_->GetWebContents();
++  if (!web_contents ||
++      !helium_noise::CanSetHeliumNoiseForOrigin(presenter_->site_url())) {
++    return;
++  }
++
++  const helium_noise::HeliumNoiseState noise_state =
++      helium_noise::GetHeliumNoiseState(web_contents->GetBrowserContext(),
++                                        presenter_->site_url());
++  if (noise_state == helium_noise::HeliumNoiseState::kUnavailable) {
++    return;
++  }
++  const bool noise_enabled =
++      noise_state == helium_noise::HeliumNoiseState::kEnabled;
++
++  noise_container_view_ = AddChildView(CreateContainerView());
++  auto* noise_button =
++      noise_container_view_->AddChildView(std::make_unique<RichHoverButton>(
++          base::BindRepeating(&PageInfoNavigationHandler::OpenNoisePage,
++                              base::Unretained(navigation_handler_)),
++          PageInfoViewFactory::GetNoiseIcon(noise_enabled),
++          l10n_util::GetStringUTF16(IDS_PAGE_INFO_HELIUM_NOISE_HEADER),
++          /*subtitle_text=*/std::u16string(),
++          PageInfoViewFactory::GetOpenSubpageIcon()));
++  noise_button->SetTooltipText(
++      l10n_util::GetStringUTF16(IDS_PAGE_INFO_HELIUM_NOISE_TOOLTIP));
++  noise_button->SetID(
++      PageInfoViewFactory::VIEW_ID_PAGE_INFO_LINK_OR_BUTTON_NOISE_SUBPAGE);
++  noise_button->SetTitleTextStyleAndColor(views::style::STYLE_BODY_3_MEDIUM,
++                                          kColorPageInfoForeground);
++}
++
+ void PageInfoMainView::SetPermissionInfo(
+     const PermissionInfoList& permission_info_list,
+     ChosenObjectInfoList chosen_object_info_list) {
+@@ -618,6 +654,11 @@ gfx::Size PageInfoMainView::CalculatePre
+     width =
+         std::max(width, security_container_view_->GetPreferredSize().width());
+   }
++
++  if (noise_container_view_) {
++    width =
++        std::max(width, noise_container_view_->GetPreferredSize().width());
++  }
+   return gfx::Size(width,
+                    GetLayoutManager()->GetPreferredHeightForWidth(this, width));
+ }
+--- a/chrome/browser/ui/views/page_info/page_info_main_view.h
++++ b/chrome/browser/ui/views/page_info/page_info_main_view.h
+@@ -129,6 +129,8 @@ class PageInfoMainView : public views::V
+   // the label depending on the number of visible permissions.
+   void UpdateResetButton(const PermissionInfoList& permission_info_list);
+ 
++  void MaybeAddNoiseButton();
++
+   void OnMerchantTrustDataFetched(
+       const GURL& url,
+       std::optional<page_info::MerchantData> merchant_data);
+@@ -223,6 +225,8 @@ class PageInfoMainView : public views::V
+ 
+   raw_ptr<views::View> security_container_view_ = nullptr;
+ 
++  raw_ptr<views::View> noise_container_view_ = nullptr;
++
+   raw_ptr<views::LabelButton, AcrossTasksDanglingUntriaged> reset_button_ =
+       nullptr;
+ 

--- a/patches/helium/ui/layout/centered-address-bar.patch
+++ b/patches/helium/ui/layout/centered-address-bar.patch
@@ -205,7 +205,7 @@
      </message>
 --- a/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
 +++ b/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
-@@ -558,6 +558,7 @@ void AddAppearanceStrings(content::WebUI
+@@ -559,6 +559,7 @@ void AddAppearanceStrings(content::WebUI
        {"browserLayoutCompact", IDS_SETTINGS_BROWSER_LAYOUT_COMPACT},
        {"browserLayoutVertical", IDS_SETTINGS_BROWSER_LAYOUT_VERTICAL},
        {"tabStripRightAlign", IDS_SETTINGS_TAB_STRIP_RIGHT_ALIGN},

--- a/patches/helium/ui/layout/minimal-location-bar.patch
+++ b/patches/helium/ui/layout/minimal-location-bar.patch
@@ -255,7 +255,7 @@
      </message>
 --- a/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
 +++ b/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
-@@ -560,6 +560,7 @@ void AddAppearanceStrings(content::WebUI
+@@ -561,6 +561,7 @@ void AddAppearanceStrings(content::WebUI
        {"tabStripRightAlign", IDS_SETTINGS_TAB_STRIP_RIGHT_ALIGN},
        {"centeredLocationBar", IDS_SETTINGS_CENTERED_LOCATION_BAR},
        {"verticalCollapseShortcut", IDS_SETTINGS_VERTICAL_COLLAPSE_SHORTCUT},

--- a/patches/helium/ui/layout/settings.patch
+++ b/patches/helium/ui/layout/settings.patch
@@ -41,7 +41,7 @@
      </message>
 --- a/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
 +++ b/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
-@@ -552,6 +552,12 @@ void AddAppearanceStrings(content::WebUI
+@@ -553,6 +553,12 @@ void AddAppearanceStrings(content::WebUI
        {"openNewTabNextToActive", IDS_SETTINGS_NEW_TAB_NEXT_TO_ACTIVE_BUTTON},
        {"cycleTabsInMRUOrder", IDS_SETTINGS_CYCLE_TABS_IN_MRU_ORDER},
        {"roundedFrame", IDS_SETTINGS_ROUNDED_FRAME},

--- a/patches/helium/ui/layout/shortcuts.patch
+++ b/patches/helium/ui/layout/shortcuts.patch
@@ -166,7 +166,7 @@
      VK_NEXT,        IDC_MOVE_TAB_NEXT,          VIRTKEY, CONTROL, SHIFT
 --- a/chrome/app/settings_strings.grdp
 +++ b/chrome/app/settings_strings.grdp
-@@ -4748,6 +4748,16 @@
+@@ -4774,6 +4774,16 @@
        Enable quick page link copying with Ctrl+Shift+C
      </message>
    </if>
@@ -185,7 +185,7 @@
    <message name="IDS_SETTINGS_AI_PAGE_MAIN_TITLE" desc="This string is the title of a card that sets the context for the ‘AI innovations’ section of Chrome’s settings. Here, the user can see settings related to AI (artificial intelligence) in this section; these settings include Help me write and more. This title is before the ‘Things to consider’ subheading and bullet points. We want users to read this card and understand the considerations that apply to all Chrome’s AI features. The tone should be motivating." formatter_data="android_java">
 --- a/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
 +++ b/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
-@@ -558,6 +558,7 @@ void AddAppearanceStrings(content::WebUI
+@@ -559,6 +559,7 @@ void AddAppearanceStrings(content::WebUI
        {"browserLayoutCompact", IDS_SETTINGS_BROWSER_LAYOUT_COMPACT},
        {"browserLayoutVertical", IDS_SETTINGS_BROWSER_LAYOUT_VERTICAL},
        {"tabStripRightAlign", IDS_SETTINGS_TAB_STRIP_RIGHT_ALIGN},
@@ -195,7 +195,7 @@
        {"showHomeButton", IDS_SETTINGS_SHOW_HOME_BUTTON},
 --- a/chrome/browser/extensions/api/settings_private/prefs_util.cc
 +++ b/chrome/browser/extensions/api/settings_private/prefs_util.cc
-@@ -675,6 +675,8 @@ const PrefsUtil::TypedPrefMap& PrefsUtil
+@@ -677,6 +677,8 @@ const PrefsUtil::TypedPrefMap& PrefsUtil
        settings_api::PrefType::kBoolean;
    (*s_allowlist)[::prefs::kCopyPageUrlShortcut] =
        settings_api::PrefType::kBoolean;

--- a/patches/helium/ui/layout/zen-mode-wiring.patch
+++ b/patches/helium/ui/layout/zen-mode-wiring.patch
@@ -34,7 +34,7 @@
      </message>
 --- a/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
 +++ b/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
-@@ -285,9 +285,9 @@ void AddA11yStrings(content::WebUIDataSo
+@@ -286,9 +286,9 @@ void AddA11yStrings(content::WebUIDataSo
        {"focusHighlightLabel",
         IDS_SETTINGS_ACCESSIBILITY_FOCUS_HIGHLIGHT_DESCRIPTION},
        {"toastAlertLevelTitle",
@@ -46,7 +46,7 @@
  #endif
  #if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_MAC)
        {"overscrollHistoryNavigationTitle",
-@@ -558,6 +558,10 @@ void AddAppearanceStrings(content::WebUI
+@@ -559,6 +559,10 @@ void AddAppearanceStrings(content::WebUI
        {"browserLayoutCompact", IDS_SETTINGS_BROWSER_LAYOUT_COMPACT},
        {"browserLayoutVertical", IDS_SETTINGS_BROWSER_LAYOUT_VERTICAL},
        {"tabStripRightAlign", IDS_SETTINGS_TAB_STRIP_RIGHT_ALIGN},

--- a/patches/helium/ui/native-frame-materials.patch
+++ b/patches/helium/ui/native-frame-materials.patch
@@ -104,7 +104,7 @@
      </message>
 --- a/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
 +++ b/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
-@@ -552,6 +552,9 @@ void AddAppearanceStrings(content::WebUI
+@@ -553,6 +553,9 @@ void AddAppearanceStrings(content::WebUI
        {"openNewTabNextToActive", IDS_SETTINGS_NEW_TAB_NEXT_TO_ACTIVE_BUTTON},
        {"cycleTabsInMRUOrder", IDS_SETTINGS_CYCLE_TABS_IN_MRU_ORDER},
        {"roundedFrame", IDS_SETTINGS_ROUNDED_FRAME},
@@ -114,7 +114,7 @@
        {"browserLayout", IDS_SETTINGS_BROWSER_LAYOUT},
        {"browserLayoutClassic", IDS_SETTINGS_BROWSER_LAYOUT_CLASSIC},
        {"browserLayoutDynamic", IDS_SETTINGS_BROWSER_LAYOUT_DYNAMIC},
-@@ -659,6 +662,8 @@ void AddAppearanceStrings(content::WebUI
+@@ -660,6 +663,8 @@ void AddAppearanceStrings(content::WebUI
  
    html_source->AddBoolean("showCtrlTabMru",
                            base::FeatureList::IsEnabled(features::kCtrlTabMru));

--- a/patches/helium/ui/page-zoom-indicator.patch
+++ b/patches/helium/ui/page-zoom-indicator.patch
@@ -434,7 +434,7 @@
      </message>
 --- a/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
 +++ b/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
-@@ -570,6 +570,7 @@ void AddAppearanceStrings(content::WebUI
+@@ -571,6 +571,7 @@ void AddAppearanceStrings(content::WebUI
        {"minimalLocationBar", IDS_SETTINGS_MINIMAL_LOCATION_BAR},
        {"shiftRightClickContextMenu",
         IDS_SETTINGS_SHIFT_RIGHT_CLICK_CONTEXT_MENU},

--- a/patches/helium/ui/rounded-frame-corners.patch
+++ b/patches/helium/ui/rounded-frame-corners.patch
@@ -36,7 +36,7 @@
      </message>
 --- a/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
 +++ b/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
-@@ -551,6 +551,7 @@ void AddAppearanceStrings(content::WebUI
+@@ -552,6 +552,7 @@ void AddAppearanceStrings(content::WebUI
        {"systemMode", IDS_NTP_CUSTOMIZE_CHROME_COLOR_SCHEME_MODE_SYSTEM_LABEL},
        {"openNewTabNextToActive", IDS_SETTINGS_NEW_TAB_NEXT_TO_ACTIVE_BUTTON},
        {"cycleTabsInMRUOrder", IDS_SETTINGS_CYCLE_TABS_IN_MRU_ORDER},

--- a/patches/series
+++ b/patches/series
@@ -224,6 +224,7 @@ helium/settings/custom-profile-avatar-ui.patch
 helium/settings/custom-keyboard-shortcuts-page.patch
 helium/settings/clear-browsing-data-popup.patch
 helium/settings/crash-reporting-settings.patch
+helium/settings/helium-noise-settings.patch
 
 helium/hop/setup.patch
 helium/hop/disable-password-manager.patch
@@ -322,3 +323,4 @@ helium/ui/dont-antialias-rects.patch
 helium/ui/fix-windows-ui-position.patch
 helium/ui/native-frame-materials.patch
 helium/ui/page-zoom-indicator.patch
+helium/ui/helium-noise-page-info.patch


### PR DESCRIPTION
now users can toggle helium noise globally or per origin/domain (including wildcards). this change also gives fingerprinting protection a home with a description of how it works.

- added a global pref for helium noise
- added origin-based content setting for helium noise
- added a settings helper for getting the noise activation state
- added a page and an entry point to browser privacy settings
- added page info controls for helium noise for quick per-origin changes
- cleaned up noise includes and public header registration

https://github.com/user-attachments/assets/bf271c22-f166-4551-ac41-f4a62827c2a1
