### PR TITLE
helium/core/sync/vault: set up private vault object encryption

### DIFF
--- a/patches/helium/core/sync/vault-encryption.patch
+++ b/patches/helium/core/sync/vault-encryption.patch
@@ -1,0 +1,250 @@
+--- a/components/sync/engine/extension_sync/BUILD.gn
++++ b/components/sync/engine/extension_sync/BUILD.gn
+@@ -11,6 +11,8 @@ proto_library("sync_vault_proto") {
+ 
+ source_set("extension_sync") {
+   sources = [
++    "sync_vault_cryptographer.cc",
++    "sync_vault_cryptographer.h",
+     "sync_vault_format.cc",
+     "sync_vault_format.h",
+     "sync_vault_limits.h",
+@@ -18,5 +20,8 @@ source_set("extension_sync") {
+ 
+   public_deps = [ "//base" ]
+ 
+-  deps = [ ":sync_vault_proto" ]
++  deps = [
++    ":sync_vault_proto",
++    "//crypto",
++  ]
+ }
+--- /dev/null
++++ b/components/sync/engine/extension_sync/sync_vault_cryptographer.cc
+@@ -0,0 +1,148 @@
++// Copyright 2026 The Helium Authors
++// You can use, redistribute, and/or modify this source code under
++// the terms of the GPL-3.0 license that can be found in the LICENSE file.
++
++#include "components/sync/engine/extension_sync/sync_vault_cryptographer.h"
++
++#include <array>
++#include <cstdint>
++#include <optional>
++#include <string>
++#include <string_view>
++#include <utility>
++#include <vector>
++
++#include "base/containers/span.h"
++#include "base/notreached.h"
++#include "base/strings/string_view_util.h"
++#include "base/uuid.h"
++#include "crypto/aead.h"
++#include "crypto/hash.h"
++#include "crypto/kdf.h"
++#include "crypto/random.h"
++#include "crypto/secure_util.h"
++
++namespace syncer {
++
++namespace {
++
++constexpr auto kAlgorithm = crypto::aead::AES_256_GCM_SIV;
++constexpr size_t kNonceBytes = 12;
++constexpr size_t kAuthenticationTagBytes = 16;
++constexpr std::string_view kKeyInfo =
++    "helium-private-sync-v1/object-aead/aes-256-gcm-siv";
++constexpr std::string_view kAssociatedDataPrefix =
++    "helium-private-sync-v1/object/";
++
++static_assert(kNonceBytes + kAuthenticationTagBytes ==
++              kSyncVaultContainerOverheadBytes);
++
++bool IsKnownRole(SyncVaultObjectRole role) {
++  return role >= SyncVaultObjectRole::kDescriptor &&
++         role <= SyncVaultObjectRole::kEntity;
++}
++
++}  // namespace
++
++// static
++SyncVaultCryptographer::CreateResult SyncVaultCryptographer::Create(
++    base::span<const uint8_t> vault_key,
++    std::string vault_uuid) {
++  if (vault_key.size() != kVaultKeySize) {
++    return base::unexpected(SyncVaultCryptoError::kInvalidKey);
++  }
++  const base::Uuid parsed_uuid = base::Uuid::ParseCaseInsensitive(vault_uuid);
++  if (!parsed_uuid.is_valid() || vault_uuid.size() != 36u) {
++    return base::unexpected(SyncVaultCryptoError::kInvalidContext);
++  }
++  return std::unique_ptr<SyncVaultCryptographer>(new SyncVaultCryptographer(
++      vault_key.first<kVaultKeySize>(), parsed_uuid.AsLowercaseString()));
++}
++
++SyncVaultCryptographer::SyncVaultCryptographer(
++    base::span<const uint8_t, kVaultKeySize> vault_key,
++    std::string vault_uuid)
++    : object_key_(crypto::kdf::Hkdf<kVaultKeySize>(
++          crypto::hash::kSha256,
++          vault_key,
++          base::as_byte_span(vault_uuid),
++          base::as_byte_span(kKeyInfo))),
++      vault_uuid_(std::move(vault_uuid)) {}
++
++SyncVaultCryptographer::~SyncVaultCryptographer() {
++  crypto::SecureZeroBuffer(object_key_);
++}
++
++SyncVaultCryptographer::TransformResult SyncVaultCryptographer::Encrypt(
++    SyncVaultObjectRole role,
++    base::span<const uint8_t> plaintext) const {
++  if (!IsKnownRole(role)) {
++    return base::unexpected(SyncVaultCryptoError::kInvalidContext);
++  }
++  if (plaintext.size() > MaximumPlaintextBytes(role)) {
++    return base::unexpected(SyncVaultCryptoError::kObjectTooLarge);
++  }
++
++  std::array<uint8_t, kNonceBytes> nonce;
++  crypto::RandBytes(nonce);
++  std::vector<uint8_t> ciphertext = crypto::aead::Seal(
++      kAlgorithm, object_key_, plaintext, nonce,
++      BuildAssociatedData(role));
++  std::vector<uint8_t> container;
++  container.reserve(nonce.size() + ciphertext.size());
++  container.insert(container.end(), nonce.begin(), nonce.end());
++  container.insert(container.end(), ciphertext.begin(), ciphertext.end());
++  return container;
++}
++
++SyncVaultCryptographer::TransformResult SyncVaultCryptographer::Decrypt(
++    SyncVaultObjectRole role,
++    base::span<const uint8_t> container) const {
++  if (!IsKnownRole(role)) {
++    return base::unexpected(SyncVaultCryptoError::kInvalidContext);
++  }
++  if (container.size() < kSyncVaultContainerOverheadBytes) {
++    return base::unexpected(SyncVaultCryptoError::kMalformedContainer);
++  }
++  if (container.size() >
++      kSyncVaultContainerOverheadBytes + MaximumPlaintextBytes(role)) {
++    return base::unexpected(SyncVaultCryptoError::kObjectTooLarge);
++  }
++
++  std::optional<std::vector<uint8_t>> plaintext = crypto::aead::Open(
++      kAlgorithm, object_key_, container.subspan(kNonceBytes),
++      container.first<kNonceBytes>(), BuildAssociatedData(role));
++  if (!plaintext) {
++    return base::unexpected(SyncVaultCryptoError::kAuthenticationFailed);
++  }
++  return std::move(*plaintext);
++}
++
++std::vector<uint8_t> SyncVaultCryptographer::BuildAssociatedData(
++    SyncVaultObjectRole role) const {
++  std::vector<uint8_t> associated_data;
++  associated_data.reserve(kAssociatedDataPrefix.size() + vault_uuid_.size() +
++                          sizeof(uint8_t));
++  associated_data.insert(associated_data.end(), kAssociatedDataPrefix.begin(),
++                         kAssociatedDataPrefix.end());
++  associated_data.insert(associated_data.end(), vault_uuid_.begin(),
++                         vault_uuid_.end());
++  associated_data.push_back(static_cast<uint8_t>(role));
++  return associated_data;
++}
++
++// static
++size_t SyncVaultCryptographer::MaximumPlaintextBytes(SyncVaultObjectRole role) {
++  switch (role) {
++    case SyncVaultObjectRole::kDescriptor:
++    case SyncVaultObjectRole::kHead:
++      return kSyncVaultMaximumMetadataPlaintextBytes;
++    case SyncVaultObjectRole::kJournal:
++      return kSyncVaultMaximumJournalPlaintextBytes;
++    case SyncVaultObjectRole::kEntity:
++      return kSyncVaultMaximumEntityPlaintextBytes;
++  }
++  NOTREACHED();
++}
++
++}  // namespace syncer
+--- /dev/null
++++ b/components/sync/engine/extension_sync/sync_vault_cryptographer.h
+@@ -0,0 +1,75 @@
++// Copyright 2026 The Helium Authors
++// You can use, redistribute, and/or modify this source code under
++// the terms of the GPL-3.0 license that can be found in the LICENSE file.
++
++#ifndef COMPONENTS_SYNC_ENGINE_EXTENSION_SYNC_SYNC_VAULT_CRYPTOGRAPHER_H_
++#define COMPONENTS_SYNC_ENGINE_EXTENSION_SYNC_SYNC_VAULT_CRYPTOGRAPHER_H_
++
++#include <array>
++#include <cstddef>
++#include <cstdint>
++#include <memory>
++#include <string>
++#include <vector>
++
++#include "base/containers/span.h"
++#include "base/types/expected.h"
++#include "components/sync/engine/extension_sync/sync_vault_limits.h"
++
++namespace syncer {
++
++enum class SyncVaultObjectRole : uint8_t {
++  kDescriptor = 1,
++  kHead = 2,
++  kJournal = 3,
++  kEntity = 4,
++};
++
++enum class SyncVaultCryptoError {
++  kInvalidKey,
++  kInvalidContext,
++  kMalformedContainer,
++  kObjectTooLarge,
++  kAuthenticationFailed,
++};
++
++// Thin object-encryption adapter over Chromium's AEAD implementation. One
++// purpose-specific key is derived for the vault; role and vault identity are
++// authenticated as associated data.
++class SyncVaultCryptographer {
++ public:
++  static constexpr size_t kVaultKeySize = 32;
++
++  using CreateResult = base::expected<std::unique_ptr<SyncVaultCryptographer>,
++                                      SyncVaultCryptoError>;
++  using TransformResult =
++      base::expected<std::vector<uint8_t>, SyncVaultCryptoError>;
++
++  static CreateResult Create(base::span<const uint8_t> vault_key,
++                             std::string vault_uuid);
++
++  SyncVaultCryptographer(const SyncVaultCryptographer&) = delete;
++  SyncVaultCryptographer& operator=(const SyncVaultCryptographer&) = delete;
++  ~SyncVaultCryptographer();
++
++  TransformResult Encrypt(SyncVaultObjectRole role,
++                          base::span<const uint8_t> plaintext) const;
++  TransformResult Decrypt(SyncVaultObjectRole role,
++                          base::span<const uint8_t> container) const;
++
++  const std::string& vault_uuid() const { return vault_uuid_; }
++
++ private:
++  SyncVaultCryptographer(base::span<const uint8_t, kVaultKeySize> vault_key,
++                         std::string vault_uuid);
++
++  std::vector<uint8_t> BuildAssociatedData(SyncVaultObjectRole role) const;
++  static size_t MaximumPlaintextBytes(SyncVaultObjectRole role);
++
++  std::array<uint8_t, kVaultKeySize> object_key_;
++  const std::string vault_uuid_;
++};
++
++}  // namespace syncer
++
++#endif  // COMPONENTS_SYNC_ENGINE_EXTENSION_SYNC_SYNC_VAULT_CRYPTOGRAPHER_H_

--- a/patches/series
+++ b/patches/series
@@ -126,6 +126,7 @@ helium/core/sync/engine-interface.patch
 helium/core/sync/service-backends.patch
 helium/core/sync/datatype-policy.patch
 helium/core/sync/vault-format.patch
+helium/core/sync/vault-encryption.patch
 
 helium/settings/setup-behavior-settings-page.patch
 helium/core/keyboard-shortcuts.patch


### PR DESCRIPTION
derive a vault-specific 256bit object key from the vault key and UUID using HKDF-SHA256. encrypt with AES-256-GCM-SIV, authenticate the vault UUID and object role as associated data.

enforce the role-specific plaintext limits defined by the vault format before encryption and decryption. reject invalid or oversized objects

related: #90