### PR TITLE
i18n/uk: translate remaining strings

### DIFF
--- a/i18n/translations/uk.json
+++ b/i18n/translations/uk.json
@@ -998,5 +998,150 @@
     "name": "IDS_CONTENT_CONTEXT_SYSTEM_TRANSLATE",
     "source": "Translate “<ph name=\"SELECTION_TEXT\">$1<ex>Bonjour</ex></ph>”",
     "message": "Перекласти «<ph name=\"SELECTION_TEXT\">$1<ex>Bonjour</ex></ph>»"
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_PAGE_TITLE",
+    "source": "Helium Setup",
+    "message": "Налаштування Helium"
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_BUTTON_USE_DEFAULTS",
+    "source": "Use defaults",
+    "message": "Використати типові налаштування"
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_BUTTON_LETS_GO",
+    "source": "Let's go!",
+    "message": "Почнімо!"
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_PARTNER_TITLE",
+    "source": "Helium Partner",
+    "message": "Партнер Helium"
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_PARTNER_TOOLTIP",
+    "source": "Paying for this service will support\nthe development of Helium.",
+    "message": "Оплата цієї послуги підтримає\nрозробку Helium."
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_WELCOME_GREETING",
+    "source": "Meet Helium",
+    "message": "Знайомтеся з Helium"
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_WELCOME_BODY",
+    "source": "Configure your browser just the way you want it, or use\nthe default preset with best privacy and comfort.",
+    "message": "Налаштуйте браузер так, як вам зручно, або скористайтеся\nтиповим набором для оптимальної конфіденційності й комфорту."
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_WELCOME_TERMS",
+    "source": "By continuing, you agree to the <ph name=\"BEGIN_LINK_PRIVACY\">$1</ph>privacy policy<ph name=\"END_LINK_PRIVACY\">$2</ph> and <ph name=\"BEGIN_LINK_TERMS\">$3</ph>terms of use<ph name=\"END_LINK_TERMS\">$4</ph>.",
+    "message": "Продовжуючи, ви погоджуєтеся з <ph name=\"BEGIN_LINK_PRIVACY\">$1</ph>політикою конфіденційності<ph name=\"END_LINK_PRIVACY\">$2</ph> та <ph name=\"BEGIN_LINK_TERMS\">$3</ph>умовами використання<ph name=\"END_LINK_TERMS\">$4</ph>."
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_WELCOME_FOOTER",
+    "source": "You can skip setup and come back later, but Helium services won't work without it.",
+    "message": "Ви можете пропустити налаштування й повернутися до нього пізніше, але без нього служби Helium не працюватимуть."
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_FINISH_TITLE",
+    "source": "Ready to browse?",
+    "message": "Готові до перегляду?"
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_FINISH_BODY",
+    "source": "The setup is complete, thank you for choosing Helium.\nTime to enjoy the Internet again.",
+    "message": "Налаштування завершено. Дякуємо, що обрали Helium.\nЧас знову насолоджуватися інтернетом."
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_SERVICES_TITLE",
+    "source": "Helium services",
+    "message": "Служби Helium"
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_SERVICES_SUBTITLE",
+    "source": "Services are not active until you consent to using them.\nChanges will be applied after you go to the next page.",
+    "message": "Служби не працюватимуть, доки ви не погодитеся на їх використання.\nЗміни буде застосовано після переходу до наступної сторінки."
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_SERVICES_CONNECTION_TITLE",
+    "source": "Allow connecting to Helium services",
+    "message": "Дозволити підключення до служб Helium"
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_SERVICES_CONNECTION_DESC",
+    "source": "Helium services provide additional functionality, such as: extension downloads, native !bangs, filter list updates, and browser updates. When disabled, none of these features will work, but Helium will not make any web requests.",
+    "message": "Служби Helium надають додаткові можливості, як-от завантаження розширень, вбудовані !bang-команди, оновлення списків фільтрів і браузера. Якщо їх вимкнути, жодна з цих функцій не працюватиме, але Helium не надсилатиме жодних вебзапитів."
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_SERVICES_BANGS_TITLE",
+    "source": "Allow downloading the !bangs list",
+    "message": "Дозволити завантаження списку !bang-команд"
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_SERVICES_BANGS_DESC",
+    "source": "Helium will fetch a list of bangs that help you browse the Internet faster, such as !w or !gh. When disabled, bangs will not work.",
+    "message": "Helium завантажуватиме список !bang-команд, які допомагають швидше переглядати інтернет, наприклад !w або !gh. Якщо вимкнути цю функцію, !bang-команди не працюватимуть."
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_SERVICES_EXTENSIONS_TITLE",
+    "source": "Proxy extension downloads and updates",
+    "message": "Завантажувати й оновлювати розширення через проксі"
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_SERVICES_EXTENSIONS_DESC",
+    "source": "When enabled, Helium will proxy extension downloads and updates to protect your privacy. When disabled, downloading and updating extensions will not work.",
+    "message": "Коли цю функцію ввімкнено, Helium пропускатиме завантаження й оновлення розширень через проксі, щоб захистити вашу конфіденційність. Якщо її вимкнути, завантаження та оновлення розширень не працюватимуть."
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_SERVICES_UBLOCK_TITLE",
+    "source": "Allow downloading filter lists for uBlock Origin",
+    "message": "Дозволити завантаження списків фільтрів для uBlock Origin"
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_SERVICES_UBLOCK_DESC",
+    "source": "Helium will fetch fresh filter lists for uBlock Origin. All requests to lists are proxied to protect your privacy. When disabled, default filter lists will be loaded from local storage, which are only updated along with Helium. Optional filter lists will be requested without proxying.",
+    "message": "Helium отримуватиме оновлені списки фільтрів для uBlock Origin. Для захисту вашої конфіденційності всі запити до списків проходитимуть через проксі. Якщо цю функцію вимкнено, типові списки фільтрів завантажуватимуться з локального сховища й оновлюватимуться лише разом із Helium. Додаткові списки фільтрів запитуватимуться без проксі."
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_SERVICES_AUTOUPDATES_TITLE",
+    "source": "Allow automatic browser updates",
+    "message": "Дозволити автоматичне оновлення браузера"
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_SERVICES_AUTOUPDATES_DESC",
+    "source": "Helium will automatically check for updates and install them. This includes browser and component updates. We recommend keeping this setting enabled to ensure you get the latest features and security updates.",
+    "message": "Helium автоматично перевірятиме наявність оновлень і встановлюватиме їх. Це стосується оновлень браузера та компонентів. Рекомендуємо не вимикати це налаштування, щоб отримувати найновіші функції й оновлення безпеки."
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_SERVICES_AUTOUPDATES_TITLE_LINUX",
+    "source": "Allow automatic component updates",
+    "message": "Дозволити автоматичне оновлення компонентів"
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_SERVICES_AUTOUPDATES_DESC_LINUX",
+    "source": "Helium will automatically check for component updates and install them. We recommend keeping this setting enabled. On Linux, browser updates are handled by your distro's package manager. Please check for Helium package updates at least every week.",
+    "message": "Helium автоматично перевірятиме наявність оновлень компонентів і встановлюватиме їх. Рекомендуємо не вимикати це налаштування. У Linux оновлення браузера виконує менеджер пакетів вашого дистрибутива. Перевіряйте оновлення пакета Helium принаймні раз на тиждень."
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_SERVICES_SPELLCHECK_TITLE",
+    "source": "Allow downloading dictionary files for spell checking",
+    "message": "Дозволити завантаження файлів словників для перевірки правопису"
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_SERVICES_SPELLCHECK_DESC",
+    "source": "Helium will fetch dictionary files used for spell checking when requested. When disabled, spell checking will not work.",
+    "message": "Helium завантажуватиме файли словників для перевірки правопису за потреби. Якщо вимкнути цю функцію, перевірка правопису не працюватиме."
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_SERVICES_INSTANCE_TITLE",
+    "source": "Use your own instance of Helium services",
+    "message": "Використовувати власний екземпляр служб Helium"
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_SERVICES_INSTANCE_DESC",
+    "source": "You can host your own instance of Helium services and use it in your browser instead of the pre-hosted server. If you have one, you can set it in Helium settings.",
+    "message": "Ви можете розгорнути власний екземпляр служб Helium і використовувати його у своєму браузері замість готового сервера. Адресу такого екземпляра можна вказати в налаштуваннях Helium."
   }
 ]

--- a/i18n/translations/uk.json
+++ b/i18n/translations/uk.json
@@ -1143,5 +1143,150 @@
     "name": "IDS_HELIUM_ONBOARDING_SERVICES_INSTANCE_DESC",
     "source": "You can host your own instance of Helium services and use it in your browser instead of the pre-hosted server. If you have one, you can set it in Helium settings.",
     "message": "Ви можете розгорнути власний екземпляр служб Helium і використовувати його у своєму браузері замість готового сервера. Адресу такого екземпляра можна вказати в налаштуваннях Helium."
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_SEARCH_SUBTITLE",
+    "source": "You can change your choice later in Settings.\nEngines are ordered by privacy.",
+    "message": "Свій вибір можна змінити пізніше в налаштуваннях.\nПошукові системи впорядковано за рівнем конфіденційності."
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_SEARCH_CATEGORIES_PRIVATE",
+    "source": "A privacy-first search engine which\ndoesn't profile or track you.",
+    "message": "Пошукова система, орієнтована на конфіденційність,\nяка не створює ваш профіль і не відстежує вас."
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_SEARCH_CATEGORIES_SMALL",
+    "source": "Transparent, but not privacy-focused.\nOffers better privacy than mainstream\nsearch engines.",
+    "message": "Прозора, але не орієнтована на конфіденційність.\nЗабезпечує кращу конфіденційність, ніж популярні\nпошукові системи."
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_SEARCH_CATEGORIES_MAINSTREAM",
+    "source": "A mainstream search engine which\ncollects extensive personal data.",
+    "message": "Популярна пошукова система, яка\nзбирає значний обсяг персональних даних."
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_SEARCH_CATEGORIES_CUSTOM",
+    "source": "A custom search engine. Its privacy\nwasn't verified by Helium.",
+    "message": "Власна пошукова система. Helium не перевіряв\nрівень її конфіденційності."
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_SEARCH_ENGINES_DUCKDUCKGO",
+    "source": "Privacy-focused. Relies on Bing for results. Promises not to track or profile you.",
+    "message": "Орієнтована на конфіденційність. Використовує результати Bing. Обіцяє не відстежувати вас і не створювати ваш профіль."
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_SEARCH_ENGINES_KAGI",
+    "source": "Privacy-focused. Doesn't use Google or Bing. Has custom ranking. Requires a paid account. No ads, tracking, or profiling.",
+    "message": "Орієнтована на конфіденційність. Не використовує Google або Bing. Має власне ранжування. Потребує платного облікового запису. Без реклами, відстеження та профілювання."
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_SEARCH_ENGINES_QWANT",
+    "source": "Based in Europe. Relies on Bing for results. Sends tracking data to Microsoft.",
+    "message": "Розташована в Європі. Використовує результати Bing. Надсилає дані відстеження Microsoft."
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_SEARCH_ENGINES_ECOSIA",
+    "source": "May plant trees for clicking ads. Relies on Google and Bing for results. Sends tracking data to Google and Microsoft.",
+    "message": "Може висаджувати дерева за натискання на рекламу. Використовує результати Google і Bing. Надсилає дані відстеження Google і Microsoft."
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_SEARCH_ENGINES_BING",
+    "source": "Collects extensive personal data. Privacy controls are buried and limited. Subjectively overwhelming UI.",
+    "message": "Збирає значний обсяг персональних даних. Налаштування конфіденційності важко знайти, а їхні можливості обмежені. Інтерфейс суб’єктивно перевантажений."
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_SEARCH_ENGINES_GOOGLE",
+    "source": "It's Google. It dominates the search market, collects extensive personal data, and profiles you.",
+    "message": "Це Google. Він домінує на ринку пошуку, збирає значний обсяг персональних даних і створює ваш профіль."
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_SEARCH_ENGINES_STARTPAGE",
+    "source": "Privacy-focused. Relies on Google and Bing for results. Promises not to track or profile you.",
+    "message": "Орієнтована на конфіденційність. Використовує результати Google і Bing. Обіцяє не відстежувати вас і не створювати ваш профіль."
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_SEARCH_ENGINES_BRAVE",
+    "source": "Privacy-focused. Doesn't use Google or Bing. Promises not to track or profile you. May show promotions related to Brave services.",
+    "message": "Орієнтована на конфіденційність. Не використовує Google або Bing. Обіцяє не відстежувати вас і не створювати ваш профіль. Може показувати пропозиції, пов’язані зі службами Brave."
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_DEFAULT_BROWSER_TITLE",
+    "source": "Ready to switch to Helium?",
+    "message": "Готові перейти на Helium?"
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_DEFAULT_BROWSER_SUBTITLE",
+    "source": "Better privacy, speed, and comfort. All in one click.\nLet's make links open in Helium by default.",
+    "message": "Більше конфіденційності, швидкості й зручності. Усе одним натисканням.\nНехай посилання за замовчуванням відкриваються в Helium."
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_DEFAULT_BROWSER_YES_DESC",
+    "source": "Make Helium my default browser.",
+    "message": "Зробити Helium моїм браузером за замовчуванням."
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_DEFAULT_BROWSER_NO_DESC",
+    "source": "Just trying Helium for now.",
+    "message": "Поки що лише знайомлюся з Helium."
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_DATA_IMPORT_TITLE",
+    "source": "Take your stuff with you",
+    "message": "Перенесіть свої дані"
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_DATA_IMPORT_SUBTITLE",
+    "source": "Transfer your most important bookmarks, history,\n and extensions from other browsers.",
+    "message": "Перенесіть найважливіші закладки, історію\nта розширення з інших браузерів."
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_PASSWORD_TITLE",
+    "source": "Password manager",
+    "message": "Менеджер паролів"
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_PASSWORD_SUBTITLE",
+    "source": "Helium doesn't have a built-in password manager, by design.\n Would you like to install a browser-agnostic one?",
+    "message": "Helium навмисно не має вбудованого менеджера паролів.\nБажаєте встановити менеджер, який не залежить від браузера?"
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_PASSWORD_SETUP_GUIDE",
+    "source": "Setup",
+    "message": "Налаштувати"
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_PASSWORD_ERROR",
+    "source": "Error:",
+    "message": "Помилка:"
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_PASSWORD_MANAGERS_PROTON_PASS",
+    "source": "Secure and privacy-focused password manager by Proton. Stores data in Europe. All clients are open-source. Free with an optional paid plan.",
+    "message": "Безпечний менеджер паролів від Proton, орієнтований на конфіденційність. Зберігає дані в Європі. Усі клієнти мають відкритий вихідний код. Безкоштовний із додатковим платним тарифом."
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_PASSWORD_MANAGERS_BITWARDEN",
+    "source": "The most popular open-source password manager. Offers data storage in Europe or US. Free with an optional paid plan. Can be self-hosted.",
+    "message": "Найпопулярніший менеджер паролів із відкритим кодом. Пропонує зберігання даних у Європі або США. Безкоштовний із додатковим платним тарифом. Можна розгорнути на власному сервері."
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_PASSWORD_MANAGERS_ONE_PASSWORD",
+    "source": "Popular, paid, and closed-source password manager. Offers data storage in Europe or US. May not work correctly with Helium due to negligence.",
+    "message": "Популярний платний менеджер паролів із закритим кодом. Пропонує зберігання даних у Європі або США. Через недбалість розробників може некоректно працювати з Helium."
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_PASSWORD_MANAGERS_DASHLANE",
+    "source": "Popular, paid, and closed-source password manager. Stores data in Europe. Known for aggressive upselling tactics.",
+    "message": "Популярний платний менеджер паролів із закритим кодом. Зберігає дані в Європі. Відомий агресивним нав’язуванням платних функцій."
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_PASSWORD_MANAGERS_ICLOUD_PASSWORDS",
+    "source": "Free password manager by Apple. Will nag you about using Safari and require re-authentication on browser restart. Can't generate passwords.",
+    "message": "Безкоштовний менеджер паролів від Apple. Надокучатиме пропозиціями перейти на Safari й вимагатиме повторної автентифікації після перезапуску браузера. Не вміє генерувати паролі."
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_PASSWORD_MANAGERS_KEE_PASS_XC",
+    "source": "Local, free, and open-source password manager for advanced users. Requires technical knowledge to set up and use.",
+    "message": "Локальний безкоштовний менеджер паролів із відкритим кодом для досвідчених користувачів. Для налаштування й використання потрібні технічні знання."
   }
 ]

--- a/i18n/translations/uk.json
+++ b/i18n/translations/uk.json
@@ -823,5 +823,180 @@
     "name": "IDS_HELIUM_ONBOARDING_DATA_IMPORT_BOOKMARKS",
     "source": "Bookmarks",
     "message": "Закладки"
+  },
+  {
+    "name": "IDS_CONTENT_CONTEXT_SEARCHWEBWITH",
+    "source": "&amp;Search with <ph name=\"SEARCH_ENGINE\">$1<ex>DuckDuckGo</ex></ph>",
+    "message": "&amp;Шукати за допомогою <ph name=\"SEARCH_ENGINE\">$1<ex>DuckDuckGo</ex></ph>"
+  },
+  {
+    "name": "IDS_FORCE_PASTE",
+    "source": "Force paste",
+    "message": "Примусово вставити"
+  },
+  {
+    "name": "IDS_FORCE_PASTE",
+    "source": "Force Paste",
+    "message": "Примусово вставити"
+  },
+  {
+    "name": "IDS_SETTINGS_SHIFT_RIGHT_CLICK_CONTEXT_MENU",
+    "source": "Force context menu with Shift+Right Click",
+    "message": "Примусово показувати контекстне меню за допомогою Shift + клацання правою кнопкою миші"
+  },
+  {
+    "name": "IDS_SETTINGS_HELIUM_CRASH_REPORTING_TITLE",
+    "source": "Crash reporting",
+    "message": "Надсилання звітів про збої"
+  },
+  {
+    "name": "IDS_SETTINGS_HELIUM_CRASH_REPORTING_DESCRIPTION",
+    "source": "Choose whether Helium can ask to send crash reports or send them automatically. Disabling reports will delete all pending reports.",
+    "message": "Виберіть, чи може Helium запитувати дозволу на надсилання звітів про збої або надсилати їх автоматично. Якщо вимкнути звіти, усі звіти, що очікують на надсилання, буде видалено."
+  },
+  {
+    "name": "IDS_SETTINGS_HELIUM_CRASH_REPORTING_DISABLED",
+    "source": "Disabled",
+    "message": "Вимкнено"
+  },
+  {
+    "name": "IDS_SETTINGS_HELIUM_CRASH_REPORTING_ASK",
+    "source": "Ask after a crash",
+    "message": "Запитувати після збою"
+  },
+  {
+    "name": "IDS_SETTINGS_HELIUM_CRASH_REPORTING_AUTOMATIC",
+    "source": "Send automatically",
+    "message": "Надсилати автоматично"
+  },
+  {
+    "name": "IDS_SETTINGS_NOISE",
+    "source": "Fingerprinting protection",
+    "message": "Захист від цифрових відбитків"
+  },
+  {
+    "name": "IDS_SETTINGS_NOISE_LINK_DESCRIPTION",
+    "source": "Manage how Helium protects you against fingerprinting",
+    "message": "Налаштуйте захист Helium від створення цифрових відбитків"
+  },
+  {
+    "name": "IDS_SETTINGS_NOISE_TOGGLE_DESCRIPTION",
+    "source": "Make it harder for sites to fingerprint your browser and device",
+    "message": "Ускладнювати сайтам створення цифрового відбитка вашого браузера та пристрою"
+  },
+  {
+    "name": "IDS_SETTINGS_NOISE_DESCRIPTION",
+    "source": "When fingerprinting protection is enabled, Helium adds noise to certain browser features to make it harder for sites to track and profile you. Each site sees consistent randomized information during your browsing session to reduce the chances of detection.",
+    "message": "Коли захист від цифрових відбитків увімкнено, Helium додає шум до даних певних функцій браузера, щоб сайтам було складніше відстежувати вас і створювати ваш профіль. Протягом сеансу перегляду кожен сайт отримує узгоджені випадково змінені дані, що зменшує ймовірність виявлення захисту."
+  },
+  {
+    "name": "IDS_SETTINGS_NOISE_DISCLAIMER",
+    "source": "Fingerprinting cannot be fully prevented, but Helium's analysis defenses make it harder to recover the original fingerprint.",
+    "message": "Неможливо повністю запобігти створенню цифрових відбитків, але засоби захисту Helium від аналізу ускладнюють відновлення вихідного відбитка."
+  },
+  {
+    "name": "IDS_SETTINGS_NOISE_CUSTOM_DESCRIPTION",
+    "source": "When the general fingerprinting protection feature is enabled, sites listed below follow a custom setting. Inserting \"[*.]\" before a domain name applies it to the entire domain.",
+    "message": "Коли загальний захист від цифрових відбитків увімкнено, для наведених нижче сайтів застосовуються індивідуальні налаштування. Якщо додати «[*.]» перед доменним ім’ям, правило застосовуватиметься до всього домену."
+  },
+  {
+    "name": "IDS_SETTINGS_NOISE_EXCEPTIONS_TITLE",
+    "source": "Sites without fingerprinting protection",
+    "message": "Сайти без захисту від цифрових відбитків"
+  },
+  {
+    "name": "IDS_SETTINGS_NOISE_ALLOW_OVERRIDES_TITLE",
+    "source": "Overrides to allow fingerprinting protection",
+    "message": "Сайти з примусово ввімкненим захистом від цифрових відбитків"
+  },
+  {
+    "name": "IDS_HELIUM_CRASH_REPORTING_DIALOG_TITLE",
+    "source": "{COUNT, plural, =1 {Would you like to send a crash report?} other {Would you like to send # crash reports?}}",
+    "message": "{COUNT, plural, =1 {Надіслати звіт про збій?} one {Надіслати # звіт про збій?} few {Надіслати # звіти про збої?} many {Надіслати # звітів про збої?} other {Надіслати # звіту про збій?}}"
+  },
+  {
+    "name": "IDS_HELIUM_CRASH_REPORTING_DIALOG_DESCRIPTION",
+    "source": "Helium closed unexpectedly. A crash report could help us fix the issue you ran into and prevent it from happening again.",
+    "message": "Helium несподівано завершив роботу. Звіт про збій може допомогти нам виправити проблему, з якою ви зіткнулися, і запобігти її повторенню."
+  },
+  {
+    "name": "IDS_HELIUM_CRASH_REPORTING_DIALOG_PRIVACY",
+    "source": "A crash report may incidentally include some sensitive data present in Helium's memory at the time of crash.",
+    "message": "Звіт про збій може випадково містити конфіденційні дані, які перебували в пам’яті Helium на момент збою."
+  },
+  {
+    "name": "IDS_HELIUM_CRASH_REPORTING_DIALOG_OPTIONAL",
+    "source": "Nothing has been sent yet. Sending a crash report is optional.",
+    "message": "Поки нічого не надіслано. Надсилати звіт про збій необов’язково."
+  },
+  {
+    "name": "IDS_HELIUM_CRASH_REPORTING_DIALOG_SEND_REPORT",
+    "source": "{COUNT, plural, =1 {Send Report} other {Send # Reports}}",
+    "message": "{COUNT, plural, =1 {Надіслати звіт} one {Надіслати # звіт} few {Надіслати # звіти} many {Надіслати # звітів} other {Надіслати # звіту}}"
+  },
+  {
+    "name": "IDS_HELIUM_CRASH_REPORTING_DIALOG_SEND_REPORT",
+    "source": "{COUNT, plural, =1 {Send report} other {Send # reports}}",
+    "message": "{COUNT, plural, =1 {Надіслати звіт} one {Надіслати # звіт} few {Надіслати # звіти} many {Надіслати # звітів} other {Надіслати # звіту}}"
+  },
+  {
+    "name": "IDS_CRASH_DISABLED_MESSAGE",
+    "source": "Crash reporting is disabled in Helium settings or by policy.",
+    "message": "Надсилання звітів про збої вимкнено в налаштуваннях Helium або політикою."
+  },
+  {
+    "name": "IDS_CRASH_BUG_LINK_LABEL",
+    "source": "Create an issue with details",
+    "message": "Створити звіт про проблему з подробицями"
+  },
+  {
+    "name": "IDS_SETTINGS_NATIVE_FRAME_MATERIALS",
+    "source": "Use native frame materials (experimental)",
+    "message": "Використовувати системні матеріали рамки (експериментально)"
+  },
+  {
+    "name": "IDS_SETTINGS_NATIVE_FRAME_MATERIALS_DESCRIPTION",
+    "source": "Applies native materials to the browser frame surfaces. May cause UI clarity issues.",
+    "message": "Застосовує системні матеріали до поверхонь рамки браузера. Може погіршити чіткість інтерфейсу."
+  },
+  {
+    "name": "IDS_SETTINGS_SHOW_ZOOM_INDICATOR",
+    "source": "Show the zoom indicator in the address bar",
+    "message": "Показувати індикатор масштабу в адресному рядку"
+  },
+  {
+    "name": "IDS_PAGE_INFO_HELIUM_NOISE_HEADER",
+    "source": "Fingerprinting protection",
+    "message": "Захист від цифрових відбитків"
+  },
+  {
+    "name": "IDS_PAGE_INFO_HELIUM_NOISE_TOOLTIP",
+    "source": "Manage fingerprinting protection for this site",
+    "message": "Налаштувати захист від цифрових відбитків для цього сайту"
+  },
+  {
+    "name": "IDS_PAGE_INFO_HELIUM_NOISE_DESCRIPTION",
+    "source": "When fingerprinting protection is enabled, Helium adds noise to certain browser features to make it harder for sites to track and profile you.",
+    "message": "Коли захист від цифрових відбитків увімкнено, Helium додає шум до даних певних функцій браузера, щоб сайтам було складніше відстежувати вас і створювати ваш профіль."
+  },
+  {
+    "name": "IDS_PAGE_INFO_HELIUM_NOISE_BREAKAGE",
+    "source": "Turning off the protection will reduce your privacy, but may fix site features that require fingerprinting.",
+    "message": "Вимкнення захисту знизить вашу конфіденційність, але може відновити роботу функцій сайту, яким потрібне створення цифрового відбитка."
+  },
+  {
+    "name": "IDS_PAGE_INFO_HELIUM_NOISE_GLOBALLY_DISABLED",
+    "source": "Fingerprinting protection is turned off in Helium settings.",
+    "message": "Захист від цифрових відбитків вимкнено в налаштуваннях Helium."
+  },
+  {
+    "name": "IDS_PAGE_INFO_HELIUM_NOISE_SETTINGS_BUTTON",
+    "source": "Manage fingerprinting protection",
+    "message": "Налаштувати захист від цифрових відбитків"
+  },
+  {
+    "name": "IDS_CONTENT_CONTEXT_SYSTEM_TRANSLATE",
+    "source": "Translate “<ph name=\"SELECTION_TEXT\">$1<ex>Bonjour</ex></ph>”",
+    "message": "Перекласти «<ph name=\"SELECTION_TEXT\">$1<ex>Bonjour</ex></ph>»"
   }
 ]


### PR DESCRIPTION
For your pull request to not get closed without review, please confirm that:

- [ ] An issue exists where the maintainers agreed that this should be implemented
      (an approved feature request, or confirmed bug).
- [ ] I tested that my contribution works locally, and does not break anything,
      otherwise I have marked my PR as draft.
- [ ] If my contribution is non-trivial, I did not use AI to write most of it.
- [x] I understand that I will be permanently banned from interacting with this
      organization if I lied by checking any of these checkboxes.

Tested on (check one or more):
- [ ] Windows
- [ ] macOS
- [ ] Linux

---

Completes the Ukrainian localization by translating the 93 strings missing from `i18n/translations/uk.json`.

The changes cover context-menu actions, crash reporting, fingerprinting protection, onboarding, Helium services, search-engine descriptions, browser-data import, and password-manager descriptions.

Validation performed:

* `python3 -m json.tool i18n/translations/uk.json`
* `python3 devutils/i18n_lint.py`
* `git diff --check`
* verified that every unique source string has a Ukrainian translation
* verified that all `<ph>` placeholders are preserved

This translation draft was prepared with AI assistance and requires human review of the Ukrainian wording before being marked ready.