### PR TITLE
helium/core/sync/vault: read authenticated private vault state

### DIFF
--- a/patches/helium/core/sync/vault-store-read.patch
+++ b/patches/helium/core/sync/vault-store-read.patch
@@ -1,0 +1,693 @@
+--- a/components/sync/engine/extension_sync/BUILD.gn
++++ b/components/sync/engine/extension_sync/BUILD.gn
+@@ -16,6 +16,8 @@ source_set("extension_sync") {
+     "sync_vault_format.cc",
+     "sync_vault_format.h",
+     "sync_vault_limits.h",
++    "sync_vault_store.cc",
++    "sync_vault_store.h",
+     "sync_vault_transport.h",
+   ]
+ 
+--- /dev/null
++++ b/components/sync/engine/extension_sync/sync_vault_store.cc
+@@ -0,0 +1,553 @@
++// Copyright 2026 The Helium Authors
++// You can use, redistribute, and/or modify this source code under
++// the terms of the GPL-3.0 license that can be found in the LICENSE file.
++
++#include "components/sync/engine/extension_sync/sync_vault_store.h"
++
++#include <cstddef>
++#include <cstdint>
++#include <memory>
++#include <optional>
++#include <string>
++#include <string_view>
++#include <utility>
++#include <vector>
++
++#include "base/check.h"
++#include "base/containers/span.h"
++#include "base/strings/string_number_conversions.h"
++#include "components/sync/engine/extension_sync/sync_vault_cryptographer.h"
++#include "crypto/hash.h"
++
++namespace syncer {
++
++namespace {
++
++constexpr char kObjectRootPrefix[] = "helium/v1/";
++constexpr char kDescriptorSuffix[] = "/descriptor";
++constexpr char kEpochSegment[] = "epoch/";
++constexpr size_t kMaximumMetadataContainerBytes =
++    kSyncVaultMaximumMetadataPlaintextBytes + kSyncVaultContainerOverheadBytes;
++constexpr size_t kContentDigestHexLength = 64;
++
++SyncVaultStoreError MapTransportError(SyncVaultTransportError error) {
++  switch (error) {
++    case SyncVaultTransportError::kAuthenticationRequired:
++      return SyncVaultStoreError::kAuthenticationRequired;
++    case SyncVaultTransportError::kNetworkError:
++      return SyncVaultStoreError::kNetworkError;
++    case SyncVaultTransportError::kTemporaryError:
++      return SyncVaultStoreError::kTemporaryError;
++    case SyncVaultTransportError::kAccessDenied:
++      return SyncVaultStoreError::kAccessDenied;
++    case SyncVaultTransportError::kInvalidData:
++      return SyncVaultStoreError::kInvalidData;
++    case SyncVaultTransportError::kUnsupported:
++      return SyncVaultStoreError::kUnsupported;
++    case SyncVaultTransportError::kAborted:
++      return SyncVaultStoreError::kAborted;
++  }
++}
++
++SyncVaultStoreError MapCryptoError(SyncVaultCryptoError error) {
++  switch (error) {
++    case SyncVaultCryptoError::kInvalidKey:
++      return SyncVaultStoreError::kInvalidVaultKey;
++    case SyncVaultCryptoError::kInvalidContext:
++    case SyncVaultCryptoError::kMalformedContainer:
++      return SyncVaultStoreError::kMalformedObject;
++    case SyncVaultCryptoError::kObjectTooLarge:
++      return SyncVaultStoreError::kObjectTooLarge;
++    case SyncVaultCryptoError::kAuthenticationFailed:
++      return SyncVaultStoreError::kAuthenticationFailed;
++  }
++}
++
++SyncVaultStoreError MapFormatError(SyncVaultFormatError error) {
++  switch (error) {
++    case SyncVaultFormatError::kMalformed:
++    case SyncVaultFormatError::kInvalidValue:
++      return SyncVaultStoreError::kMalformedObject;
++    case SyncVaultFormatError::kUnsupportedVersion:
++      return SyncVaultStoreError::kUnsupportedVersion;
++    case SyncVaultFormatError::kLimitExceeded:
++      return SyncVaultStoreError::kObjectTooLarge;
++  }
++}
++
++bool HasValidContentAddress(const std::string& object_id,
++                            base::span<const uint8_t> encrypted_data) {
++  const size_t digest_start = object_id.rfind('/');
++  return digest_start != std::string::npos &&
++         object_id.size() - digest_start - 1 == kContentDigestHexLength &&
++         object_id.substr(digest_start + 1) ==
++             base::HexEncode(crypto::hash::Sha256(encrypted_data));
++}
++
++std::optional<uint32_t> GetObjectEpochForRole(const std::string& object_prefix,
++                                              const std::string& object_id,
++                                              std::string_view role) {
++  const std::string epoch_prefix = object_prefix + kEpochSegment;
++  if (!object_id.starts_with(epoch_prefix)) {
++    return std::nullopt;
++  }
++  const size_t epoch_end = object_id.find('/', epoch_prefix.size());
++  if (epoch_end == std::string::npos || epoch_end == epoch_prefix.size()) {
++    return std::nullopt;
++  }
++  const std::string_view epoch_component = std::string_view(object_id).substr(
++      epoch_prefix.size(), epoch_end - epoch_prefix.size());
++  const std::string_view object_suffix =
++      std::string_view(object_id).substr(epoch_end + 1);
++  uint32_t epoch = 0;
++  if (!base::StringToUint(epoch_component, &epoch) ||
++      base::NumberToString(epoch) != epoch_component ||
++      object_suffix.size() != role.size() + kContentDigestHexLength ||
++      !object_suffix.starts_with(role)) {
++    return std::nullopt;
++  }
++  return epoch;
++}
++
++bool IsObjectForRole(const std::string& object_prefix,
++                     const std::string& object_id,
++                     std::string_view role) {
++  return GetObjectEpochForRole(object_prefix, object_id, role).has_value();
++}
++
++std::string GetSyncVaultObjectPrefix(const std::string& vault_uuid) {
++  return std::string(kObjectRootPrefix) + vault_uuid + "/";
++}
++
++std::string GetSyncVaultDescriptorObjectId(const std::string& vault_uuid) {
++  return std::string(kObjectRootPrefix) + vault_uuid + kDescriptorSuffix;
++}
++
++}  // namespace
++
++// static
++SyncVaultStore::CreateResult SyncVaultStore::Create(
++    std::unique_ptr<SyncVaultTransport> transport,
++    base::span<const uint8_t> vault_key,
++    std::string vault_uuid,
++    std::optional<SyncVaultCheckpoint> checkpoint,
++    PersistCheckpointCallback persist_checkpoint_callback) {
++  if (!transport || !persist_checkpoint_callback) {
++    return base::unexpected(SyncVaultStoreError::kInvalidData);
++  }
++  auto cryptographer =
++      SyncVaultCryptographer::Create(vault_key, std::move(vault_uuid));
++  if (!cryptographer.has_value()) {
++    return base::unexpected(MapCryptoError(cryptographer.error()));
++  }
++  if (checkpoint &&
++      checkpoint->vault_uuid != cryptographer.value()->vault_uuid()) {
++    return base::unexpected(SyncVaultStoreError::kInvalidData);
++  }
++  if (checkpoint && checkpoint->generation > 0) {
++    const std::optional<uint32_t> record_epoch = GetObjectEpochForRole(
++        GetSyncVaultObjectPrefix(cryptographer.value()->vault_uuid()),
++        checkpoint->record_id, "journal/");
++    if (!record_epoch || *record_epoch != checkpoint->epoch) {
++      return base::unexpected(SyncVaultStoreError::kInvalidData);
++    }
++  }
++  SyncVaultCheckpoint effective_checkpoint =
++      checkpoint.value_or(SyncVaultCheckpoint{
++          cryptographer.value()->vault_uuid(), 0, std::string(), 0});
++  if (!SerializeSyncVaultCheckpoint(effective_checkpoint).has_value()) {
++    return base::unexpected(SyncVaultStoreError::kInvalidData);
++  }
++  return std::unique_ptr<SyncVaultStore>(new SyncVaultStore(
++      std::move(transport), std::move(cryptographer.value()),
++      std::move(effective_checkpoint), std::move(persist_checkpoint_callback)));
++}
++
++SyncVaultStore::SyncVaultStore(
++    std::unique_ptr<SyncVaultTransport> transport,
++    std::unique_ptr<SyncVaultCryptographer> cryptographer,
++    SyncVaultCheckpoint checkpoint,
++    PersistCheckpointCallback persist_checkpoint_callback)
++    : transport_(std::move(transport)),
++      cryptographer_(std::move(cryptographer)),
++      checkpoint_(std::move(checkpoint)),
++      persist_checkpoint_callback_(std::move(persist_checkpoint_callback)),
++      object_prefix_(GetSyncVaultObjectPrefix(cryptographer_->vault_uuid())),
++      descriptor_object_id_(
++          GetSyncVaultDescriptorObjectId(cryptographer_->vault_uuid())),
++      head_object_id_(object_prefix_ + "head") {
++  // Production stores are assembled on the UI sequence and then transferred
++  // to the Sync sequence with their backend. Setup verification stores bind
++  // naturally on the ThreadPool sequence that first uses them.
++  DETACH_FROM_SEQUENCE(sequence_checker_);
++}
++
++SyncVaultStore::~SyncVaultStore() = default;
++
++void SyncVaultStore::SetCancelationSignal(
++    CancelationSignal* cancelation_signal) {
++  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
++  CHECK(cancelation_signal);
++  transport_->SetCancelationSignal(cancelation_signal);
++}
++
++SyncVaultStore::ReadResult SyncVaultStore::ReadState() {
++  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
++  ObjectResult descriptor =
++      ReadObject(descriptor_object_id_, kMaximumMetadataContainerBytes);
++  if (!descriptor.has_value()) {
++    return base::unexpected(descriptor.error());
++  }
++  if (!descriptor->has_value()) {
++    if (checkpoint_.generation != 0) {
++      return base::unexpected(SyncVaultStoreError::kRollback);
++    }
++    return SyncVaultState();
++  }
++  auto descriptor_status = ValidateDescriptor(descriptor->value());
++  if (!descriptor_status.has_value()) {
++    return base::unexpected(descriptor_status.error());
++  }
++
++  HeadResult head_result = ReadHead();
++  if (!head_result.has_value()) {
++    if (head_result.error() == SyncVaultStoreError::kIncompleteHistory &&
++        checkpoint_.generation == 0) {
++      return SyncVaultState();
++    }
++    return base::unexpected(head_result.error());
++  }
++  SyncVaultHead head = std::move(head_result->first);
++  std::string head_revision = std::move(head_result->second);
++  if (head.generation == 0) {
++    const SyncVaultHistoryValidationResult validation =
++        ValidateSyncVaultHistory(checkpoint_, head, {});
++    if (validation == SyncVaultHistoryValidationResult::kRollback) {
++      return base::unexpected(SyncVaultStoreError::kRollback);
++    }
++    if (validation != SyncVaultHistoryValidationResult::kAcceptCurrent) {
++      return base::unexpected(SyncVaultStoreError::kFork);
++    }
++    return SyncVaultState{{}, std::move(head), std::move(head_revision), true};
++  }
++
++  if (!IsObjectForRole(object_prefix_, head.record_id, "journal/")) {
++    return base::unexpected(SyncVaultStoreError::kMalformedObject);
++  }
++
++  JournalResult record_result = AuthenticateHead(head);
++  if (!record_result.has_value()) {
++    return base::unexpected(record_result.error());
++  }
++  SyncVaultJournalRecord latest_record = std::move(record_result.value());
++  const bool should_advance_checkpoint =
++      head.generation > checkpoint_.generation;
++
++  std::vector<uint8_t> state;
++  size_t total_size = 0;
++  for (const SyncVaultObjectReference& chunk : latest_record.state_chunks) {
++    const std::optional<uint32_t> chunk_epoch =
++        GetObjectEpochForRole(object_prefix_, chunk.object_id, "entity/");
++    if (!chunk_epoch || *chunk_epoch != latest_record.epoch) {
++      return base::unexpected(SyncVaultStoreError::kMalformedObject);
++    }
++    ObjectResult object =
++        ReadObject(chunk.object_id, kSyncVaultMaximumEncryptedObjectBytes);
++    if (!object.has_value()) {
++      return base::unexpected(object.error());
++    }
++    if (!object->has_value()) {
++      return base::unexpected(SyncVaultStoreError::kIncompleteHistory);
++    }
++    if (!HasValidContentAddress(chunk.object_id, object->value().data)) {
++      return base::unexpected(SyncVaultStoreError::kAuthenticationFailed);
++    }
++    auto plaintext = cryptographer_->Decrypt(SyncVaultObjectRole::kEntity,
++                                             object->value().data);
++    if (!plaintext.has_value()) {
++      return base::unexpected(MapCryptoError(plaintext.error()));
++    }
++    if (plaintext->size() != chunk.plaintext_size ||
++        total_size > kSyncVaultMaximumReconstructedBytes - plaintext->size()) {
++      return base::unexpected(SyncVaultStoreError::kMalformedObject);
++    }
++    total_size += plaintext->size();
++    state.insert(state.end(), plaintext->begin(), plaintext->end());
++  }
++
++  if (should_advance_checkpoint && !AdvanceCheckpoint(head)) {
++    return base::unexpected(SyncVaultStoreError::kCheckpointPersistenceFailed);
++  }
++
++  return SyncVaultState{std::move(state), std::move(head),
++                        std::move(head_revision), true};
++}
++
++SyncVaultStore::RefreshResult SyncVaultStore::ReadStateIfChanged(
++    const SyncVaultState& loaded_state) {
++  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
++  if (!loaded_state.initialized || !loaded_state.head_revision) {
++    return ReadState();
++  }
++  HeadResult current = ReadHead();
++  if (!current.has_value()) {
++    return base::unexpected(current.error());
++  }
++  if (current->first == loaded_state.head &&
++      current->second == loaded_state.head_revision) {
++    return std::nullopt;
++  }
++  ReadResult refreshed = ReadState();
++  if (!refreshed.has_value()) {
++    return base::unexpected(refreshed.error());
++  }
++  return std::move(refreshed.value());
++}
++
++base::expected<void, SyncVaultStoreError>
++SyncVaultStore::VerifyInitializedVault() {
++  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
++  ObjectResult descriptor =
++      ReadObject(descriptor_object_id_, kMaximumMetadataContainerBytes);
++  if (!descriptor.has_value()) {
++    return base::unexpected(descriptor.error());
++  }
++  if (!descriptor->has_value()) {
++    return base::unexpected(SyncVaultStoreError::kIncompleteHistory);
++  }
++  auto descriptor_status = ValidateDescriptor(descriptor->value());
++  if (!descriptor_status.has_value()) {
++    return descriptor_status;
++  }
++  HeadResult head = ReadHead();
++  if (!head.has_value()) {
++    return base::unexpected(head.error());
++  }
++  const SyncVaultHead& candidate_head = head->first;
++  if (candidate_head.generation == 0) {
++    const SyncVaultHistoryValidationResult validation =
++        ValidateSyncVaultHistory(checkpoint_, candidate_head, {});
++    if (validation == SyncVaultHistoryValidationResult::kRollback) {
++      return base::unexpected(SyncVaultStoreError::kRollback);
++    }
++    if (validation != SyncVaultHistoryValidationResult::kAcceptCurrent) {
++      return base::unexpected(SyncVaultStoreError::kFork);
++    }
++  } else {
++    JournalResult record = AuthenticateHead(candidate_head);
++    if (!record.has_value()) {
++      return base::unexpected(record.error());
++    }
++  }
++  if (!AdvanceCheckpoint(candidate_head)) {
++    return base::unexpected(SyncVaultStoreError::kCheckpointPersistenceFailed);
++  }
++  return base::ok();
++}
++
++SyncVaultStore::ObjectResult SyncVaultStore::ReadObject(
++    const std::string& object_id,
++    size_t maximum_bytes) const {
++  if (object_id.empty() ||
++      object_id.size() > kSyncVaultMaximumIdentifierBytes ||
++      maximum_bytes == 0 ||
++      maximum_bytes > kSyncVaultMaximumEncryptedObjectBytes) {
++    return base::unexpected(SyncVaultStoreError::kInvalidData);
++  }
++  SyncVaultTransport::ReadResult result =
++      transport_->ReadObject(object_id, maximum_bytes);
++  if (!result.has_value()) {
++    return base::unexpected(MapTransportError(result.error()));
++  }
++  if (result->has_value() &&
++      (result->value().data.size() > maximum_bytes ||
++       result->value().revision.empty() ||
++       result->value().revision.size() > kSyncVaultMaximumIdentifierBytes)) {
++    return base::unexpected(SyncVaultStoreError::kInvalidData);
++  }
++  return std::move(result.value());
++}
++
++base::expected<void, SyncVaultStoreError> SyncVaultStore::ValidateDescriptor(
++    const OpaqueSyncVaultObject& object) const {
++  auto plaintext =
++      cryptographer_->Decrypt(SyncVaultObjectRole::kDescriptor, object.data);
++  if (!plaintext.has_value()) {
++    return base::unexpected(MapCryptoError(plaintext.error()));
++  }
++  auto descriptor = ParseSyncVaultDescriptor(plaintext.value());
++  if (!descriptor.has_value()) {
++    return base::unexpected(MapFormatError(descriptor.error()));
++  }
++  if (descriptor->vault_uuid != cryptographer_->vault_uuid()) {
++    return base::unexpected(SyncVaultStoreError::kAuthenticationFailed);
++  }
++  return base::ok();
++}
++
++SyncVaultStore::HeadResult SyncVaultStore::ReadHead() {
++  ObjectResult object =
++      ReadObject(head_object_id_, kMaximumMetadataContainerBytes);
++  if (!object.has_value()) {
++    return base::unexpected(object.error());
++  }
++  if (!object->has_value()) {
++    return base::unexpected(SyncVaultStoreError::kIncompleteHistory);
++  }
++  auto plaintext =
++      cryptographer_->Decrypt(SyncVaultObjectRole::kHead, object->value().data);
++  if (!plaintext.has_value()) {
++    return base::unexpected(MapCryptoError(plaintext.error()));
++  }
++  auto head = ParseSyncVaultHead(plaintext.value());
++  if (!head.has_value()) {
++    return base::unexpected(MapFormatError(head.error()));
++  }
++  return std::make_pair(std::move(head.value()),
++                        std::move(object->value().revision));
++}
++
++SyncVaultStore::JournalResult SyncVaultStore::AuthenticateHead(
++    const SyncVaultHead& head) const {
++  if (head.generation == 0 ||
++      !IsObjectForRole(object_prefix_, head.record_id, "journal/")) {
++    return base::unexpected(SyncVaultStoreError::kMalformedObject);
++  }
++
++  const bool is_current_checkpoint = head.generation <= checkpoint_.generation;
++  if (is_current_checkpoint) {
++    const SyncVaultHistoryValidationResult validation =
++        ValidateSyncVaultHistory(checkpoint_, head, {});
++    if (validation == SyncVaultHistoryValidationResult::kRollback) {
++      return base::unexpected(SyncVaultStoreError::kRollback);
++    }
++    if (validation != SyncVaultHistoryValidationResult::kAcceptCurrent) {
++      return base::unexpected(SyncVaultStoreError::kFork);
++    }
++  }
++
++  JournalResult latest_result = ReadJournalRecord(head.record_id);
++  if (!latest_result.has_value()) {
++    return base::unexpected(latest_result.error());
++  }
++  SyncVaultJournalRecord latest = std::move(latest_result.value());
++  if (latest.generation != head.generation || latest.epoch != head.epoch ||
++      (latest.generation > 1 &&
++       !IsObjectForRole(object_prefix_, latest.parent_record_id, "journal/"))) {
++    return base::unexpected(SyncVaultStoreError::kMalformedObject);
++  }
++
++  if (is_current_checkpoint) {
++    return latest;
++  }
++
++  if (checkpoint_.generation < head.minimum_retained_generation) {
++    if (ValidateSyncVaultHistory(checkpoint_, head, {}) !=
++        SyncVaultHistoryValidationResult::kAcceptCompacted) {
++      return base::unexpected(SyncVaultStoreError::kMalformedObject);
++    }
++    return latest;
++  }
++
++  if (checkpoint_.generation > 0 &&
++      head.generation - checkpoint_.generation > kSyncVaultMaximumEntities) {
++    return base::unexpected(SyncVaultStoreError::kObjectTooLarge);
++  }
++
++  std::vector<AuthenticatedSyncVaultJournalRecord> ancestry;
++  std::string record_id = head.record_id;
++  uint64_t record_generation = latest.generation;
++  uint32_t record_epoch = latest.epoch;
++  std::string parent_record_id = latest.parent_record_id;
++  while (true) {
++    const uint32_t expected_epoch =
++        record_generation >= head.epoch_start_generation
++            ? head.epoch
++            : head.minimum_retained_epoch;
++    if (record_epoch != expected_epoch) {
++      return base::unexpected(SyncVaultStoreError::kMalformedObject);
++    }
++    ancestry.push_back({record_id, record_generation, parent_record_id});
++    if (checkpoint_.generation == 0 ||
++        record_generation == checkpoint_.generation + 1) {
++      break;
++    }
++    if (record_generation <= checkpoint_.generation + 1 ||
++        ancestry.size() >= kSyncVaultMaximumEntities) {
++      return base::unexpected(SyncVaultStoreError::kIncompleteHistory);
++    }
++
++    record_id = parent_record_id;
++    JournalResult parent_result = ReadJournalRecord(record_id);
++    if (!parent_result.has_value()) {
++      return base::unexpected(parent_result.error());
++    }
++    SyncVaultJournalRecord parent = std::move(parent_result.value());
++    if (parent.generation != ancestry.back().generation - 1 ||
++        (parent.generation > 1 &&
++         !IsObjectForRole(object_prefix_, parent.parent_record_id,
++                          "journal/"))) {
++      return base::unexpected(SyncVaultStoreError::kMalformedObject);
++    }
++    record_generation = parent.generation;
++    record_epoch = parent.epoch;
++    parent_record_id = std::move(parent.parent_record_id);
++  }
++
++  switch (ValidateSyncVaultHistory(checkpoint_, head, ancestry)) {
++    case SyncVaultHistoryValidationResult::kAcceptDescendant:
++      return latest;
++    case SyncVaultHistoryValidationResult::kRollback:
++      return base::unexpected(SyncVaultStoreError::kRollback);
++    case SyncVaultHistoryValidationResult::kFork:
++      return base::unexpected(SyncVaultStoreError::kFork);
++    case SyncVaultHistoryValidationResult::kIncompleteHistory:
++      return base::unexpected(SyncVaultStoreError::kIncompleteHistory);
++    case SyncVaultHistoryValidationResult::kAcceptCurrent:
++    case SyncVaultHistoryValidationResult::kAcceptCompacted:
++    case SyncVaultHistoryValidationResult::kInvalidHistory:
++      return base::unexpected(SyncVaultStoreError::kMalformedObject);
++  }
++}
++
++base::expected<SyncVaultJournalRecord, SyncVaultStoreError>
++SyncVaultStore::ReadJournalRecord(const std::string& record_id) const {
++  ObjectResult result =
++      ReadObject(record_id, kSyncVaultMaximumEncryptedObjectBytes);
++  if (!result.has_value()) {
++    return base::unexpected(result.error());
++  }
++  if (!result->has_value()) {
++    return base::unexpected(SyncVaultStoreError::kIncompleteHistory);
++  }
++  if (!HasValidContentAddress(record_id, result->value().data)) {
++    return base::unexpected(SyncVaultStoreError::kAuthenticationFailed);
++  }
++  auto plaintext = cryptographer_->Decrypt(SyncVaultObjectRole::kJournal,
++                                           result->value().data);
++  if (!plaintext.has_value()) {
++    return base::unexpected(MapCryptoError(plaintext.error()));
++  }
++  auto record = ParseSyncVaultJournalRecord(plaintext.value());
++  if (!record.has_value()) {
++    return base::unexpected(MapFormatError(record.error()));
++  }
++  const std::optional<uint32_t> object_epoch =
++      GetObjectEpochForRole(object_prefix_, record_id, "journal/");
++  if (!object_epoch || *object_epoch != record->epoch) {
++    return base::unexpected(SyncVaultStoreError::kMalformedObject);
++  }
++  return std::move(record.value());
++}
++
++bool SyncVaultStore::AdvanceCheckpoint(const SyncVaultHead& head) {
++  SyncVaultCheckpoint next{cryptographer_->vault_uuid(), head.generation,
++                           head.record_id, head.epoch};
++  if (!persist_checkpoint_callback_.Run(next)) {
++    return false;
++  }
++  checkpoint_ = std::move(next);
++  return true;
++}
++
++}  // namespace syncer
+--- /dev/null
++++ b/components/sync/engine/extension_sync/sync_vault_store.h
+@@ -0,0 +1,123 @@
++// Copyright 2026 The Helium Authors
++// You can use, redistribute, and/or modify this source code under
++// the terms of the GPL-3.0 license that can be found in the LICENSE file.
++
++#ifndef COMPONENTS_SYNC_ENGINE_EXTENSION_SYNC_SYNC_VAULT_STORE_H_
++#define COMPONENTS_SYNC_ENGINE_EXTENSION_SYNC_SYNC_VAULT_STORE_H_
++
++#include <cstddef>
++#include <cstdint>
++#include <memory>
++#include <optional>
++#include <string>
++#include <vector>
++
++#include "base/containers/span.h"
++#include "base/functional/callback.h"
++#include "base/sequence_checker.h"
++#include "base/types/expected.h"
++#include "components/sync/engine/extension_sync/sync_vault_format.h"
++#include "components/sync/engine/extension_sync/sync_vault_transport.h"
++
++namespace syncer {
++
++class CancelationSignal;
++class SyncVaultCryptographer;
++
++enum class SyncVaultStoreError {
++  kAuthenticationRequired,
++  kNetworkError,
++  kTemporaryError,
++  kAccessDenied,
++  kInvalidData,
++  kUnsupported,
++  kAborted,
++  kInvalidVaultKey,
++  kAuthenticationFailed,
++  kMalformedObject,
++  kUnsupportedVersion,
++  kObjectTooLarge,
++  kRollback,
++  kFork,
++  kIncompleteHistory,
++  kCheckpointPersistenceFailed,
++};
++
++struct SyncVaultState {
++  std::vector<uint8_t> data;
++  SyncVaultHead head;
++  std::optional<std::string> head_revision;
++  bool initialized = false;
++};
++
++// Authenticates and reconstructs a browser-owned encrypted journal from opaque
++// provider objects. A protected local checkpoint anchors accepted history.
++class SyncVaultStore {
++ public:
++  using PersistCheckpointCallback =
++      base::RepeatingCallback<bool(const SyncVaultCheckpoint&)>;
++  using CreateResult =
++      base::expected<std::unique_ptr<SyncVaultStore>, SyncVaultStoreError>;
++  using ReadResult = base::expected<SyncVaultState, SyncVaultStoreError>;
++  using RefreshResult =
++      base::expected<std::optional<SyncVaultState>, SyncVaultStoreError>;
++
++  static CreateResult Create(
++      std::unique_ptr<SyncVaultTransport> transport,
++      base::span<const uint8_t> vault_key,
++      std::string vault_uuid,
++      std::optional<SyncVaultCheckpoint> checkpoint,
++      PersistCheckpointCallback persist_checkpoint_callback);
++
++  SyncVaultStore(const SyncVaultStore&) = delete;
++  SyncVaultStore& operator=(const SyncVaultStore&) = delete;
++  ~SyncVaultStore();
++
++  void SetCancelationSignal(CancelationSignal* cancelation_signal);
++  ReadResult ReadState();
++  // Authenticates the descriptor, current head, and the journal ancestry
++  // needed to anchor that head without fetching state chunks.
++  base::expected<void, SyncVaultStoreError> VerifyInitializedVault();
++  // Authenticates the current head and returns a complete replacement only
++  // when it differs from the already loaded state.
++  RefreshResult ReadStateIfChanged(const SyncVaultState& loaded_state);
++
++  const SyncVaultCheckpoint& checkpoint() const { return checkpoint_; }
++
++ private:
++  SyncVaultStore(std::unique_ptr<SyncVaultTransport> transport,
++                 std::unique_ptr<SyncVaultCryptographer> cryptographer,
++                 SyncVaultCheckpoint checkpoint,
++                 PersistCheckpointCallback persist_checkpoint_callback);
++
++  using ObjectResult =
++      base::expected<std::optional<OpaqueSyncVaultObject>, SyncVaultStoreError>;
++  using HeadResult = base::expected<std::pair<SyncVaultHead, std::string>,
++                                    SyncVaultStoreError>;
++  using JournalResult =
++      base::expected<SyncVaultJournalRecord, SyncVaultStoreError>;
++
++  ObjectResult ReadObject(const std::string& object_id,
++                          size_t maximum_bytes) const;
++  base::expected<void, SyncVaultStoreError> ValidateDescriptor(
++      const OpaqueSyncVaultObject& object) const;
++  HeadResult ReadHead();
++  JournalResult AuthenticateHead(const SyncVaultHead& head) const;
++  base::expected<SyncVaultJournalRecord, SyncVaultStoreError> ReadJournalRecord(
++      const std::string& record_id) const;
++  bool AdvanceCheckpoint(const SyncVaultHead& head);
++
++  std::unique_ptr<SyncVaultTransport> transport_;
++  std::unique_ptr<SyncVaultCryptographer> cryptographer_;
++  SyncVaultCheckpoint checkpoint_;
++  PersistCheckpointCallback persist_checkpoint_callback_;
++  const std::string object_prefix_;
++  const std::string descriptor_object_id_;
++  const std::string head_object_id_;
++
++  SEQUENCE_CHECKER(sequence_checker_);
++};
++
++}  // namespace syncer
++
++#endif  // COMPONENTS_SYNC_ENGINE_EXTENSION_SYNC_SYNC_VAULT_STORE_H_

--- a/patches/helium/core/sync/vault-transport.patch
+++ b/patches/helium/core/sync/vault-transport.patch
@@ -1,0 +1,71 @@
+--- /dev/null
++++ b/components/sync/engine/extension_sync/sync_vault_transport.h
+@@ -0,0 +1,58 @@
++// Copyright 2026 The Helium Authors
++// You can use, redistribute, and/or modify this source code under
++// the terms of the GPL-3.0 license that can be found in the LICENSE file.
++
++#ifndef COMPONENTS_SYNC_ENGINE_EXTENSION_SYNC_SYNC_VAULT_TRANSPORT_H_
++#define COMPONENTS_SYNC_ENGINE_EXTENSION_SYNC_SYNC_VAULT_TRANSPORT_H_
++
++#include <cstddef>
++#include <cstdint>
++#include <optional>
++#include <string>
++#include <vector>
++
++#include "base/types/expected.h"
++
++namespace syncer {
++
++class CancelationSignal;
++
++enum class SyncVaultTransportError {
++  kAuthenticationRequired,
++  kNetworkError,
++  kTemporaryError,
++  kAccessDenied,
++  kInvalidData,
++  kUnsupported,
++  kAborted,
++};
++
++struct OpaqueSyncVaultObject {
++  std::vector<uint8_t> data;
++  std::string revision;
++};
++
++// Transport-neutral read access to one provider vault. Every payload is
++// already an opaque authenticated ciphertext.
++class SyncVaultTransport {
++ public:
++  using ReadResult = base::expected<std::optional<OpaqueSyncVaultObject>,
++                                    SyncVaultTransportError>;
++
++  virtual ~SyncVaultTransport() = default;
++
++  // Connects this transport to the Sync engine's cross-sequence shutdown
++  // signal. The signal must outlive the transport. Setup-only transports may
++  // operate without one.
++  virtual void SetCancelationSignal(CancelationSignal* cancelation_signal) = 0;
++
++  // Returns nullopt when the object does not exist. A returned object must not
++  // exceed `maximum_bytes` and must include its exact, non-empty provider
++  // revision.
++  virtual ReadResult ReadObject(const std::string& object_id,
++                                size_t maximum_bytes) = 0;
++};
++
++}  // namespace syncer
++
++#endif  // COMPONENTS_SYNC_ENGINE_EXTENSION_SYNC_SYNC_VAULT_TRANSPORT_H_
+--- a/components/sync/engine/extension_sync/BUILD.gn
++++ b/components/sync/engine/extension_sync/BUILD.gn
+@@ -16,6 +16,7 @@ source_set("extension_sync") {
+     "sync_vault_format.cc",
+     "sync_vault_format.h",
+     "sync_vault_limits.h",
++    "sync_vault_transport.h",
+   ]
+ 
+   public_deps = [ "//base" ]

--- a/patches/series
+++ b/patches/series
@@ -127,6 +127,8 @@ helium/core/sync/service-backends.patch
 helium/core/sync/datatype-policy.patch
 helium/core/sync/vault-format.patch
 helium/core/sync/vault-encryption.patch
+helium/core/sync/vault-transport.patch
+helium/core/sync/vault-store-read.patch
 
 helium/settings/setup-behavior-settings-page.patch
 helium/core/keyboard-shortcuts.patch


### PR DESCRIPTION
- define the transport-neutral read interface used to retrieve objects from providers
- implement the browser side of the protocol
- fetch state chunks only after accepting the head, enforce limits, then decrypt and assemble the sync state
- provide lightweight setup verification and revision-based refreshes