### PR TITLE
helium/ui/flags-webui: add default states, fix mobile scale

### DIFF
--- a/patches/helium/ui/improve-flags-webui.patch
+++ b/patches/helium/ui/improve-flags-webui.patch
@@ -70,3 +70,59 @@
  }
  
  @media (prefers-color-scheme: dark) {
+@@ -180,19 +181,6 @@ input {
+     text-align: left; /* csschecker-disable-line left-right */
+     width: 100%;
+   }
+-
+-  /* Hide the overflow description text */
+-  .body {
+-    overflow: hidden;
+-    text-overflow: ellipsis;
+-    white-space: nowrap;
+-    width: 100%;
+-  }
+-
+-  :host([expanded_]) .body {
+-    overflow: visible;
+-    white-space: normal;
+-  }
+ }
+ 
+ @media (max-width: 732px) {
+--- a/components/webui/flags/feature_entry.cc
++++ b/components/webui/flags/feature_entry.cc
+@@ -108,6 +108,23 @@ std::u16string FeatureEntry::Description
+ #endif  // BUILDFLAG(IS_CHROMEOS)
+   );
+   DCHECK_LT(index, NumOptions());
++  if (index == 0 &&
++      (type == FeatureEntry::FEATURE_VALUE ||
++       type == FeatureEntry::FEATURE_WITH_PARAMS_VALUE)) {
++    const base::Feature& base_feature = *feature.feature;
++    const bool is_enabled = base::FeatureList::IsEnabled(base_feature);
++    const bool differs_from_default =
++        is_enabled !=
++        (base_feature.default_state == base::FEATURE_ENABLED_BY_DEFAULT);
++    const char* effective_state =
++        is_enabled ? kGenericExperimentChoiceEnabled
++                   : kGenericExperimentChoiceDisabled;
++    const std::string description = base::StrCat(
++        {kGenericExperimentChoiceDefault, " (", effective_state,
++         differs_from_default ? "*" : "", ")"});
++    return base::ASCIIToUTF16(description);
++  }
++
+   const auto index_s = base::checked_cast<size_t>(index);
+   const char* description = nullptr;
+   if (type == FeatureEntry::ENABLE_DISABLE_VALUE ||
+--- a/components/webui/flags/resources/app.html.ts
++++ b/components/webui/flags/resources/app.html.ts
+@@ -79,6 +79,7 @@ export function getHtml(this: AppElement
+       </p>
+ </if>
+     </div>
++    <p>* Default state overridden via command line or variations.</p>
+     <p id="promos" ?hidden="${!this.shouldShowPromos_()}">
+       <!-- Those strings are not localized because they only
+       appear in chrome://flags, which is not localized. -->


### PR DESCRIPTION
descriptions are now visible on small widths and most flags have default states in brackets:

<img width="743" height="664" alt="image" src="https://github.com/user-attachments/assets/06804f95-b78d-4908-a394-00094384cc3c" />

closes #714