### PR TITLE
helium/core: fix PushManager.subscribe() hanging

### DIFF
--- a/devutils/tests/test_fail_fast_push_without_gcm.py
+++ b/devutils/tests/test_fail_fast_push_without_gcm.py
@@ -86,16 +86,15 @@ void GCMDriverDesktop::RemoveCachedData() {
         local_patch = root / 'test.patch'
         local_patch.write_text(''.join(local_patch_lines), encoding=ENCODING)
 
-        dry = subprocess.run(['patch', '-p1', '--dry-run', '-i',
-                              str(local_patch)],
-                             cwd=root,
-                             capture_output=True,
-                             text=True,
-                             check=False)
+        dry = subprocess.run(
+            ['patch', '-p1', '--dry-run', '-i', str(local_patch)],
+            cwd=root,
+            capture_output=True,
+            text=True,
+            check=False)
         assert dry.returncode == 0, dry.stdout + dry.stderr
 
-        applied = subprocess.run(['patch', '-p1', '-i',
-                                  str(local_patch)],
+        applied = subprocess.run(['patch', '-p1', '-i', str(local_patch)],
                                  cwd=root,
                                  capture_output=True,
                                  text=True,

--- a/devutils/tests/test_fail_fast_push_without_gcm.py
+++ b/devutils/tests/test_fail_fast_push_without_gcm.py
@@ -1,0 +1,110 @@
+# -*- coding: UTF-8 -*-
+
+# Copyright 2026 The Helium Authors
+# You can use, redistribute, and/or modify this source code under
+# the terms of the GPL-3.0 license that can be found in the LICENSE file.
+"""Test fail-fast-push-without-gcm.patch"""
+
+import logging
+import subprocess
+import tempfile
+from pathlib import Path
+
+ENCODING = 'UTF-8'
+
+
+def test_fail_fast_push_without_gcm():
+    """Test fail-fast-push-without-gcm.patch"""
+
+    logging.basicConfig(level=logging.DEBUG)
+    log = logging.getLogger('ungoogled')
+
+    patches_dir = Path(__file__).resolve().parents[2] / 'patches'
+    series_path = patches_dir / 'series'
+    patch_path = patches_dir / 'helium/core/fail-fast-push-without-gcm.patch'
+    patch_name = 'helium/core/fail-fast-push-without-gcm.patch'
+    prior_name = 'helium/core/fix-instance-id-stuck.patch'
+
+    fixture = """}
+
+GCMClient::Result GCMDriverDesktop::EnsureStarted(
+    GCMClient::StartMode start_mode) {
+  DCHECK(ui_thread_->RunsTasksInCurrentSequence());
+
+  if (gcm_started_)
+    return GCMClient::SUCCESS;
+
+  // Have any app requested the service?
+  if (app_handlers().empty())
+    return GCMClient::UNKNOWN_ERROR;
+
+  if (!delayed_task_controller_)
+    delayed_task_controller_ = std::make_unique<GCMDelayedTaskController>();
+
+  // Note that we need to pass weak pointer again since the existing weak
+  // pointer in IOWorker might have been invalidated when GCM is stopped.
+  io_thread_->PostTask(
+      FROM_HERE, base::BindOnce(&GCMDriverDesktop::IOWorker::Start,
+                                base::Unretained(io_worker_.get()), start_mode,
+                                weak_ptr_factory_.GetWeakPtr(),
+                                /*time_task_posted=*/base::TimeTicks::Now()));
+
+  return GCMClient::SUCCESS;
+}
+
+void GCMDriverDesktop::RemoveCachedData() {
+}
+"""
+
+    log.info('Check series placement')
+    series = [
+        line.strip() for line in series_path.read_text(encoding=ENCODING).splitlines()
+        if line.strip() and not line.strip().startswith('#')
+    ]
+    assert patch_name in series
+    assert series.index(patch_name) == series.index(prior_name) + 1
+
+    log.info('Check patch returns GCM_DISABLED')
+    patch_content = patch_path.read_text(encoding=ENCODING)
+    assert 'GCMDriverDesktop::EnsureStarted' in patch_content
+    assert patch_content.count('+  return GCMClient::GCM_DISABLED;') == 1
+    assert '-  return GCMClient::SUCCESS;' in patch_content
+
+    log.info('Check patch applies to EnsureStarted fixture')
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        root = Path(tmpdirname)
+        target = root / 'components/gcm_driver/gcm_driver_desktop.cc'
+        target.parent.mkdir(parents=True)
+        target.write_text(fixture, encoding=ENCODING)
+
+        local_patch_lines = []
+        for line in patch_content.splitlines(keepends=True):
+            if line.startswith('@@'):
+                local_patch_lines.append('@@ -1,28 +1,10 @@\n')
+            else:
+                local_patch_lines.append(line)
+        local_patch = root / 'test.patch'
+        local_patch.write_text(''.join(local_patch_lines), encoding=ENCODING)
+
+        dry = subprocess.run(['patch', '-p1', '--dry-run', '-i',
+                              str(local_patch)],
+                             cwd=root,
+                             capture_output=True,
+                             text=True,
+                             check=False)
+        assert dry.returncode == 0, dry.stdout + dry.stderr
+
+        applied = subprocess.run(['patch', '-p1', '-i',
+                                  str(local_patch)],
+                                 cwd=root,
+                                 capture_output=True,
+                                 text=True,
+                                 check=False)
+        assert applied.returncode == 0, applied.stdout + applied.stderr
+        patched = target.read_text(encoding=ENCODING)
+        assert 'return GCMClient::GCM_DISABLED;' in patched
+        assert 'delayed_task_controller_ = std::make_unique' not in patched
+
+
+if __name__ == '__main__':
+    test_fail_fast_push_without_gcm()

--- a/patches/helium/core/fail-fast-push-without-gcm.patch
+++ b/patches/helium/core/fail-fast-push-without-gcm.patch
@@ -1,0 +1,33 @@
+--- a/components/gcm_driver/gcm_driver_desktop.cc
++++ b/components/gcm_driver/gcm_driver_desktop.cc
+@@ -1189,28 +1189,10 @@ void GCMDriverDesktop::SetAccountTokens(
+ }
+ 
+ GCMClient::Result GCMDriverDesktop::EnsureStarted(
+-    GCMClient::StartMode start_mode) {
++    GCMClient::StartMode /*start_mode*/) {
+   DCHECK(ui_thread_->RunsTasksInCurrentSequence());
+ 
+-  if (gcm_started_)
+-    return GCMClient::SUCCESS;
+-
+-  // Have any app requested the service?
+-  if (app_handlers().empty())
+-    return GCMClient::UNKNOWN_ERROR;
+-
+-  if (!delayed_task_controller_)
+-    delayed_task_controller_ = std::make_unique<GCMDelayedTaskController>();
+-
+-  // Note that we need to pass weak pointer again since the existing weak
+-  // pointer in IOWorker might have been invalidated when GCM is stopped.
+-  io_thread_->PostTask(
+-      FROM_HERE, base::BindOnce(&GCMDriverDesktop::IOWorker::Start,
+-                                base::Unretained(io_worker_.get()), start_mode,
+-                                weak_ptr_factory_.GetWeakPtr(),
+-                                /*time_task_posted=*/base::TimeTicks::Now()));
+-
+-  return GCMClient::SUCCESS;
++  return GCMClient::GCM_DISABLED;
+ }
+ 
+ void GCMDriverDesktop::RemoveCachedData() {

--- a/patches/series
+++ b/patches/series
@@ -146,6 +146,7 @@ helium/core/tab-search-in-toolbar.patch
 helium/core/degoogle-context-menu.patch
 helium/core/fix-tab-sync-unreached-error.patch
 helium/core/fix-instance-id-stuck.patch
+helium/core/fail-fast-push-without-gcm.patch
 
 helium/core/flags-setup.patch
 helium/core/add-low-power-framerate-flag.patch


### PR DESCRIPTION
disable-gcm makes Start() a no-op, so GetToken never completes and subscribe() hangs forever. return GCM_DISABLED from EnsureStarted so it rejects with AbortError instead.

related to #927

For your pull request to not get closed without review, please confirm that:

- [x] An issue exists where the maintainers agreed that this should be implemented
      (an approved feature request, or confirmed bug).

Clarification: #927 is the approved Autopush FR. This PR does not implement Autopush. It only addresses the interim fail-fast suggestion IN that thread (reject subscribe() instead of hanging until real push lands).

- [x] I tested that my contribution works locally, and does not break anything,
      otherwise I have marked my PR as draft.
- [X] If my contribution is non-trivial, I did not use AI to write most of it.
- [x] I understand that I will be permanently banned from interacting with this
      organization if I lied by checking any of these checkboxes.

Tested on (check one or more):
- [ ] Windows
- [ ] macOS
- [x] Linux

---

## Summary

#927 asked for detectable failure until real push lands. Right now notification permission and local `Notification` work fine but `pushManager.subscribe()` never settles. Thus GCM never becomes ready under disable-gcm.

This makes `EnsureStarted` return `GCM_DISABLED` so subscribe rejects with `AbortError` ("Registration failed - push service error") as opposed to hanging. Same mapping chromium has for a disabled GCM client.

Tested on Linux with a helium-linux dev build. Subscribe fails in a few ms and local notifications still work. Also covered by a small patch apply regression test under `devutils/tests/`. Windows/Mac not tested.