### PR TITLE
core: add Ctrl+Shift+S keyboard shortcut for screenshot capture

### DIFF
--- a/patches/helium/core/screenshot-shortcut.patch
+++ b/patches/helium/core/screenshot-shortcut.patch
@@ -1,0 +1,42 @@
+--- a/chrome/browser/ui/accelerator_table.cc
++++ b/chrome/browser/ui/accelerator_table.cc
+@@ -75,6 +75,8 @@ const AcceleratorMapping kAcceleratorMap[] = {
+     {ui::VKEY_R, ui::EF_SHIFT_DOWN | ui::EF_PLATFORM_ACCELERATOR,
+      IDC_RELOAD_BYPASSING_CACHE},
+     {ui::VKEY_S, ui::EF_PLATFORM_ACCELERATOR, IDC_SAVE_PAGE},
++    {ui::VKEY_S, ui::EF_SHIFT_DOWN | ui::EF_PLATFORM_ACCELERATOR,
++     IDC_SHARING_HUB_SCREENSHOT},
+     {ui::VKEY_9, ui::EF_PLATFORM_ACCELERATOR, IDC_SELECT_LAST_TAB},
+     {ui::VKEY_NUMPAD9, ui::EF_PLATFORM_ACCELERATOR, IDC_SELECT_LAST_TAB},
+ #if BUILDFLAG(IS_LINUX)
+--- a/chrome/browser/global_keyboard_shortcuts_mac.mm
++++ b/chrome/browser/global_keyboard_shortcuts_mac.mm
+@@ -153,6 +153,7 @@ const std::vector<KeyboardShortcutData>& GetShortcutsNotPresentInMainMenu() {
+       {true,  false, false, true,  kVK_UpArrow,           IDC_FOCUS_PREVIOUS_PANE},
+       {true,  true,  false, true,  kVK_ANSI_A,            IDC_FOCUS_INACTIVE_POPUP_FOR_ACCESSIBILITY},
+       {true,  false, false, true,  kVK_ANSI_R,            IDC_SHOW_READING_MODE_KEYBOARD},
++      {true,  true,  false, false, kVK_ANSI_S,            IDC_SHARING_HUB_SCREENSHOT},
+     });
+     // clang-format on
+
+--- a/chrome/browser/ui/cocoa/accelerators_cocoa.mm
++++ b/chrome/browser/ui/cocoa/accelerators_cocoa.mm
+@@ -48,6 +48,8 @@ const struct AcceleratorMapping {
+     {IDC_PRINT, ui::EF_COMMAND_DOWN, ui::VKEY_P},
+     {IDC_RESTORE_TAB, ui::EF_COMMAND_DOWN | ui::EF_SHIFT_DOWN, ui::VKEY_T},
+     {IDC_SAVE_PAGE, ui::EF_COMMAND_DOWN, ui::VKEY_S},
++    {IDC_SHARING_HUB_SCREENSHOT, ui::EF_COMMAND_DOWN | ui::EF_SHIFT_DOWN,
++     ui::VKEY_S},
+     {IDC_SHOW_BOOKMARK_BAR, ui::EF_COMMAND_DOWN | ui::EF_SHIFT_DOWN,
+      ui::VKEY_B},
+     {IDC_SHOW_BOOKMARK_MANAGER, ui::EF_COMMAND_DOWN | ui::EF_ALT_DOWN,
+--- a/chrome/app/chrome_dll.rc
++++ b/chrome/app/chrome_dll.rc
+@@ -85,6 +85,7 @@ BEGIN
+     VK_F5,          IDC_RELOAD_BYPASSING_CACHE, VIRTKEY, SHIFT
+     "T",            IDC_RESTORE_TAB,            VIRTKEY, CONTROL, SHIFT
+     "S",            IDC_SAVE_PAGE,              VIRTKEY, CONTROL
++    "S",            IDC_SHARING_HUB_SCREENSHOT, VIRTKEY, CONTROL, SHIFT
+     "9",            IDC_SELECT_LAST_TAB,        VIRTKEY, CONTROL
+     VK_NUMPAD9,     IDC_SELECT_LAST_TAB,        VIRTKEY, CONTROL
+     VK_NEXT,        IDC_MOVE_TAB_NEXT,          VIRTKEY, CONTROL, SHIFT

--- a/patches/series
+++ b/patches/series
@@ -122,6 +122,7 @@ helium/core/search/remove-description-snippet-deps.patch
 
 helium/settings/setup-behavior-settings-page.patch
 helium/core/keyboard-shortcuts.patch
+helium/core/screenshot-shortcut.patch
 helium/core/update-default-browser-prefs.patch
 helium/core/add-default-browser-reject-button.patch
 helium/core/proxy-extension-downloads.patch


### PR DESCRIPTION
## Summary
- Adds a `Ctrl+Shift+S` (`Cmd+Shift+S` on macOS) keyboard shortcut for the screenshot feature, so it no longer requires going through the Sharing Hub menu.
- Binds the existing `IDC_SHARING_HUB_SCREENSHOT` command (already dispatched to `ScreenshotCapture()` in `browser_command_controller.cc`, no changes needed there) across all four accelerator tables, following the same pattern established by `patches/helium/core/keyboard-shortcuts.patch`:
  - `chrome/browser/ui/accelerator_table.cc` (Windows/Linux/ChromeOS)
  - `chrome/browser/global_keyboard_shortcuts_mac.mm` + `chrome/browser/ui/cocoa/accelerators_cocoa.mm` (macOS)
  - `chrome/app/chrome_dll.rc` (Windows resource table)
- Registered the new patch in `patches/series` right after `keyboard-shortcuts.patch`.

Closes #1975.

## Testing
I don't currently have a Chromium build environment set up to compile and manually verify this locally (full build needs ~150-250GB disk and is RAM-intensive at link time). I did verify:
- `Ctrl+Shift+S` / `Cmd+Shift+S` is not bound to anything else in any of the four accelerator tables (only near-conflict is `Ctrl+S` → Save Page).
- The patch applies cleanly (`git apply --check`) against the tree state produced *after* `keyboard-shortcuts.patch` is applied, since it's ordered later in `patches/series`.
- `IDC_SHARING_HUB_SCREENSHOT` dispatch already exists and is unconditionally enabled (`show_main_ui`), so no changes were needed to `browser_command_controller.cc`.

Opening this as a draft and would appreciate it if a maintainer (or anyone with a build set up) could confirm the shortcut actually triggers the screenshot capture UI before merging. Happy to iterate on feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)