### PR TITLE
helium/core/search: add startpage and brave search

### DIFF
--- a/patches/helium/core/search/break-favicons.patch
+++ b/patches/helium/core/search/break-favicons.patch
@@ -1,32 +1,50 @@
 --- a/third_party/search_engines_data/resources/definitions/prepopulated_engines.json
 +++ b/third_party/search_engines_data/resources/definitions/prepopulated_engines.json
-@@ -52,7 +52,7 @@
+@@ -52,9 +52,9 @@
      "bing": {
        "name": "Microsoft Bing",
        "keyword": "bing.com",
 -      "favicon_url": "https://www.bing.com/favicon.ico",
 +      "favicon_url": "",
        "base_builtin_resource_id": "SEARCH_ENGINE_BING",
-       "logo_url": "https://cdn.sapphire.microsoftapp.net/icons/bing_144.png",
+-      "logo_url": "https://cdn.sapphire.microsoftapp.net/icons/bing_144.png",
++      "logo_url": "",
        "search_url": "https://www.bing.com/search?q={searchTerms}",
-@@ -121,7 +121,7 @@
+       "suggest_url": "https://www.bing.com/osjson.aspx?query={searchTerms}&language={language}",
+       "image_url": "https://www.bing.com/images/detail/search?iss=sbiupload&FORM=CHROMI#enterInsights",
+@@ -80,7 +80,7 @@
+     "brave": {
+       "name": "Brave",
+       "keyword": "search.brave.com",
+-      "favicon_url": "https://cdn.search.brave.com/serp/favicon.ico",
++      "favicon_url": "",
+       "base_builtin_resource_id": "SEARCH_ENGINE_BRAVE",
+       "search_url": "https://search.brave.com/search?q={searchTerms}",
+       "suggest_url": "https://search.brave.com/api/suggest?q={searchTerms}",
+@@ -121,9 +121,9 @@
      "duckduckgo": {
        "name": "DuckDuckGo",
        "keyword": "duckduckgo.com",
 -      "favicon_url": "https://duckduckgo.com/favicon.ico",
 +      "favicon_url": "",
        "base_builtin_resource_id": "SEARCH_ENGINE_DUCKDUCKGO",
-       "logo_url": "https://staticcdn.duckduckgo.com/android/DuckDuckGoLogo.png",
+-      "logo_url": "https://staticcdn.duckduckgo.com/android/DuckDuckGoLogo.png",
++      "logo_url": "",
        "search_url": "https://duckduckgo.com/?q={searchTerms}",
-@@ -140,7 +140,7 @@
+       "suggest_url": "https://duckduckgo.com/ac/?q={searchTerms}&type=list",
+       "new_tab_url": "https://duckduckgo.com/chrome_newtab",
+@@ -140,9 +140,9 @@
      "ecosia": {
        "name": "Ecosia",
        "keyword": "ecosia.org",
 -      "favicon_url": "https://cdn.ecosia.org/assets/images/ico/favicon.ico",
 +      "favicon_url": "",
        "base_builtin_resource_id": "SEARCH_ENGINE_ECOSIA",
-       "logo_url": "https://www.ecosia.org/static/icons/ecosia-logo-app-144x144.png",
+-      "logo_url": "https://www.ecosia.org/static/icons/ecosia-logo-app-144x144.png",
++      "logo_url": "",
        "search_url": "https://www.ecosia.org/search?q={searchTerms}",
+       "suggest_url": "https://ac.ecosia.org?q={searchTerms}&mkt={language}&type=list&language={language}",
+       "new_tab_url": "https://www.ecosia.org/newtab/",
 @@ -174,7 +174,7 @@
      "break_stuff_google": {
        "name": "Google",
@@ -54,3 +72,12 @@
        "base_builtin_resource_id": "SEARCH_ENGINE_QWANT",
        "search_url": "https://www.qwant.com/?q={searchTerms}",
        "suggest_url": "https://api.qwant.com/api/suggest/?q={searchTerms}",
+@@ -411,7 +411,7 @@
+     "startpage": {
+       "name": "startpage",
+       "keyword": "startpage.com",
+-      "favicon_url": "https://www.startpage.com/favicon.ico",
++      "favicon_url": "",
+       "base_builtin_resource_id": "SEARCH_ENGINE_STARTPAGE",
+       "search_url": "https://www.startpage.com/sp/search?q={searchTerms}",
+       "suggest_url": "https://www.startpage.com/osuggestions?q={searchTerms}",

--- a/patches/helium/core/search/bump-engines-version.patch
+++ b/patches/helium/core/search/bump-engines-version.patch
@@ -1,0 +1,11 @@
+--- a/third_party/search_engines_data/resources/definitions/prepopulated_engines.json
++++ b/third_party/search_engines_data/resources/definitions/prepopulated_engines.json
+@@ -28,7 +28,7 @@
+     // existing data should get a new version. Otherwise, existing data may
+     // continue to be used and updates made here will not always appear.
+     // Also then run tools/search_engine_choice/generate_search_engine_icons.py.
+-    "kCurrentDataVersion": 206
++    "kCurrentDataVersion": 207
+   },
+ 
+   // The following engines are included in country lists and are added to the

--- a/patches/helium/core/search/engine-defaults.patch
+++ b/patches/helium/core/search/engine-defaults.patch
@@ -21,7 +21,7 @@
        "AD": "ES",
        "AF": "ZZ",
        "AG": "ZZ",
-@@ -151,6 +152,19 @@
+@@ -151,6 +152,21 @@
      "type": "map"
    },
    "elements": {
@@ -33,7 +33,9 @@
 +          "&bing",
 +          "&break_stuff_google",
 +          "&qwant",
-+          "&kagi"
++          "&kagi",
++          "&startpage",
++          "&brave"
 +      ]
 +    }
 +  },
@@ -41,7 +43,7 @@
      "AE": {
        "search_engines": [
          "&google",
-@@ -1230,4 +1244,4 @@
+@@ -1230,4 +1246,4 @@
        ]
      }
    }

--- a/patches/helium/core/search/fix-startpage-brave-names.patch
+++ b/patches/helium/core/search/fix-startpage-brave-names.patch
@@ -1,0 +1,20 @@
+--- a/third_party/search_engines_data/resources/definitions/prepopulated_engines.json
++++ b/third_party/search_engines_data/resources/definitions/prepopulated_engines.json
+@@ -78,7 +78,7 @@
+     },
+ 
+     "brave": {
+-      "name": "Brave",
++      "name": "Brave Search",
+       "keyword": "search.brave.com",
+       "favicon_url": "",
+       "base_builtin_resource_id": "SEARCH_ENGINE_BRAVE",
+@@ -411,7 +411,7 @@
+     },
+ 
+     "startpage": {
+-      "name": "startpage",
++      "name": "Startpage",
+       "keyword": "startpage.com",
+       "favicon_url": "",
+       "base_builtin_resource_id": "SEARCH_ENGINE_STARTPAGE",

--- a/patches/series
+++ b/patches/series
@@ -118,6 +118,8 @@ helium/core/search/remove-description-snippet-deps.patch
 helium/core/search/break-favicons.patch
 helium/core/search/omnibox-default-search-icon.patch
 helium/core/search/add-kagi-image-search.patch
+helium/core/search/fix-startpage-brave-names.patch
+helium/core/search/bump-engines-version.patch
 
 helium/settings/setup-behavior-settings-page.patch
 helium/core/keyboard-shortcuts.patch


### PR DESCRIPTION
this PR:
- adds startpage and brave search, and fixes its names
- removes related favicon and logo urls to prevent unintentional requests
- bumps prepopulated_engine's `kCurrentDataVersion` to make sure existing profiles get new engines ahead of upstream bump

closes #92
closes #177
closes #618