### PR TITLE
deps: update search_engines_data and onboarding

### DIFF
--- a/deps.ini
+++ b/deps.ini
@@ -1,16 +1,17 @@
 # Everything that's downloaded after cloning Chromium goes here.
 # It will not work from main downloads.ini
 [search_engines_data]
-url = https://gist.githubusercontent.com/wukko/2a591364dda346e10219e4adabd568b1/raw/e75ae3c4a1ce940ef7627916a48bc40882d24d40/nonfree-search-engines-data.tar.gz
-download_filename = nonfree-search-engines-data.tar.gz
-sha256 = 00a87050fa3f941d04d67fb5763991e0b8ea399a88b505ab0e56dd263f06864c
+version = 202607242007
+url = https://github.com/imputnet/helium-nonfree-assets/releases/download/%(version)s/nonfree-search-engines-data-%(version)s.tar.gz
+download_filename = nonfree-search-engines-data-%(version)s.tar.gz
+sha256 = e14fa5b38ced15ae516143da23edcba608eea63e54960173ae8829f08efffb58
 output_path = ./third_party/search_engines_data/resources_internal
 
 [onboarding]
-version = 202607132006
+version = 202607241958
 url = https://github.com/imputnet/helium-onboarding/releases/download/%(version)s/helium-onboarding-%(version)s.tar.gz
 download_filename = onboarding-page-%(version)s.tar.gz
-sha256 = 668b5d3a95a5f991e6673803004ad753500f8a016dbacfed60dc91c7cad0b242
+sha256 = 3e026530dd93f5ef660f66d21bc7547123b053984a44d6ce310696c9dded98ce
 output_path = ./components/helium_onboarding
 
 # If you are bumping this, you *NEED* to re-strip the assets.json

--- a/i18n/source.gen.json
+++ b/i18n/source.gen.json
@@ -1231,28 +1231,10 @@
     "message": "Configure your browser just the way you want it, or use\nthe default preset with best privacy and comfort."
   },
   {
-    "name": "IDS_HELIUM_ONBOARDING_WELCOME_TERMS_NOTE",
+    "name": "IDS_HELIUM_ONBOARDING_WELCOME_TERMS",
     "source": "components/helium_onboarding/helium_onboarding_strings.grdp",
-    "context": "Legal note prefix before privacy policy and terms links.",
-    "message": "By continuing, you agree to the"
-  },
-  {
-    "name": "IDS_HELIUM_ONBOARDING_WELCOME_TERMS_PRIVACY",
-    "source": "components/helium_onboarding/helium_onboarding_strings.grdp",
-    "context": "Privacy policy link text in the onboarding legal note.",
-    "message": "privacy policy"
-  },
-  {
-    "name": "IDS_HELIUM_ONBOARDING_WELCOME_TERMS_AND",
-    "source": "components/helium_onboarding/helium_onboarding_strings.grdp",
-    "context": "Conjunction between privacy policy and terms links in the onboarding legal note.",
-    "message": "and"
-  },
-  {
-    "name": "IDS_HELIUM_ONBOARDING_WELCOME_TERMS_USE",
-    "source": "components/helium_onboarding/helium_onboarding_strings.grdp",
-    "context": "Terms of use link text in the onboarding legal note.",
-    "message": "terms of use"
+    "context": "Legal note shown during onboarding. Keep each BEGIN/END placeholder pair around its corresponding link text, but move the pairs as needed for a natural translation.",
+    "message": "By continuing, you agree to the <ph name=\"BEGIN_LINK_PRIVACY\">$1</ph>privacy policy<ph name=\"END_LINK_PRIVACY\">$2</ph> and <ph name=\"BEGIN_LINK_TERMS\">$3</ph>terms of use<ph name=\"END_LINK_TERMS\">$4</ph>."
   },
   {
     "name": "IDS_HELIUM_ONBOARDING_WELCOME_FOOTER",
@@ -1420,25 +1402,25 @@
     "name": "IDS_HELIUM_ONBOARDING_SEARCH_ENGINES_DUCKDUCKGO",
     "source": "components/helium_onboarding/helium_onboarding_strings.grdp",
     "context": "Onboarding description of DuckDuckGo as a search engine option.",
-    "message": "Privacy-focused. Relies on Bing results but promises to never track or profile you."
+    "message": "Privacy-focused. Relies on Bing for results. Promises not to track or profile you."
   },
   {
     "name": "IDS_HELIUM_ONBOARDING_SEARCH_ENGINES_KAGI",
     "source": "components/helium_onboarding/helium_onboarding_strings.grdp",
     "context": "Onboarding description of Kagi as a search engine option.",
-    "message": "Privacy-focused. Customizable results without ads or tracking. Requires a paid account."
+    "message": "Privacy-focused. Doesn't use Google or Bing. Has custom ranking. Requires a paid account. No ads, tracking, or profiling."
   },
   {
     "name": "IDS_HELIUM_ONBOARDING_SEARCH_ENGINES_QWANT",
     "source": "components/helium_onboarding/helium_onboarding_strings.grdp",
     "context": "Onboarding description of Qwant as a search engine option.",
-    "message": "Based in Europe. Uses Bing results. Sends tracking data to Microsoft."
+    "message": "Based in Europe. Relies on Bing for results. Sends tracking data to Microsoft."
   },
   {
     "name": "IDS_HELIUM_ONBOARDING_SEARCH_ENGINES_ECOSIA",
     "source": "components/helium_onboarding/helium_onboarding_strings.grdp",
     "context": "Onboarding description of Ecosia as a search engine option.",
-    "message": "May plant trees for clicking ads. Relies on Bing and Google. Sends tracking data to Microsoft and Google."
+    "message": "May plant trees for clicking ads. Relies on Google and Bing for results. Sends tracking data to Google and Microsoft."
   },
   {
     "name": "IDS_HELIUM_ONBOARDING_SEARCH_ENGINES_BING",
@@ -1451,6 +1433,18 @@
     "source": "components/helium_onboarding/helium_onboarding_strings.grdp",
     "context": "Onboarding description of Google as a search engine option.",
     "message": "It's Google. It dominates the search market, collects extensive personal data, and profiles you."
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_SEARCH_ENGINES_STARTPAGE",
+    "source": "components/helium_onboarding/helium_onboarding_strings.grdp",
+    "context": "Onboarding description of Startpage as a search engine option.",
+    "message": "Privacy-focused. Relies on Google and Bing for results. Promises not to track or profile you."
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_SEARCH_ENGINES_BRAVE",
+    "source": "components/helium_onboarding/helium_onboarding_strings.grdp",
+    "context": "Onboarding description of Brave as a search engine option.",
+    "message": "Privacy-focused. Doesn't use Google or Bing. Promises not to track or profile you. May show promotions related to Brave services."
   },
   {
     "name": "IDS_HELIUM_ONBOARDING_DEFAULT_BROWSER_TITLE",

--- a/i18n/translations/fr.json
+++ b/i18n/translations/fr.json
@@ -881,26 +881,6 @@
     "message": "Configurez votre navigateur exactement comme vous le souhaitez, ou utilisez\nle préréglage par défaut, optimisé pour la confidentialité et le confort."
   },
   {
-    "name": "IDS_HELIUM_ONBOARDING_WELCOME_TERMS_NOTE",
-    "source": "By continuing, you agree to the",
-    "message": "En continuant, vous acceptez la"
-  },
-  {
-    "name": "IDS_HELIUM_ONBOARDING_WELCOME_TERMS_PRIVACY",
-    "source": "privacy policy",
-    "message": "politique de confidentialité"
-  },
-  {
-    "name": "IDS_HELIUM_ONBOARDING_WELCOME_TERMS_AND",
-    "source": "and",
-    "message": "et les"
-  },
-  {
-    "name": "IDS_HELIUM_ONBOARDING_WELCOME_TERMS_USE",
-    "source": "terms of use",
-    "message": "conditions d'utilisation"
-  },
-  {
     "name": "IDS_HELIUM_ONBOARDING_WELCOME_FOOTER",
     "source": "You can skip setup and come back later, but Helium services won't work without it.",
     "message": "Vous pouvez ignorer la configuration et y revenir plus tard, mais les services Helium ne fonctionneront pas sans elle."
@@ -1030,26 +1010,6 @@
     "name": "IDS_HELIUM_ONBOARDING_SEARCH_CATEGORIES_CUSTOM",
     "source": "A custom search engine. Its privacy\nwasn't verified by Helium.",
     "message": "Un moteur de recherche personnalisé. Son respect\nde la vie privée n’a pas été vérifié par Helium."
-  },
-  {
-    "name": "IDS_HELIUM_ONBOARDING_SEARCH_ENGINES_DUCKDUCKGO",
-    "source": "Privacy-focused. Relies on Bing results but promises to never track or profile you.",
-    "message": "Axé sur la confidentialité. S'appuie sur les résultats de Bing, mais promet de ne jamais vous suivre ni vous profiler."
-  },
-  {
-    "name": "IDS_HELIUM_ONBOARDING_SEARCH_ENGINES_KAGI",
-    "source": "Privacy-focused. Customizable results without ads or tracking. Requires a paid account.",
-    "message": "Axé sur la confidentialité. Résultats personnalisables, sans publicité ni suivi. Nécessite un compte payant."
-  },
-  {
-    "name": "IDS_HELIUM_ONBOARDING_SEARCH_ENGINES_QWANT",
-    "source": "Based in Europe. Uses Bing results. Sends tracking data to Microsoft.",
-    "message": "Basé en Europe. Utilise les résultats de Bing. Envoie des données de suivi à Microsoft."
-  },
-  {
-    "name": "IDS_HELIUM_ONBOARDING_SEARCH_ENGINES_ECOSIA",
-    "source": "May plant trees for clicking ads. Relies on Bing and Google. Sends tracking data to Microsoft and Google.",
-    "message": "Peut planter des arbres lorsque vous cliquez sur des publicités. S'appuie sur Bing et Google. Envoie des données de suivi à Microsoft et Google."
   },
   {
     "name": "IDS_HELIUM_ONBOARDING_SEARCH_ENGINES_BING",


### PR DESCRIPTION
the updated dependencies include updated icons, search engine descriptions, and addition of startpage and brave search.

we now also use nonfree assets builds from a proper source of truth ([imputnet/helium-nonfree-assets](https://github.com/imputnet/helium-nonfree-assets)) instead of a random gist.

i18n-no-notify