### PR TITLE
helium/ui/vertical: fix tab mute button hit testing

### DIFF
--- a/patches/helium/ui/layout/vertical.patch
+++ b/patches/helium/ui/layout/vertical.patch
@@ -1609,7 +1609,22 @@
    if (active_) {
      return true;
    }
-@@ -977,6 +986,8 @@ void TabView::OnAXNameChanged(ax::mojom:
+@@ -850,7 +859,13 @@ bool TabView::ShouldEnableMuteToggle(int
+     return false;
+   }
+ 
+-  return alert_indicator_->x() >= required_width;
++  // The alert indicator is on the leading edge, after the favicon. Measure
++  // the selectable title area between it and the trailing close button (or
++  // the tab edge when the close button is hidden).
++  const int selectable_region_end =
++      close_button_->GetVisible() ? close_button_->x() : width();
++  return selectable_region_end - alert_indicator_->bounds().right() >=
++         required_width;
+ }
+ 
+ void TabView::ToggleTabAudioMute() {
+@@ -977,6 +992,8 @@ void TabView::OnAXNameChanged(ax::mojom:
  void TabView::OnCollapseStateChanged(
      tabs::VerticalTabStripCollapseState state) {
    collapsed_ = state == tabs::VerticalTabStripCollapseState::kCollapsed;

--- a/patches/helium/ui/native-frame-materials.patch
+++ b/patches/helium/ui/native-frame-materials.patch
@@ -1255,7 +1255,7 @@
    if (selection_state == TabStyle::TabSelectionState::kActive) {
      return true;
    }
-@@ -880,7 +901,7 @@ bool TabView::IsApparentlyActive() const
+@@ -886,7 +907,7 @@ bool TabView::IsApparentlyActive() const
    if (active_) {
      return true;
    }
@@ -1264,7 +1264,7 @@
      return GetHoverOpacity() > 0.5f;
    }
    return selected_;
-@@ -1091,6 +1112,13 @@ void TabView::UpdateThemeColors() {
+@@ -1097,6 +1118,13 @@ void TabView::UpdateThemeColors() {
    if (!tab_interface) {
      return;
    }
@@ -1278,7 +1278,7 @@
  
    BrowserFrameView* const browser_frame_view =
        BrowserView::GetBrowserViewForBrowser(
-@@ -1104,10 +1132,8 @@ void TabView::UpdateThemeColors() {
+@@ -1110,10 +1138,8 @@ void TabView::UpdateThemeColors() {
  
    active_tab_fill_id_ = active_tab_fill_id;
    inactive_tab_fill_id_ = inactive_tab_fill_id;
@@ -1291,7 +1291,7 @@
  }
  
  void TabView::UpdateColors() {
-@@ -1207,6 +1233,25 @@ TabStyle::TabSelectionState TabView::Get
+@@ -1213,6 +1239,25 @@ TabStyle::TabSelectionState TabView::Get
                                : TabStyle::TabSelectionState::kInactive);
  }
  


### PR DESCRIPTION
the selectable-area check still assumed the alert indicator was on the trailing edge. measure the title area after the indicator instead so mute toggling remains enabled on sufficiently wide inactive tabs.

hopefully fixes #2058 