### PR TITLE
helium/core: disable webui omnibox

### DIFF
--- a/patches/helium/core/disable-omnibox-webui.patch
+++ b/patches/helium/core/disable-omnibox-webui.patch
@@ -1,0 +1,16 @@
+--- a/chrome/browser/ui/omnibox/omnibox_next_features.cc
++++ b/chrome/browser/ui/omnibox/omnibox_next_features.cc
+@@ -31,11 +31,11 @@ namespace omnibox {
+ namespace internal {
+ 
+ // If enabled, shows the omnibox suggestions in the popup in WebUI.
+-BASE_FEATURE(kWebUIOmniboxPopup, ENABLED);
++BASE_FEATURE(kWebUIOmniboxPopup, DISABLED);
+ 
+ // If enabled, Omnibox popup will transition to AI-Mode with the compose-box
+ // panel taking up the whole of the popup, covering the location bar completely.
+-BASE_FEATURE(kWebUIOmniboxAimPopup, ENABLED);
++BASE_FEATURE(kWebUIOmniboxAimPopup, DISABLED);
+ 
+ // If enabled, the Omnibox Popup will enable a different UI state when on a
+ // webpage.

--- a/patches/series
+++ b/patches/series
@@ -198,9 +198,9 @@ helium/core/enable-glow-up-features.patch
 helium/core/enable-bookmark-bar-settings.patch
 helium/core/force-paste-action.patch
 helium/core/shift-right-click-context-menu.patch
-
 helium/core/crash-reporter-privacy-tweaks.patch
 helium/core/crash-reporting-prefs.patch
+helium/core/disable-omnibox-webui.patch
 
 helium/settings/settings-page-icons.patch
 helium/settings/move-search-suggest.patch


### PR DESCRIPTION
we don't care about google ai mode for which the webui omnibox was made. no clue why it's even in chromium instead of chrome, along with tons of other trash.

it was enabled in latest patch via https://crrev.com/c/8176782