### PR TITLE
helium/core/network: add a flag for forcing QUIC to v2 on HTTP/3

### DIFF
--- a/patches/helium/core/add-middle-click-autoscroll-flag.patch
+++ b/patches/helium/core/add-middle-click-autoscroll-flag.patch
@@ -11,10 +11,10 @@
  #endif  /* CHROME_BROWSER_HELIUM_FLAG_CHOICES_H_ */
 --- a/chrome/browser/helium_flag_entries.h
 +++ b/chrome/browser/helium_flag_entries.h
-@@ -35,4 +35,8 @@
-      "Disable Encrypted Client Hello (ECH)",
-      "Disables TLS Encrypted Client Hello, reducing traffic privacy when accessing websites that support ECH. Use this flag only if ECH is blocked on your network. Helium flag.",
-      kOsAll, SINGLE_VALUE_TYPE(helium::kDisableEchCommandLine)},
+@@ -39,4 +39,8 @@
+      "Use only QUIC v2 for HTTP/3",
+      "Restricts HTTP/3 connections to QUIC v2 instead of default QUIC v1. This may help on networks that block QUIC v1 but do not recognize QUIC v2. It does not force QUIC on unsupported sites. Connections may fall back to TCP when the server does not support QUIC v2. Helium flag.",
+      kOsAll, SINGLE_VALUE_TYPE_AND_VALUE(switches::kQuicVersion, "RFCv2")},
 +    {helium::kMiddleClickAutoscrollCommandLine,
 +     "Middle Click Autoscroll",
 +     "Enables autoscroll on middle click. Helium flag, Chromium feature.",

--- a/patches/helium/core/network/quic-v2-flag.patch
+++ b/patches/helium/core/network/quic-v2-flag.patch
@@ -1,0 +1,11 @@
+--- a/chrome/browser/helium_flag_entries.h
++++ b/chrome/browser/helium_flag_entries.h
+@@ -35,4 +35,8 @@
+      "Disable Encrypted Client Hello (ECH)",
+      "Disables TLS Encrypted Client Hello, reducing traffic privacy when accessing websites that support ECH. Use this flag only if ECH is blocked on your network. Helium flag.",
+      kOsAll, SINGLE_VALUE_TYPE(helium::kDisableEchCommandLine)},
++    {"quic-v2-only",
++     "Use only QUIC v2 for HTTP/3",
++     "Restricts HTTP/3 connections to QUIC v2 instead of default QUIC v1. This may help on networks that block QUIC v1 but do not recognize QUIC v2. It does not force QUIC on unsupported sites. Connections may fall back to TCP when the server does not support QUIC v2. Helium flag.",
++     kOsAll, SINGLE_VALUE_TYPE_AND_VALUE(switches::kQuicVersion, "RFCv2")},
+ #endif  /* CHROME_BROWSER_HELIUM_FLAG_ENTRIES_H_ */

--- a/patches/helium/ui/layout/compact.patch
+++ b/patches/helium/ui/layout/compact.patch
@@ -11,7 +11,7 @@
  
 --- a/chrome/browser/helium_flag_entries.h
 +++ b/chrome/browser/helium_flag_entries.h
-@@ -39,4 +39,8 @@
+@@ -43,4 +43,8 @@
       "Middle Click Autoscroll",
       "Enables autoscroll on middle click. Helium flag, Chromium feature.",
       kOsDesktop, FEATURE_VALUE_TYPE(blink::features::kHeliumMiddleClickAutoscroll)},

--- a/patches/helium/ui/native-frame-materials.patch
+++ b/patches/helium/ui/native-frame-materials.patch
@@ -42,7 +42,7 @@
  
 --- a/chrome/browser/helium_flag_entries.h
 +++ b/chrome/browser/helium_flag_entries.h
-@@ -43,4 +43,8 @@
+@@ -47,4 +47,8 @@
       "Automatic address bar width in compact layout",
       "Allows the location bar to automatically reduce its width in the compact browser layout. The omnibox may be uncomfortable to use. Helium flag.",
       kOsDesktop, FEATURE_VALUE_TYPE(features::kHeliumCompactLocationWidth)},

--- a/patches/series
+++ b/patches/series
@@ -171,6 +171,7 @@ helium/core/noise/hardware-concurrency.patch
 
 helium/core/network/disable-ech-flag.patch
 helium/core/network/global-privacy-control-pref.patch
+helium/core/network/quic-v2-flag.patch
 
 helium/core/reduce-accept-language-headers.patch
 helium/core/disable-ad-topics-and-etc.patch


### PR DESCRIPTION
may be useful for bypassing some network restrictions

<img width="767" height="330" alt="image" src="https://github.com/user-attachments/assets/9759fea3-6eaa-440f-bc28-a3e4809255fd" />

`Alt-Svc: h3` is not upgraded to QUIC v2 when v2 is forced due to a bug in chromium which needs to be handled in a separate patch and PR
