### PR TITLE
helium/ui: fix side panel visual bugs

### DIFF
--- a/patches/helium/ui/layout/vertical.patch
+++ b/patches/helium/ui/layout/vertical.patch
@@ -429,6 +429,34 @@
    }
  
    return layout;
+@@ -1504,8 +1417,16 @@ void BrowserViewTabbedLayoutImpl::DoPreL
+ void BrowserViewTabbedLayoutImpl::DoPostLayoutVisualAdjustments(
+     const BrowserLayoutParams& params) {
+   int side_panel_start = layout_data_->revised_params.visual_client_area.x();
++  int side_panel_end =
++      layout_data_->revised_params.visual_client_area.right();
+   if (layout_data_->tab_strip_type == TabStripType::kVertical) {
+-    side_panel_start = views().vertical_tab_strip_region_view->bounds().right();
++    const gfx::Rect vertical_tab_strip_bounds =
++        views().vertical_tab_strip_region_view->bounds();
++    if (delegate().IsVerticalTabStripRightAligned()) {
++      side_panel_end = vertical_tab_strip_bounds.x();
++    } else {
++      side_panel_start = vertical_tab_strip_bounds.right();
++    }
+   }
+ 
+   // Clip the side panel so it doesn't run off the edge of the browser or into
+@@ -1514,8 +1435,7 @@ void BrowserViewTabbedLayoutImpl::DoPost
+     const int left_overlap =
+         std::max(0, side_panel_start - views().side_panel->x());
+     const int right_overlap = std::max(
+-        0, views().side_panel->bounds().right() -
+-               layout_data_->revised_params.visual_client_area.right());
++        0, views().side_panel->bounds().right() - side_panel_end);
+     if (left_overlap > 0 || right_overlap > 0) {
+       gfx::Rect side_panel_visible_bounds =
+           views().side_panel->GetLocalBounds();
 --- a/chrome/browser/ui/views/frame/vertical_tab_strip_region_view.h
 +++ b/chrome/browser/ui/views/frame/vertical_tab_strip_region_view.h
 @@ -33,7 +33,6 @@

--- a/patches/helium/ui/layout/zen-mode.patch
+++ b/patches/helium/ui/layout/zen-mode.patch
@@ -2413,3 +2413,23 @@
        ToastId::kImageCopied,
        ToastSpecification::Builder(features::IsRoundedIconsEnabled()
                                        ? kContentCopyIcon
+--- a/chrome/browser/ui/views/side_panel/side_panel.cc
++++ b/chrome/browser/ui/views/side_panel/side_panel.cc
+@@ -83,12 +83,15 @@ gfx::RoundedCornersF GetContentRoundedCo
+       side_panel->GetWidget() && side_panel->GetWidget()->IsFullscreen();
+   const int window_edge_radius =
+       is_fullscreen ? generic_radius : GetPaddedFrameRadius();
+-  const bool vertical_tabstrip_on_panel_side =
++  const bool vertical_tabstrip_touches_window_edge =
+       browser_view->ShouldDrawVerticalTabStrip() &&
++      (!browser_view->IsZenModeEnabledForLayout() ||
++       browser_view->IsZenModeSideChromePinned()) &&
+       (browser_view->IsVerticalTabStripRightAligned() ==
+        side_panel->IsRightAligned());
+   const int lower_window_edge_radius =
+-      !vertical_tabstrip_on_panel_side ? window_edge_radius : generic_radius;
++      vertical_tabstrip_touches_window_edge ? generic_radius
++                                            : window_edge_radius;
+ 
+   return side_panel->IsRightAligned()
+              ? gfx::RoundedCornersF(generic_radius, generic_radius,


### PR DESCRIPTION
- fix clipping with right-aligned tabs
- fix radius in zen mode when VTS is floating

fixes #2247

<img width="631" height="1076" alt="image" src="https://github.com/user-attachments/assets/c955eec4-8008-41ec-98c4-2e84f0f965e5" />
<img width="548" height="1076" alt="image" src="https://github.com/user-attachments/assets/6b5b2f08-f86c-4b75-9a41-021d0970ab76" />
