### PR TITLE
patches: cleanup and fixes after 151 refresh

### DIFF
--- a/patches/helium/core/custom-keyboard-shortcuts.patch
+++ b/patches/helium/core/custom-keyboard-shortcuts.patch
@@ -1735,16 +1735,7 @@
  #endif
 --- a/chrome/browser/global_keyboard_shortcuts_mac.mm
 +++ b/chrome/browser/global_keyboard_shortcuts_mac.mm
-@@ -7,6 +7,8 @@
- #import <AppKit/AppKit.h>
- #include <Carbon/Carbon.h>
- 
-+#include <algorithm>
-+
- #include "base/apple/foundation_util.h"
- #include "base/check.h"
- #include "base/feature_list.h"
-@@ -79,7 +81,7 @@ bool MatchesEventForKeyboardShortcut(con
+@@ -79,7 +79,7 @@ bool MatchesEventForKeyboardShortcut(con
  }
  
  const std::vector<KeyboardShortcutData>&
@@ -1753,7 +1744,7 @@
    // clang-format off
    static base::NoDestructor<std::vector<KeyboardShortcutData>> keys({
      // cmd    shift  cntrl  option vkeycode               command
-@@ -183,6 +185,21 @@ const std::vector<KeyboardShortcutData>&
+@@ -183,6 +183,21 @@ const std::vector<KeyboardShortcutData>&
    return *keys;
  }
  
@@ -1775,7 +1766,7 @@
  const std::vector<NSMenuItem*>& GetMenuItemsNotPresentInMainMenu() {
    static base::NoDestructor<std::vector<NSMenuItem*>> menu_items([]() {
      std::vector<NSMenuItem*> menu_items;
-@@ -241,7 +258,7 @@ int DelayedWebContentsCommandForKeyEvent
+@@ -241,7 +256,7 @@ int DelayedWebContentsCommandForKeyEvent
  
    // Scan through keycodes and see if it corresponds to one of the non-menu
    // shortcuts.

--- a/patches/helium/settings/clear-browsing-data-popup.patch
+++ b/patches/helium/settings/clear-browsing-data-popup.patch
@@ -30,13 +30,6 @@
    </div>
    <div slot="button-container" class="row-aligned">
  <if expr="not is_chromeos">
-@@ -181,4 +165,4 @@
- <template is="dom-if" if="[[showOtherGoogleDataDialog_]]" restamp>
-   <settings-other-google-data-dialog on-cancel="onOtherGoogleDataDialogClose_">
-   </settings-other-google-data-dialog>
--</template>
-\ No newline at end of file
-+</template>
 --- a/chrome/browser/resources/settings/clear_browsing_data_dialog/clear_browsing_data_dialog.ts
 +++ b/chrome/browser/resources/settings/clear_browsing_data_dialog/clear_browsing_data_dialog.ts
 @@ -163,7 +163,7 @@ export class SettingsClearBrowsingDataDi

--- a/patches/helium/ui/find-bar.patch
+++ b/patches/helium/ui/find-bar.patch
@@ -1,6 +1,6 @@
 --- a/chrome/browser/ui/views/toolbar/toolbar_view.cc
 +++ b/chrome/browser/ui/views/toolbar/toolbar_view.cc
-@@ -1791,8 +1791,7 @@ const AppMenuControl* ToolbarView::GetAp
+@@ -1787,8 +1787,7 @@ const AppMenuControl* ToolbarView::GetAp
  }
  
  gfx::Rect ToolbarView::GetFindBarBoundingBox(int contents_bottom) {

--- a/patches/helium/ui/infobar.patch
+++ b/patches/helium/ui/infobar.patch
@@ -39,7 +39,7 @@
  #include "ui/views/cascading_property.h"
  #include "ui/views/controls/focus_ring.h"
  #include "ui/views/view_class_properties.h"
-@@ -33,61 +27,85 @@
+@@ -33,61 +27,82 @@
  
  namespace {
  
@@ -119,9 +119,6 @@
 +                               kSeparatorHeightDip, height()),
 +                     separator_color);
 +  }
-+  canvas->FillRect(gfx::Rect(0, height() - kSeparatorHeightDip, width(),
-+                             kSeparatorHeightDip),
-+                   separator_color);
  }
  
 -void ContentShadow::OnThemeChanged() {
@@ -151,7 +148,7 @@
    views::SetCascadingColorProviderColor(this, views::kCascadingBackgroundColor,
                                          kColorToolbar);
    SetBackground(
-@@ -107,50 +125,61 @@ bool InfoBarContainerView::IsEmpty() con
+@@ -107,50 +122,61 @@ bool InfoBarContainerView::IsEmpty() con
    return GetPreferredSize().height() == 0;
  }
  
@@ -258,16 +255,19 @@
  
    const bool would_have_separator = has_infobar || !is_split_view;
    switch (layout_data_->window_state) {
-@@ -202,7 +204,7 @@ BrowserViewTabbedLayoutImpl::CalculateSe
+@@ -202,8 +204,9 @@ BrowserViewTabbedLayoutImpl::CalculateSe
      case WindowState::kMaximized: {
        // Side panel shadow overlay is disabled in Helium.
        info.shadow_box = false;
 -      const bool suppress_separator = false;
+-      info.multi_contents_separator = !suppress_separator && !has_infobar;
 +      const bool suppress_separator = infobar_attached_to_rounded_frame;
-       info.multi_contents_separator = !suppress_separator && !has_infobar;
++      // Keep the regular contents separator below the infobar.
++      info.multi_contents_separator = !suppress_separator;
        info.top_container_separator = !suppress_separator && has_infobar;
        info.side_panel_top_padding = !is_force_to_top;
-@@ -687,6 +689,9 @@ BrowserViewTabbedLayoutImpl::CalculatePr
+       info.adjust_for_missing_separator =
+@@ -687,6 +690,9 @@ BrowserViewTabbedLayoutImpl::CalculatePr
    bool needs_exclusion = true;
    const bool adjust_for_cracking = AvoidCrackingForFractionalDisplay();
    const HorizontalLayout& horizontal_layout = layout_data_->horizontal_layout;
@@ -277,7 +277,7 @@
  
    // Lay out horizontal tab strip region if present.
    if (IsParentedTo(views().horizontal_tab_strip_region_view,
-@@ -1030,9 +1035,19 @@ BrowserViewTabbedLayoutImpl::CalculatePr
+@@ -1030,9 +1036,19 @@ BrowserViewTabbedLayoutImpl::CalculatePr
      params.SetTop(top_container_layout.bounds.bottom());
    }
  
@@ -298,7 +298,7 @@
      gfx::Rect infobar_bounds;
      if (infobar_visible) {
        // Infobars slide down with top container reveal, but not when they're in
-@@ -1061,7 +1076,8 @@ BrowserViewTabbedLayoutImpl::CalculatePr
+@@ -1061,7 +1077,8 @@ BrowserViewTabbedLayoutImpl::CalculatePr
    // especially obvious in split view, where turning the separator off provides
    // the required top padding.
    const auto& separator_info = layout_data_->separator_info;
@@ -379,41 +379,7 @@
  #endif  // CHROME_BROWSER_UI_VIEWS_INFOBARS_INFOBAR_CONTAINER_VIEW_H_
 --- a/chrome/browser/ui/views/frame/multi_contents_view.cc
 +++ b/chrome/browser/ui/views/frame/multi_contents_view.cc
-@@ -516,8 +516,9 @@ views::ProposedLayout MultiContentsView:
-     available_space.Inset(split_view_insets_);
-   } else if (should_use_rounded_frame) {
-     gfx::Insets single_insets(kSplitViewContentInset);
--    single_insets.set_top(
--        contents_separators_.should_show_top ? 0 : kSplitViewContentInset);
-+    const bool top_chrome_attached =
-+        contents_separators_.should_show_top || top_edge_attached_to_infobar_;
-+    single_insets.set_top(top_chrome_attached ? 0 : kSplitViewContentInset);
-     single_insets.set_left(contents_separators_.leading_side_chrome_attached
-                                ? 0
-                                : kSplitViewContentInset);
-@@ -646,6 +647,7 @@ gfx::Rect MultiContentsView::CalculateDr
-       drop_target_side_chrome_attached || !should_use_rounded_frame,
-       !is_drop_target_on_bottom && use_system_side_corners &&
-           !contents_separators_.should_show_top &&
-+          !top_edge_attached_to_infobar_ &&
-           !should_use_rounded_frame,
-       use_system_side_corners);
-   UpdateContentsBorderAndOverlay();
-@@ -674,9 +676,10 @@ gfx::Rect MultiContentsView::CalculateDr
-   if (!is_drop_target_on_bottom) {
-     int top_margin = 0;
-     if (IsInSplitView() || should_use_rounded_frame) {
--      top_margin = contents_separators_.should_show_top
--                       ? 0
--                       : kSplitViewContentInset;
-+      const bool top_chrome_attached =
-+          contents_separators_.should_show_top ||
-+          top_edge_attached_to_infobar_;
-+      top_margin = top_chrome_attached ? 0 : kSplitViewContentInset;
-     } else if (contents_separators_.should_show_top) {
-       top_margin =
-           contents_separators_.top_separator->GetPreferredSize().height();
-@@ -913,10 +916,18 @@ void MultiContentsView::OnRoundedFramePr
+@@ -913,10 +913,18 @@ void MultiContentsView::OnRoundedFramePr
  }
  
  void MultiContentsView::SetShouldShowTopSeparator(bool should_show) {

--- a/patches/helium/ui/layout/centered-address-bar.patch
+++ b/patches/helium/ui/layout/centered-address-bar.patch
@@ -119,7 +119,7 @@
  }  // namespace
  
  ////////////////////////////////////////////////////////////////////////////////
-@@ -681,6 +738,11 @@ void ToolbarView::Init() {
+@@ -677,6 +734,11 @@ void ToolbarView::Init() {
      OnShowMediaButtonChanged();
    }
  
@@ -131,7 +131,7 @@
    InitLayout();
  
    for (auto* button : std::array<views::Button*, 5>{back_, forward_, reload_,
-@@ -1584,7 +1646,11 @@ void ToolbarView::InitLayout() {
+@@ -1580,7 +1642,11 @@ void ToolbarView::InitLayout() {
                                 views::MaximumFlexSizeRule::kUnbounded)
            .WithOrder(location_bar_flex_order);
  
@@ -144,7 +144,7 @@
  
    layout_manager_->SetOrientation(views::LayoutOrientation::kHorizontal)
        .SetCrossAxisAlignment(views::LayoutAlignment::kCenter)
-@@ -1994,6 +2060,46 @@ void ToolbarView::OnShowMediaButtonChang
+@@ -1990,6 +2056,46 @@ void ToolbarView::OnShowMediaButtonChang
    InvalidateLayout();
  }
  

--- a/patches/helium/ui/layout/compact.patch
+++ b/patches/helium/ui/layout/compact.patch
@@ -191,7 +191,7 @@
  constexpr int kToolbarFlexOrderOffset = 1000;
  constexpr int kLocationBarFlexOrder = kToolbarFlexOrderOffset + 1;
  constexpr int kToolbarActionsFlexOrder = kToolbarFlexOrderOffset + 2;
-@@ -1348,6 +1350,22 @@ bool ToolbarView::IsRectInWindowCaption(
+@@ -1344,6 +1346,22 @@ bool ToolbarView::IsRectInWindowCaption(
      return gfx::ToEnclosingRect(rect_in_target_coords_f);
    };
  
@@ -214,7 +214,7 @@
    // Check each child view to see if the rect intersects with
    // any clickable elements. If it does, check if the click is actually on that
    // element. False if on a clickable element, true if not on a clickable element.
-@@ -1763,6 +1781,30 @@ void ToolbarView::LayoutCommon() {
+@@ -1759,6 +1777,30 @@ void ToolbarView::LayoutCommon() {
    // Cast button visibility is controlled externally.
  }
  
@@ -245,7 +245,7 @@
  void ToolbarView::UpdateToolbarLayout() {
    if (!location_bar_) {
      return;
-@@ -1773,7 +1815,10 @@ void ToolbarView::UpdateToolbarLayout()
+@@ -1769,7 +1811,10 @@ void ToolbarView::UpdateToolbarLayout()
                                 views::MaximumFlexSizeRule::kPreferred);
    const int location_bar_margin =
        GetLayoutConstant(LayoutConstant::kLocationBarMargin);
@@ -257,7 +257,7 @@
    const views::FlexSpecification location_bar_flex_rule =
        views::FlexSpecification(min_location_bar_flex,
                                 views::MaximumFlexSizeRule::kUnbounded)
-@@ -2115,7 +2160,7 @@ void ToolbarView::OnLocationBarCenteredC
+@@ -2111,7 +2156,7 @@ void ToolbarView::OnLocationBarCenteredC
  
  gfx::Rect ToolbarView::GetCenteredLocationBarBounds(gfx::Rect bounds,
                                                      int toolbar_width) const {
@@ -343,7 +343,7 @@
      elements.emplace_back(
 --- a/chrome/browser/ui/views/frame/layout/browser_view_tabbed_layout_impl.cc
 +++ b/chrome/browser/ui/views/frame/layout/browser_view_tabbed_layout_impl.cc
-@@ -310,6 +310,9 @@ BrowserViewTabbedLayoutImpl::GetMinimumT
+@@ -311,6 +311,9 @@ BrowserViewTabbedLayoutImpl::GetMinimumT
        }
        return std::make_pair(result, gfx::Size());
      }
@@ -353,7 +353,7 @@
      case TabStripType::kNone:
        return std::make_pair(gfx::Size(), gfx::Size());
    }
-@@ -592,6 +595,9 @@ BrowserViewTabbedLayoutImpl::GetTabStrip
+@@ -593,6 +596,9 @@ BrowserViewTabbedLayoutImpl::GetTabStrip
  #endif
      return TabStripType::kVertical;
    }

--- a/patches/helium/ui/layout/core.patch
+++ b/patches/helium/ui/layout/core.patch
@@ -206,14 +206,14 @@
    if (enable_state_lock_count_ > 0) {
      if (new_enabled != is_vertical_tabs_enabled_) {
        ToastController* const toast_controller =
-@@ -305,6 +301,7 @@ void VerticalTabStripStateController::On
-             new_enabled ? ToastId::kTabStripSwitchDelayedVertical
+@@ -306,6 +302,7 @@ void VerticalTabStripStateController::On
                          : ToastId::kTabStripSwitchDelayedHorizontal));
        }
-+      mode_changed_while_locked_ = true;
      }
++    mode_changed_while_locked_ = true;
      return;
    }
+ 
 @@ -315,8 +312,7 @@ void VerticalTabStripStateController::On
  }
  

--- a/patches/helium/ui/layout/dynamic.patch
+++ b/patches/helium/ui/layout/dynamic.patch
@@ -16,7 +16,7 @@
  #include "chrome/browser/ui/ui_features.h"
  #include "chrome/browser/ui/views/animations/side_panel_animations.h"
  #include "chrome/browser/ui/views/animations/tab_strip_animations.h"
-@@ -278,6 +280,9 @@ BrowserViewTabbedLayoutImpl::GetMinimumT
+@@ -279,6 +281,9 @@ BrowserViewTabbedLayoutImpl::GetMinimumT
      const BrowserLayoutParams& params) const {
    switch (GetTabStripType()) {
      case TabStripType::kHorizontal: {
@@ -26,7 +26,7 @@
        auto result = views().horizontal_tab_strip_region_view->GetMinimumSize();
        result.Enlarge(GetExclusionWidth(params), 0);
        return std::make_pair(gfx::Size(), result);
-@@ -320,6 +325,10 @@ BrowserViewTabbedLayoutImpl::CalculateHo
+@@ -321,6 +326,10 @@ BrowserViewTabbedLayoutImpl::CalculateHo
  
    layout.is_split_view = delegate().IsActiveTabSplit();
  
@@ -37,7 +37,7 @@
    if (views().side_panel &&
        views().side_panel->GetCurrentEntryType() == SidePanelType::kContent) {
      layout.force_top_container_to_top = true;
-@@ -595,6 +604,25 @@ HeliumLayoutType BrowserViewTabbedLayout
+@@ -596,6 +605,25 @@ HeliumLayoutType BrowserViewTabbedLayout
                      : HeliumLayoutType::kClassic;
  }
  
@@ -63,7 +63,7 @@
  BrowserViewTabbedLayoutImpl::VerticalTabStripCollapsedState
  BrowserViewTabbedLayoutImpl::GetVerticalTabStripCollapsedState() const {
    if (!views().vertical_tab_strip_region_view) {
-@@ -701,21 +729,29 @@ BrowserViewTabbedLayoutImpl::CalculatePr
+@@ -702,21 +730,29 @@ BrowserViewTabbedLayoutImpl::CalculatePr
    BrowserLayoutParams params = layout_data_->revised_params;
    bool needs_exclusion = true;
    const bool adjust_for_cracking = AvoidCrackingForFractionalDisplay();
@@ -95,7 +95,7 @@
        needs_exclusion = false;
      }
      layout.AddChild(views().horizontal_tab_strip_region_view, tabstrip_bounds,
-@@ -899,6 +935,22 @@ BrowserViewTabbedLayoutImpl::CalculatePr
+@@ -900,6 +936,22 @@ BrowserViewTabbedLayoutImpl::CalculatePr
          top_container_layout, top_container_params, needs_exclusion);
      top_container_layout.bounds =
          GetTopContainerBoundsInParent(top_container_local_bounds, params);
@@ -118,7 +118,7 @@
      params.SetTop(top_container_layout.bounds.bottom());
  
      // Possibly bump the leading margin of the top container out to cover the
-@@ -916,6 +968,22 @@ BrowserViewTabbedLayoutImpl::CalculatePr
+@@ -917,6 +969,22 @@ BrowserViewTabbedLayoutImpl::CalculatePr
      }
    }
  
@@ -141,7 +141,7 @@
    // Lay out the main area background.
    ProposedLayout* main_background_layout = nullptr;
    if (IsParentedTo(views().main_background_region, views().browser_view)) {
-@@ -1294,6 +1362,10 @@ gfx::Rect BrowserViewTabbedLayoutImpl::C
+@@ -1295,6 +1363,10 @@ gfx::Rect BrowserViewTabbedLayoutImpl::C
      BrowserLayoutParams params,
      bool needs_exclusion) const {
    const int original_top = params.visual_client_area.y();
@@ -152,7 +152,7 @@
  
    if (IsParentedTo(views().horizontal_tab_strip_region_view,
                     views().top_container)) {
-@@ -1334,6 +1406,17 @@ gfx::Rect BrowserViewTabbedLayoutImpl::C
+@@ -1335,6 +1407,17 @@ gfx::Rect BrowserViewTabbedLayoutImpl::C
      layout.AddChild(views().toolbar, toolbar_bounds, toolbar_visible);
    }
  
@@ -170,7 +170,7 @@
    // Lay out the bookmarks bar if one is present.
    const bool bookmarks_visible = delegate().IsBookmarkBarVisible();
    if (IsParentedTo(views().bookmark_bar, views().top_container)) {
-@@ -1378,6 +1461,7 @@ void BrowserViewTabbedLayoutImpl::Config
+@@ -1379,6 +1462,7 @@ void BrowserViewTabbedLayoutImpl::Config
    // In these cases, the top container's background color should match the
    // frame color to ensure visual consistency.
    if (GetTabStripType() == TabStripType::kHorizontal &&

--- a/patches/helium/ui/layout/shortcuts.patch
+++ b/patches/helium/ui/layout/shortcuts.patch
@@ -124,7 +124,7 @@
  #if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_CHROMEOS)
 --- a/chrome/browser/global_keyboard_shortcuts_mac.mm
 +++ b/chrome/browser/global_keyboard_shortcuts_mac.mm
-@@ -145,6 +145,8 @@ const std::vector<KeyboardShortcutData>&
+@@ -143,6 +143,8 @@ const std::vector<KeyboardShortcutData>&
        {true,  false, false, false, kVK_ANSI_9,            IDC_SELECT_LAST_TAB},
        {true,  false, false, false, kVK_ANSI_Keypad9,      IDC_SELECT_LAST_TAB},
  

--- a/patches/helium/ui/layout/toolbar-actions.patch
+++ b/patches/helium/ui/layout/toolbar-actions.patch
@@ -214,7 +214,7 @@
    if (extensions_container) {
      extensions_container_ = AddChildView(std::move(extensions_container));
      extensions_toolbar_coordinator_ =
-@@ -680,16 +742,6 @@ void ToolbarView::Init() {
+@@ -676,16 +738,6 @@ void ToolbarView::Init() {
    }
  
    if (glic::GlicEnabling::IsProfileEligible(browser_view_->GetProfile())) {
@@ -231,7 +231,7 @@
      UpdateGlicButtonVisibility();
    }
  
-@@ -707,6 +759,16 @@ void ToolbarView::Init() {
+@@ -703,6 +755,16 @@ void ToolbarView::Init() {
  
    reload_->SetVisible(show_reload_button_.GetValue());
  
@@ -248,7 +248,7 @@
    show_avatar_button_.Init(
        prefs::kShowAvatarButton, prefs,
        base::BindRepeating(&ToolbarView::OnShowAvatarButtonChanged,
-@@ -757,8 +819,9 @@ void ToolbarView::Init() {
+@@ -753,8 +815,9 @@ void ToolbarView::Init() {
        views::FlexSpecification(views::MinimumFlexSizeRule::kPreferred,
                                 views::MaximumFlexSizeRule::kPreferred);
  
@@ -260,7 +260,7 @@
      if (button) {
        button->set_tag(GetViewCommandMap().at(button->GetID()));
        button->SetProperty(views::kFlexBehaviorKey, flex_preferred);
-@@ -785,6 +848,12 @@ void ToolbarView::OnVerticalTabStripMode
+@@ -781,6 +844,12 @@ void ToolbarView::OnVerticalTabStripMode
    should_display_vertical_tabs_ = controller->ShouldDisplayVerticalTabs();
    UpdateGlicButtonVisibility();
    UpdateGlicActorVisibility();
@@ -273,7 +273,7 @@
  }
  
  std::unique_ptr<GlicAndActorButtonsContainer>
-@@ -1617,6 +1686,20 @@ void ToolbarView::OnThemeChanged() {
+@@ -1613,6 +1682,20 @@ void ToolbarView::OnThemeChanged() {
    SchedulePaint();
  }
  
@@ -294,7 +294,7 @@
  bool ToolbarView::AcceleratorPressed(const ui::Accelerator& accelerator) {
    const views::View* focused_view = focus_manager()->GetFocusedView();
    if (focused_view && (focused_view->GetID() == VIEW_ID_OMNIBOX)) {
-@@ -1768,15 +1851,36 @@ void ToolbarView::LayoutCommon() {
+@@ -1764,15 +1847,36 @@ void ToolbarView::LayoutCommon() {
        browser_->GetWindow() && (browser_->GetWindow()->IsMaximized() ||
                                  browser_->GetWindow()->IsFullscreen());
    const int margin = extend_buttons_to_edge ? interior_margin.left() : 0;
@@ -336,7 +336,7 @@
  
    // Cast button visibility is controlled externally.
  }
-@@ -1832,6 +1936,19 @@ void ToolbarView::UpdateToolbarLayout()
+@@ -1828,6 +1932,19 @@ void ToolbarView::UpdateToolbarLayout()
                       .WithOrder(order);
    };
  
@@ -356,7 +356,7 @@
    if (location_bar_view_) {
      location_bar_view_->SetProperty(views::kFlexBehaviorKey,
                                      location_bar_flex_rule);
-@@ -1876,6 +1993,67 @@ bool ToolbarView::IsCompactLayout() cons
+@@ -1872,6 +1989,67 @@ bool ToolbarView::IsCompactLayout() cons
    return controller && controller->IsCompactLayout();
  }
  

--- a/patches/helium/ui/layout/toolbar-layout.patch
+++ b/patches/helium/ui/layout/toolbar-layout.patch
@@ -19,7 +19,7 @@
  // Maximum portion of the window a "size-restricted" contents-height side panel
  // can take up. This is not the only limit on side panel size.
  constexpr float kMaxContentsHeightSidePanelFraction = 2.f / 3.f;
-@@ -582,6 +587,14 @@ BrowserViewTabbedLayoutImpl::GetTabStrip
+@@ -583,6 +588,14 @@ BrowserViewTabbedLayoutImpl::GetTabStrip
                                           : TabStripType::kNone;
  }
  
@@ -34,7 +34,7 @@
  BrowserViewTabbedLayoutImpl::VerticalTabStripCollapsedState
  BrowserViewTabbedLayoutImpl::GetVerticalTabStripCollapsedState() const {
    if (!views().vertical_tab_strip_region_view) {
-@@ -1297,15 +1310,20 @@ gfx::Rect BrowserViewTabbedLayoutImpl::C
+@@ -1298,15 +1311,20 @@ gfx::Rect BrowserViewTabbedLayoutImpl::C
                      layout_data_->tab_strip_type == TabStripType::kHorizontal);
    }
  
@@ -80,7 +80,7 @@
  // Gets the display mode for a given browser.
  ToolbarView::DisplayMode GetDisplayMode(Browser* browser) {
    // Checked in this order because even tabbed PWAs use the CUSTOM_TAB
-@@ -745,10 +751,15 @@ void ToolbarView::Init() {
+@@ -741,10 +747,15 @@ void ToolbarView::Init() {
  
    InitLayout();
  
@@ -96,7 +96,7 @@
      }
    }
  
-@@ -1624,27 +1635,6 @@ views::View* ToolbarView::GetDefaultFocu
+@@ -1620,27 +1631,6 @@ views::View* ToolbarView::GetDefaultFocu
  void ToolbarView::InitLayout() {
    const int default_margin =
        GetLayoutConstant(LayoutConstant::kToolbarIconDefaultMargin);
@@ -124,7 +124,7 @@
  
    layout_manager_ =
        SetLayoutManager(std::make_unique<CenteredLocationBarLayout>(
-@@ -1657,16 +1647,7 @@ void ToolbarView::InitLayout() {
+@@ -1653,16 +1643,7 @@ void ToolbarView::InitLayout() {
        .SetCollapseMargins(true)
        .SetDefault(views::kMarginsKey, gfx::Insets::VH(0, default_margin));
  
@@ -142,7 +142,7 @@
  
    if (extensions_container_) {
      const views::FlexSpecification extensions_flex_rule =
-@@ -1782,6 +1763,74 @@ void ToolbarView::LayoutCommon() {
+@@ -1778,6 +1759,74 @@ void ToolbarView::LayoutCommon() {
    // Cast button visibility is controlled externally.
  }
  

--- a/patches/helium/ui/layout/vertical.patch
+++ b/patches/helium/ui/layout/vertical.patch
@@ -39,7 +39,7 @@
  #include "ui/views/view_class_properties.h"
  #include "ui/views/view_utils.h"
  
-@@ -355,9 +355,6 @@ BrowserViewTabbedLayoutImpl::CalculateHo
+@@ -356,9 +356,6 @@ BrowserViewTabbedLayoutImpl::CalculateHo
        // Collapsed tab strip always gets its preferred size.
        min_vertical_tab_strip_width = preferred_vertical_tab_strip_width;
  
@@ -49,7 +49,7 @@
      } else {
        // Minimum size is bounded from below by size of leading exclusion area.
        if (layout.vertical_tab_strip_collapsed_state ==
-@@ -371,10 +368,6 @@ BrowserViewTabbedLayoutImpl::CalculateHo
+@@ -372,10 +369,6 @@ BrowserViewTabbedLayoutImpl::CalculateHo
              vertical_tab_strip->GetMinimumSize().width();
        }
  
@@ -60,7 +60,7 @@
        // Figure out the maximum size of the vertical tabstrip that can still
        // accommodate the toolbar.
        //
-@@ -481,6 +474,7 @@ BrowserViewTabbedLayoutImpl::CalculateVe
+@@ -482,6 +475,7 @@ BrowserViewTabbedLayoutImpl::CalculateVe
        gfx::Tween::DoubleValueBetween(open_amount, 0.0, -1.0);
    const bool is_split_view = layout_data_->horizontal_layout.is_split_view;
    const bool has_infobar = delegate().IsInfobarVisible();
@@ -68,7 +68,7 @@
    std::optional<double> max_uncollapsed_top_corner;
  
    if (layout_data_->tab_strip_type == TabStripType::kVertical) {
-@@ -497,8 +491,7 @@ BrowserViewTabbedLayoutImpl::CalculateVe
+@@ -498,8 +492,7 @@ BrowserViewTabbedLayoutImpl::CalculateVe
          break;
        case WindowState::kNormal:
        case WindowState::kMaximized:
@@ -78,7 +78,7 @@
            top_corner_collapsed_state =
                delegate().IsBookmarkBarVisible() || !would_have_separator
                    ? -1.0
-@@ -517,15 +510,11 @@ BrowserViewTabbedLayoutImpl::CalculateVe
+@@ -518,15 +511,11 @@ BrowserViewTabbedLayoutImpl::CalculateVe
  
    // Now that the proper default value is set, calculate all of the corner
    // animation values.
@@ -95,25 +95,25 @@
    animation.expand_on_hover =
        *controller->GetCurrentValue(TabStripAnimations::kVerticalTabStrip,
                                     TabStripAnimations::kTabStripHoverWidth);
-@@ -659,23 +648,16 @@ int BrowserViewTabbedLayoutImpl::GetColl
+@@ -660,23 +649,16 @@ int BrowserViewTabbedLayoutImpl::GetColl
  
    const auto& params = layout_data_->revised_params;
  
 -  // If there is no leading exclusion, the tabstrip goes all the way to the top.
 -  if (params.leading_exclusion.IsEmpty()) {
 -    return 0;
-+  if (delegate().IsToolbarVisible()) {
-+    return GetBoundsWithExclusion(params, views().toolbar).height();
-   }
- 
+-  }
+-
 -  const int exclusion_height =
 -      base::ClampCeil(params.leading_exclusion.ContentWithPadding().height());
 -
 -  // Try to align with toolbar. But if it's not visible, then don't.
 -  if (!delegate().IsToolbarVisible()) {
 -    return exclusion_height;
--  }
--
++  if (delegate().IsToolbarVisible()) {
++    return GetBoundsWithExclusion(params, views().toolbar).height();
+   }
+ 
 -  // Gets where the bottom of the toolbar will be laid out.
 -  const int provisional_toolbar_height =
 -      GetBoundsWithExclusion(params, views().toolbar).height();
@@ -127,7 +127,7 @@
  }
  
  gfx::Size BrowserViewTabbedLayoutImpl::GetMinimumSize(
-@@ -744,6 +726,9 @@ BrowserViewTabbedLayoutImpl::CalculatePr
+@@ -745,6 +727,9 @@ BrowserViewTabbedLayoutImpl::CalculatePr
    const bool infobar_visible = delegate().IsInfobarVisible();
    const bool should_use_rounded_frame =
        views().multi_contents_view->ShouldUseRoundedFrame();
@@ -137,7 +137,7 @@
  
    // Lay out horizontal tab strip region if present.
    if (!dynamic_tab_strip &&
-@@ -771,18 +756,12 @@ BrowserViewTabbedLayoutImpl::CalculatePr
+@@ -772,18 +757,12 @@ BrowserViewTabbedLayoutImpl::CalculatePr
    gfx::Rect unclipped_contents_region = params.visual_client_area;
  
    // Lay out vertical tab strip if visible.
@@ -156,7 +156,7 @@
        const int vertical_tab_strip_hover_width =
            std::max(0, tabs::kVerticalTabStripDefaultUncollapsedWidth -
                            horizontal_layout.vertical_tab_strip_width) *
-@@ -810,8 +789,12 @@ BrowserViewTabbedLayoutImpl::CalculatePr
+@@ -811,8 +790,12 @@ BrowserViewTabbedLayoutImpl::CalculatePr
          last_vertical_tab_strip_width_ = vertical_tab_strip_width;
        }
  
@@ -170,7 +170,7 @@
                      params.visual_client_area.y() +
                          vertical_tab_strip_animation.top_offset,
                      vertical_tab_strip_width,
-@@ -828,7 +811,7 @@ BrowserViewTabbedLayoutImpl::CalculatePr
+@@ -829,7 +812,7 @@ BrowserViewTabbedLayoutImpl::CalculatePr
        if (adjust_for_cracking) {
          inset_amount -= 1;
        }
@@ -179,7 +179,7 @@
  
        // Let the vertical tab strip animate out over the content.
        if (vertical_tab_strip_animation.current_motion) {
-@@ -837,11 +820,13 @@ BrowserViewTabbedLayoutImpl::CalculatePr
+@@ -838,11 +821,13 @@ BrowserViewTabbedLayoutImpl::CalculatePr
                  TabStripAnimations::kExpand ||
              vertical_tab_strip_animation.current_motion ==
                  TabStripAnimations::kCollapse;
@@ -197,7 +197,7 @@
        }
      }
      layout.AddChild(views().vertical_tab_strip_region_view,
-@@ -849,52 +834,6 @@ BrowserViewTabbedLayoutImpl::CalculatePr
+@@ -850,52 +835,6 @@ BrowserViewTabbedLayoutImpl::CalculatePr
                      layout_data_->tab_strip_type == TabStripType::kVertical);
    }
  
@@ -250,7 +250,7 @@
    // TODO(crbug.com/469425263): Ensure correct layout calculations for the
    // Project Panel Container.
    if (IsParentedToAndVisible(views().projects_panel_container,
-@@ -934,13 +873,32 @@ BrowserViewTabbedLayoutImpl::CalculatePr
+@@ -935,13 +874,44 @@ BrowserViewTabbedLayoutImpl::CalculatePr
          layout.AddChild(views().top_container, gfx::Rect());
  
      // Calculate the params for laying out the top container.
@@ -282,11 +282,23 @@
 +          bookmarks_bounds.set_x(bookmarks_bounds.x() + vertical_width);
 +        }
 +      }
++      auto separator_child =
++          top_container_children.find(views().top_container_separator);
++      if (separator_child != top_container_children.end() &&
++          !separator_child->second.bounds.IsEmpty()) {
++        const int vertical_width = horizontal_layout.vertical_tab_strip_width;
++        gfx::Rect& separator_bounds = separator_child->second.bounds;
++        separator_bounds.set_width(
++            std::max(0, separator_bounds.width() - vertical_width));
++        if (!vertical_right_aligned) {
++          separator_bounds.set_x(separator_bounds.x() + vertical_width);
++        }
++      }
 +    }
  
      if (dynamic_tab_strip &&
          layout_data_->tab_strip_type == TabStripType::kHorizontal) {
-@@ -958,20 +916,6 @@ BrowserViewTabbedLayoutImpl::CalculatePr
+@@ -959,20 +929,6 @@ BrowserViewTabbedLayoutImpl::CalculatePr
      }
  
      params.SetTop(top_container_layout.bounds.bottom());
@@ -307,7 +319,7 @@
    }
  
    if (dynamic_tab_strip) {
-@@ -1122,7 +1066,7 @@ BrowserViewTabbedLayoutImpl::CalculatePr
+@@ -1123,7 +1079,7 @@ BrowserViewTabbedLayoutImpl::CalculatePr
      params.SetTop(top_container_layout.bounds.bottom());
    }
  
@@ -316,7 +328,7 @@
      if (delegate().IsVerticalTabStripRightAligned()) {
        trailing_side_chrome_attached = true;
      } else {
-@@ -1277,7 +1221,8 @@ BrowserViewTabbedLayoutImpl::CalculatePr
+@@ -1278,7 +1234,8 @@ BrowserViewTabbedLayoutImpl::CalculatePr
        // view even if there's a shadow box, but since the curve is effectively
        // the same this will not produce a visual bug.
        const int radius =
@@ -326,7 +338,7 @@
        if (base::i18n::IsRTL()) {
          content_corners.set_lower_right(radius);
        } else {
-@@ -1289,75 +1234,31 @@ BrowserViewTabbedLayoutImpl::CalculatePr
+@@ -1290,75 +1247,31 @@ BrowserViewTabbedLayoutImpl::CalculatePr
  
    // Make final visual adjustments required for child views to paint.
    if (layout_data_->tab_strip_type == TabStripType::kVertical) {

--- a/patches/helium/ui/layout/zen-mode-wiring.patch
+++ b/patches/helium/ui/layout/zen-mode-wiring.patch
@@ -195,7 +195,7 @@
      VK_F6,          IDC_FOCUS_NEXT_PANE,        VIRTKEY
 --- a/chrome/browser/global_keyboard_shortcuts_mac.mm
 +++ b/chrome/browser/global_keyboard_shortcuts_mac.mm
-@@ -146,6 +146,7 @@ const std::vector<KeyboardShortcutData>&
+@@ -144,6 +144,7 @@ const std::vector<KeyboardShortcutData>&
        {true,  false, false, false, kVK_ANSI_Keypad9,      IDC_SELECT_LAST_TAB},
  
        {true,  false, false, false, kVK_ANSI_S,            IDC_CTRL_S_SHORTCUT},

--- a/patches/helium/ui/layout/zen-mode.patch
+++ b/patches/helium/ui/layout/zen-mode.patch
@@ -1124,7 +1124,7 @@
  // Maximum portion of the window a "size-restricted" contents-height side panel
  // can take up. This is not the only limit on side panel size.
  constexpr float kMaxContentsHeightSidePanelFraction = 2.f / 3.f;
-@@ -721,6 +804,8 @@ BrowserViewTabbedLayoutImpl::CalculatePr
+@@ -722,6 +805,8 @@ BrowserViewTabbedLayoutImpl::CalculatePr
        IsDynamicTabStrip(layout_data_->tab_strip_type);
    const bool show_dynamic_tab_strip =
        ShowDynamicTabStrip(layout_data_->tab_strip_type);
@@ -1133,7 +1133,7 @@
    std::optional<int> dynamic_tab_strip_top;
    const HorizontalLayout& horizontal_layout = layout_data_->horizontal_layout;
    const bool infobar_visible = delegate().IsInfobarVisible();
-@@ -739,14 +824,20 @@ BrowserViewTabbedLayoutImpl::CalculatePr
+@@ -740,14 +825,20 @@ BrowserViewTabbedLayoutImpl::CalculatePr
        const int leading_margin = GetHorizontalTabStripLeadingMargin(params);
        tabstrip_bounds = GetBoundsWithExclusion(
            params, views().horizontal_tab_strip_region_view, leading_margin);
@@ -1159,7 +1159,7 @@
    }
  
    // This will be the area next to the vertical tab strip (if present) that will
-@@ -762,14 +853,7 @@ BrowserViewTabbedLayoutImpl::CalculatePr
+@@ -763,14 +854,7 @@ BrowserViewTabbedLayoutImpl::CalculatePr
    if (IsParentedTo(views().vertical_tab_strip_region_view,
                     views().browser_view)) {
      if (layout_data_->tab_strip_type == TabStripType::kVertical) {
@@ -1175,7 +1175,7 @@
  
        // The overall width during an expand must change monotonically.
        if (vertical_tab_strip_animation.current_motion ==
-@@ -791,15 +875,30 @@ BrowserViewTabbedLayoutImpl::CalculatePr
+@@ -792,15 +876,30 @@ BrowserViewTabbedLayoutImpl::CalculatePr
  
        const int vertical_tab_strip_x =
            vertical_right_aligned
@@ -1215,7 +1215,7 @@
  
        if (layout_data_->window_state == WindowState::kFullscreenWithToolbar &&
            layout_data_->separator_info.adjust_for_missing_separator) {
-@@ -807,19 +906,25 @@ BrowserViewTabbedLayoutImpl::CalculatePr
+@@ -808,19 +907,25 @@ BrowserViewTabbedLayoutImpl::CalculatePr
              gfx::Insets::TLBR(views::Separator::kThickness, 0, 0, 0));
        }
  
@@ -1246,7 +1246,7 @@
          InsetHorizontal(unclipped_contents_region,
                          VerticalTabStripRegionView::kCollapsedWidth,
                          !vertical_right_aligned);
-@@ -831,7 +936,8 @@ BrowserViewTabbedLayoutImpl::CalculatePr
+@@ -832,7 +937,8 @@ BrowserViewTabbedLayoutImpl::CalculatePr
      }
      layout.AddChild(views().vertical_tab_strip_region_view,
                      vertical_tab_strip_bounds,
@@ -1256,7 +1256,7 @@
    }
  
    // TODO(crbug.com/469425263): Ensure correct layout calculations for the
-@@ -885,7 +991,8 @@ BrowserViewTabbedLayoutImpl::CalculatePr
+@@ -886,7 +992,8 @@ BrowserViewTabbedLayoutImpl::CalculatePr
      top_container_layout.bounds = GetTopContainerBoundsInParent(
          top_container_local_bounds, parent_params);
  
@@ -1266,7 +1266,7 @@
        auto& top_container_children = top_container_layout.children;
        auto bookmarks_child = top_container_children.find(views().bookmark_bar);
        if (bookmarks_child != top_container_children.end() &&
-@@ -907,15 +1014,40 @@ BrowserViewTabbedLayoutImpl::CalculatePr
+@@ -920,15 +1027,40 @@ BrowserViewTabbedLayoutImpl::CalculatePr
        if (const auto* toolbar_layout =
                top_container_layout.GetLayoutFor(views().toolbar);
            toolbar_layout && !toolbar_layout->bounds.IsEmpty()) {
@@ -1309,7 +1309,7 @@
    }
  
    if (dynamic_tab_strip) {
-@@ -923,15 +1055,21 @@ BrowserViewTabbedLayoutImpl::CalculatePr
+@@ -936,15 +1068,21 @@ BrowserViewTabbedLayoutImpl::CalculatePr
  
      const int tabstrip_height =
          views().horizontal_tab_strip_region_view->GetPreferredSize().height();
@@ -1339,7 +1339,7 @@
    }
  
    // Lay out the main area background.
-@@ -964,6 +1102,8 @@ BrowserViewTabbedLayoutImpl::CalculatePr
+@@ -977,6 +1115,8 @@ BrowserViewTabbedLayoutImpl::CalculatePr
    bool side_panel_leading = false;
    bool leading_side_chrome_attached = false;
    bool trailing_side_chrome_attached = false;
@@ -1348,7 +1348,7 @@
    const double side_panel_reveal_amount =
        horizontal_layout.has_side_panel()
            ? views().side_panel->GetAnimationValue()
-@@ -1066,11 +1206,14 @@ BrowserViewTabbedLayoutImpl::CalculatePr
+@@ -1079,11 +1219,14 @@ BrowserViewTabbedLayoutImpl::CalculatePr
      params.SetTop(top_container_layout.bounds.bottom());
    }
  
@@ -1364,7 +1364,7 @@
      }
    }
  
-@@ -1109,14 +1252,21 @@ BrowserViewTabbedLayoutImpl::CalculatePr
+@@ -1122,14 +1265,21 @@ BrowserViewTabbedLayoutImpl::CalculatePr
    const auto& separator_info = layout_data_->separator_info;
    views().multi_contents_view->SetTopChromeAttachmentState(
        infobar_visible && should_use_rounded_frame,
@@ -1389,7 +1389,7 @@
      const bool include_leading_inset =
          separator_info.shadow_box ||
          !(horizontal_layout.has_side_panel() && side_panel_leading);
-@@ -1126,11 +1276,17 @@ BrowserViewTabbedLayoutImpl::CalculatePr
+@@ -1139,11 +1289,17 @@ BrowserViewTabbedLayoutImpl::CalculatePr
      const int default_inset = MultiContentsView::kSplitViewContentInset;
      const int panel_side_inset =
          base::ClampRound((1.0 - side_panel_reveal_amount) * default_inset);
@@ -1410,7 +1410,7 @@
  
      views().multi_contents_view->SetSplitViewInsets(contents_insets);
    }
-@@ -1259,6 +1415,8 @@ BrowserViewTabbedLayoutImpl::CalculatePr
+@@ -1272,6 +1428,8 @@ BrowserViewTabbedLayoutImpl::CalculatePr
  
      views().vertical_tab_strip_region_view->SetHasLeadingExclusionForLayout(
          has_leading_exclusion);
@@ -1419,7 +1419,7 @@
    }
  
    return layout;
-@@ -1273,6 +1431,8 @@ gfx::Rect BrowserViewTabbedLayoutImpl::C
+@@ -1286,6 +1444,8 @@ gfx::Rect BrowserViewTabbedLayoutImpl::C
        IsDynamicTabStrip(layout_data_->tab_strip_type);
    const bool show_dynamic_tab_strip =
        ShowDynamicTabStrip(layout_data_->tab_strip_type);
@@ -1428,7 +1428,7 @@
  
    if (IsParentedTo(views().horizontal_tab_strip_region_view,
                     views().top_container)) {
-@@ -1281,12 +1441,19 @@ gfx::Rect BrowserViewTabbedLayoutImpl::C
+@@ -1294,12 +1454,19 @@ gfx::Rect BrowserViewTabbedLayoutImpl::C
        const int leading_margin = GetHorizontalTabStripLeadingMargin(params);
        tabstrip_bounds = GetBoundsWithExclusion(
            params, views().horizontal_tab_strip_region_view, leading_margin);
@@ -1451,7 +1451,7 @@
    }
  
    // Lay out toolbar. If toolbar is in the top-most row, it will go into the
-@@ -1307,21 +1474,26 @@ gfx::Rect BrowserViewTabbedLayoutImpl::C
+@@ -1320,21 +1487,26 @@ gfx::Rect BrowserViewTabbedLayoutImpl::C
                            params.visual_client_area.y(),
                            params.visual_client_area.width(),
                            views().toolbar->GetPreferredSize().height());
@@ -1482,7 +1482,7 @@
    }
  
    // Lay out the bookmarks bar if one is present.
-@@ -1330,24 +1502,33 @@ gfx::Rect BrowserViewTabbedLayoutImpl::C
+@@ -1343,24 +1515,33 @@ gfx::Rect BrowserViewTabbedLayoutImpl::C
      const gfx::Rect bookmarks_bounds(
          params.visual_client_area.x(), params.visual_client_area.y(),
          params.visual_client_area.width(),
@@ -1523,7 +1523,7 @@
    }
  
    return gfx::Rect(params.visual_client_area.x(), original_top,
-@@ -1355,13 +1536,60 @@ gfx::Rect BrowserViewTabbedLayoutImpl::C
+@@ -1368,13 +1549,60 @@ gfx::Rect BrowserViewTabbedLayoutImpl::C
                     params.visual_client_area.y() - original_top);
  }
  
@@ -1589,7 +1589,7 @@
    // parented to the `top_container()` and the frame header is not visible.
 --- a/chrome/browser/ui/views/toolbar/toolbar_view.cc
 +++ b/chrome/browser/ui/views/toolbar/toolbar_view.cc
-@@ -1687,7 +1687,7 @@ void ToolbarView::OnThemeChanged() {
+@@ -1683,7 +1683,7 @@ void ToolbarView::OnThemeChanged() {
  }
  
  void ToolbarView::NewTabButtonPressed(const ui::Event& event) {
@@ -1598,7 +1598,7 @@
  }
  
  void ToolbarView::VerticalTabsCollapseButtonPressed(const ui::Event& event) {
-@@ -1987,6 +1987,16 @@ void ToolbarView::UpdateToolbarLayout()
+@@ -1983,6 +1983,16 @@ void ToolbarView::UpdateToolbarLayout()
    InvalidateLayout();
  }
  
@@ -1615,7 +1615,7 @@
  bool ToolbarView::IsCompactLayout() const {
    auto* controller =
        HeliumLayoutStateController::From(browser_view_->browser());
-@@ -2024,8 +2034,11 @@ void ToolbarView::UpdateVerticalTabsColl
+@@ -2020,8 +2030,11 @@ void ToolbarView::UpdateVerticalTabsColl
  
    auto* controller =
        tabs::VerticalTabStripStateController::From(browser_view_->browser());
@@ -2096,18 +2096,17 @@
    }
  
    available_space =
-@@ -516,9 +563,7 @@ views::ProposedLayout MultiContentsView:
+@@ -516,8 +563,7 @@ views::ProposedLayout MultiContentsView:
      available_space.Inset(split_view_insets_);
    } else if (should_use_rounded_frame) {
      gfx::Insets single_insets(kSplitViewContentInset);
--    const bool top_chrome_attached =
--        contents_separators_.should_show_top || top_edge_attached_to_infobar_;
--    single_insets.set_top(top_chrome_attached ? 0 : kSplitViewContentInset);
+-    single_insets.set_top(
+-        contents_separators_.should_show_top ? 0 : kSplitViewContentInset);
 +    single_insets.set_top(attached_chrome.TopInset());
      single_insets.set_left(contents_separators_.leading_side_chrome_attached
                                 ? 0
                                 : kSplitViewContentInset);
-@@ -614,6 +659,7 @@ void MultiContentsView::BeforeApplyLayou
+@@ -613,6 +659,7 @@ void MultiContentsView::BeforeApplyLayou
  
  gfx::Rect MultiContentsView::CalculateDropTargetLayout(
      const gfx::Rect& available_space,
@@ -2115,7 +2114,7 @@
      std::vector<views::ChildLayout>& child_layouts) const {
    CHECK(IsDragAndDropEnabled());
    if (!drop_target_view_->GetVisible()) {
-@@ -631,13 +677,12 @@ gfx::Rect MultiContentsView::CalculateDr
+@@ -630,13 +677,12 @@ gfx::Rect MultiContentsView::CalculateDr
    const bool is_drop_target_on_bottom =
        drop_side == MultiContentsDropTargetView::DropSide::BOTTOM;
    const bool should_use_rounded_frame = ShouldUseRoundedFrame();
@@ -2132,33 +2131,31 @@
    }
    const views::Widget* widget = browser_view_->GetWidget();
    const bool use_system_side_corners =
-@@ -646,9 +691,8 @@ gfx::Rect MultiContentsView::CalculateDr
+@@ -645,8 +691,8 @@ gfx::Rect MultiContentsView::CalculateDr
        drop_target_side_chrome_attached,
        drop_target_side_chrome_attached || !should_use_rounded_frame,
        !is_drop_target_on_bottom && use_system_side_corners &&
 -          !contents_separators_.should_show_top &&
--          !top_edge_attached_to_infobar_ &&
 -          !should_use_rounded_frame,
 +          !attached_chrome.top &&
 +          (!should_use_rounded_frame || zen_mode),
        use_system_side_corners);
    UpdateContentsBorderAndOverlay();
  
-@@ -675,11 +719,8 @@ gfx::Rect MultiContentsView::CalculateDr
+@@ -673,10 +719,8 @@ gfx::Rect MultiContentsView::CalculateDr
  
    if (!is_drop_target_on_bottom) {
      int top_margin = 0;
 -    if (IsInSplitView() || should_use_rounded_frame) {
--      const bool top_chrome_attached =
--          contents_separators_.should_show_top ||
--          top_edge_attached_to_infobar_;
--      top_margin = top_chrome_attached ? 0 : kSplitViewContentInset;
+-      top_margin = contents_separators_.should_show_top
+-                       ? 0
+-                       : kSplitViewContentInset;
 +    if (IsInSplitView() || should_use_rounded_frame || zen_mode) {
 +      top_margin = attached_chrome.TopInset();
      } else if (contents_separators_.should_show_top) {
        top_margin =
            contents_separators_.top_separator->GetPreferredSize().height();
-@@ -816,6 +857,12 @@ bool MultiContentsView::ShouldUseRounded
+@@ -813,6 +857,12 @@ bool MultiContentsView::ShouldUseRounded
           !is_fullscreen;
  }
  
@@ -2171,7 +2168,7 @@
  void MultiContentsView::UpdateContentsBorderAndOverlay() const {
    const views::Widget* widget = browser_view_->GetWidget();
    const bool is_fullscreen = widget && widget->IsFullscreen();
-@@ -832,18 +879,26 @@ void MultiContentsView::UpdateContentsBo
+@@ -829,18 +879,26 @@ void MultiContentsView::UpdateContentsBo
    const bool is_drop_target_on_bottom =
        is_drop_target_visible &&
        drop_target_view_->side() == MultiContentsDropTargetView::DropSide::BOTTOM;
@@ -2207,7 +2204,7 @@
        !is_drop_target_on_bottom;
  
    for (auto* contents_container_view : contents_container_views_) {
-@@ -867,6 +922,8 @@ void MultiContentsView::UpdateContentsBo
+@@ -864,6 +922,8 @@ void MultiContentsView::UpdateContentsBo
      contents_container_view->UpdateBorderAndOverlay(
          is_in_split, should_round_contents, is_active,
          is_active && active_contents_view_highlighted_,
@@ -2216,7 +2213,7 @@
          use_system_bottom_left_radius && is_first_view,
          use_system_bottom_right_radius && is_last_view);
    }
-@@ -928,9 +985,7 @@ void MultiContentsView::SetTopChromeAtta
+@@ -925,9 +985,7 @@ void MultiContentsView::SetTopChromeAtta
    }
    top_edge_attached_to_infobar_ = top_edge_attached_to_infobar;
    contents_separators_.should_show_top = should_show_top_separator;
@@ -2227,7 +2224,7 @@
    // This can be called during BrowserView layout, so protect against creating a
    // layout loop.
    InvalidateLayout(/*avoid_propagate_during_layout=*/true);
-@@ -945,11 +1000,7 @@ void MultiContentsView::SetAttachedSideC
+@@ -942,11 +1000,7 @@ void MultiContentsView::SetAttachedSideC
    }
    contents_separators_.leading_side_chrome_attached = leading_attached;
    contents_separators_.trailing_side_chrome_attached = trailing_attached;

--- a/patches/helium/ui/native-frame-materials.patch
+++ b/patches/helium/ui/native-frame-materials.patch
@@ -983,17 +983,7 @@
  #include "chrome/browser/ui/views/infobars/infobar_view.h"
  #include "chrome/grit/generated_resources.h"
  #include "ui/accessibility/ax_enums.mojom.h"
-@@ -70,7 +71,8 @@ void ChromeBorder::SetState(bool rounded
- }
- 
- void ChromeBorder::OnPaint(gfx::Canvas* canvas) {
--  if (rounded_frame_enabled_ || width() <= 0 || height() <= 0) {
-+  if (helium::ShouldUseNativeFrameMaterials(this) || rounded_frame_enabled_ ||
-+      width() <= 0 || height() <= 0) {
-     return;
-   }
- 
-@@ -108,8 +110,7 @@ InfoBarContainerView::InfoBarContainerVi
+@@ -105,8 +106,7 @@ InfoBarContainerView::InfoBarContainerVi
    AddChildViewRaw(chrome_border_.get());
    views::SetCascadingColorProviderColor(this, views::kCascadingBackgroundColor,
                                          kColorToolbar);
@@ -1003,7 +993,7 @@
  
    GetViewAccessibility().SetRole(ax::mojom::Role::kGroup);
    GetViewAccessibility().SetName(
-@@ -140,9 +141,7 @@ void InfoBarContainerView::SetRoundedFra
+@@ -137,9 +137,7 @@ void InfoBarContainerView::SetRoundedFra
    static_cast<ChromeBorder*>(chrome_border_.get())
        ->SetState(rounded_frame_enabled, leading_side_chrome_attached,
                   trailing_side_chrome_attached);
@@ -1014,7 +1004,7 @@
  }
  
  void InfoBarContainerView::Layout(PassKey) {
-@@ -182,6 +181,11 @@ gfx::Size InfoBarContainerView::Calculat
+@@ -179,6 +177,11 @@ gfx::Size InfoBarContainerView::Calculat
    return preferred_size;
  }
  
@@ -1026,7 +1016,7 @@
  void InfoBarContainerView::PlatformSpecificAddInfoBar(
      infobars::InfoBar* infobar,
      size_t position) {
-@@ -255,5 +259,15 @@ void InfoBarContainerView::PlatformSpeci
+@@ -252,5 +255,15 @@ void InfoBarContainerView::PlatformSpeci
    }
  }
  
@@ -1118,17 +1108,17 @@
  #include "ui/gfx/favicon_size.h"
  #include "ui/gfx/geometry/insets.h"
  #include "ui/gfx/geometry/skia_conversions.h"
-@@ -540,7 +542,9 @@ float TabStyleViewsImpl::GetZValue() con
-   if (tab_->IsSelected()) {
-     sort_value += 4.f;
+@@ -555,7 +557,9 @@ bool TabStyleViewsImpl::IsApparentlyActi
+   if (selection_state == TabStyle::TabSelectionState::kActive) {
+     return true;
    }
 -  if (IsHovering()) {
 +  if (!helium::ShouldUseNativeFrameMaterials(
 +          tab_->controller()->GetBrowserWindowInterface()) &&
 +      IsHovering()) {
-     sort_value += 2.f;
+     return GetHoverOpacity() > 0.5f;
    }
- 
+   return selection_state == TabStyle::TabSelectionState::kSelected;
 @@ -801,6 +805,12 @@ int TabStyleViewsImpl::GetStrokeThicknes
  bool TabStyleViewsImpl::ShouldPaintTabBackgroundColor(
      TabStyle::TabSelectionState selection_state,
@@ -1180,7 +1170,7 @@
      gfx::ScopedCanvas scale_scoper(canvas);
      canvas->sk_canvas()->scale(scale, scale);
      gfx::ImageSkia* image =
-@@ -928,6 +953,8 @@ void TabStyleViewsImpl::PaintBackgroundH
+@@ -927,6 +952,8 @@ void TabStyleViewsImpl::PaintBackgroundH
        GetCurrentTabBackgroundColor(GetSelectionState(), /*hovered=*/true);
  
    if (features::IsGlassFrameEnabled() &&

--- a/patches/helium/ui/split-view.patch
+++ b/patches/helium/ui/split-view.patch
@@ -69,10 +69,11 @@
  }  // namespace
  
  DEFINE_CLASS_ELEMENT_IDENTIFIER_VALUE(SplitTabMenuModel,
-@@ -172,16 +153,6 @@ SplitTabMenuModel::SplitTabMenuModel(Tab
+@@ -171,17 +152,6 @@ SplitTabMenuModel::SplitTabMenuModel(Tab
+   SetElementIdentifierAt(
        GetIndexOfCommandId(GetCommandIdInt(CommandId::kExitSplit)).value(),
        kExitSplitMenuItem);
- 
+-
 -  // Only render feedback in the toolbar button menu.
 -  if (menu_source == MenuSource::kToolbarButton &&
 -      chrome::CanShowFeedback(tab_strip_model->profile())) {
@@ -86,7 +87,7 @@
  }
  
  SplitTabMenuModel::~SplitTabMenuModel() = default;
-@@ -280,9 +251,6 @@ void SplitTabMenuModel::ExecuteCommand(i
+@@ -280,9 +250,6 @@ void SplitTabMenuModel::ExecuteCommand(i
      case CommandId::kExitSplit:
        tab_strip_model_->RemoveSplit(split_id);
        break;
@@ -96,7 +97,7 @@
      case CommandId::kToggleOrientation: {
        split_tabs::SplitTabLayout new_layout =
            GetSplitLayout() == split_tabs::SplitTabLayout::kSideBySide
-@@ -354,11 +322,3 @@ void SplitTabMenuModel::CloseTabAtIndex(
+@@ -354,11 +321,3 @@ void SplitTabMenuModel::CloseTabAtIndex(
        index, TabCloseTypes::CLOSE_USER_GESTURE |
                   TabCloseTypes::CLOSE_CREATE_HISTORICAL_TAB);
  }

--- a/patches/helium/ui/tab-search-in-toolbar.patch
+++ b/patches/helium/ui/tab-search-in-toolbar.patch
@@ -273,7 +273,7 @@
    // `toolbar_webview_->GetPinnedActionsContainer()`.
 --- a/chrome/browser/ui/views/toolbar/toolbar_view.cc
 +++ b/chrome/browser/ui/views/toolbar/toolbar_view.cc
-@@ -1341,6 +1341,15 @@ views::Button* ToolbarView::GetChromeLab
+@@ -1337,6 +1337,15 @@ views::Button* ToolbarView::GetChromeLab
    return ChromeLabsCoordinator::From(browser_)->GetChromeLabsButton();
  }
  

--- a/patches/helium/ui/tabs.patch
+++ b/patches/helium/ui/tabs.patch
@@ -193,10 +193,11 @@
  
    PaintBackgroundStroke(canvas, group_color.value_or(tab_stroke_color));
    PaintSeparators(canvas);
-@@ -944,9 +885,6 @@ void TabStyleViewsImpl::PaintTabBackgrou
+@@ -943,10 +884,6 @@ void TabStyleViewsImpl::PaintTabBackgrou
+         BrowserView::GetBrowserViewForBrowser(tab_->controller()->GetBrowser()),
          image);
    }
- 
+-
 -  if (hovered) {
 -    PaintBackgroundHover(canvas, scale);
 -  }

--- a/patches/helium/ui/toolbar-button-prefs.patch
+++ b/patches/helium/ui/toolbar-button-prefs.patch
@@ -174,18 +174,7 @@
  #include "chrome/browser/ui/intent_picker_tab_helper.h"
  #include "chrome/browser/ui/layout_constants.h"
  #include "chrome/browser/ui/omnibox/omnibox_view.h"
-@@ -554,6 +555,10 @@ void ToolbarView::Init() {
-                                    browser_->profile()->IsGuestSession();
-     else if (sab_value == "never")
-       show_avatar_toolbar_button = false;
-+    else if (!base::CommandLine::ForCurrentProcess()->HasSwitch(
-+                 "show-avatar-button") &&
-+             browser_->profile()->IsRegularProfile())
-+      show_avatar_toolbar_button = false;
- 
-     avatar_->SetVisible(show_avatar_toolbar_button);
-   }
-@@ -623,6 +628,59 @@ void ToolbarView::Init() {
+@@ -623,6 +624,59 @@ void ToolbarView::Init() {
      UpdateGlicButtonVisibility();
    }
  
@@ -245,7 +234,7 @@
    InitLayout();
  
    for (auto* button : std::array<views::Button*, 5>{back_, forward_, reload_,
-@@ -1899,6 +1957,35 @@ void ToolbarView::OnShowHomeButtonChange
+@@ -1899,6 +1953,35 @@ void ToolbarView::OnShowHomeButtonChange
    }
  }
  

--- a/patches/inox-patchset/fix-building-without-safebrowsing.patch
+++ b/patches/inox-patchset/fix-building-without-safebrowsing.patch
@@ -205,3 +205,13 @@
   protected:
    void OnURLLoaderComplete(network::SimpleURLLoader* url_loader,
                             std::optional<std::string> response_body);
+--- a/chrome/browser/external_protocol/BUILD.gn
++++ b/chrome/browser/external_protocol/BUILD.gn
+@@ -38,6 +38,7 @@ source_set("impl") {
+     "//chrome/browser/safe_browsing",
+     "//chrome/browser/ui/browser_window",
+     "//chrome/common:constants",
++    "//components/paint_preview/buildflags",
+     "//components/prefs",
+     "//components/url_matcher",
+     "//services/network/public/cpp",


### PR DESCRIPTION
- native-frame-materials: move the hover guard back to IsApparentlyActive(). the refresh accidentally moved it to GetZValue()
- infobar/vertical: bring back the separator above infobars, clipped to content area like in m150. reuse the regular contents separator below. drop hunks that were previously removed by zen patch.
- inox-patchset: add missing paint_preview buildflags dep to external_protocol, the generated header could race on clean builds
- drop no-op avatar branch, unused includes, and whitespace-only hunks added by merge commit
