### PR TITLE
helium/core/search: update google image search url

### DIFF
--- a/patches/helium/core/search/restore-google.patch
+++ b/patches/helium/core/search/restore-google.patch
@@ -32,7 +32,7 @@
 -      "send_x_geo_header": true,
 +      "search_url": "https://www.google.com/search?q={searchTerms}",
 +      "suggest_url": "https://www.google.com/complete/search?client=chrome&q={searchTerms}",
-+      "image_url": "https://www.google.com/searchbyimage/upload",
++      "image_url": "https://lens.google.com/upload",
 +      "image_url_post_params": "encoded_image={google:imageThumbnail}",
 +      "type": "SEARCH_ENGINE_OTHER",
        "id": 1


### PR DESCRIPTION
google has killed the old one for an amazing reason