### PR TITLE
helium/ui/layout: rephrase address bar toggles

### DIFF
--- a/i18n/source.gen.json
+++ b/i18n/source.gen.json
@@ -1108,13 +1108,13 @@
     "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
     "source": "chrome/app/settings_strings.grdp",
     "context": "Label for the toggle to use a centered address bar.",
-    "message": "Center the address bar"
+    "message": "Centered address bar"
   },
   {
     "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
     "source": "chrome/app/settings_strings.grdp",
-    "context": "Label for the toggle that enables the minimal address bar.",
-    "message": "Minimal address bar"
+    "context": "Label for the toggle that enables the minimal URL in the address bar, showing only the site origin.",
+    "message": "Minimal URL in the address bar"
   },
   {
     "name": "IDS_SETTINGS_ACCESSIBILITY_TOAST_TOGGLE_TITLE",

--- a/i18n/translations/af.json
+++ b/i18n/translations/af.json
@@ -371,16 +371,6 @@
     "message": "Gebruik Ctrl+S om vertikale oortjies in Vertikale uitleg aan of af te skakel"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "Sentreer die adresbalk"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Minimale adresbalk"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium kan nie as verstek gestel word nie, omdat geen <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph>-lêer in enige van die volgende gevind is nie: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/am.json
+++ b/i18n/translations/am.json
@@ -370,16 +370,6 @@
     "message": "በቁመታዊ አቀማመጥ ቁመታዊ ትሮችን ለመቀያየር Ctrl+S ይጠቀሙ"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "የአድራሻ አሞሌውን ወደ መሃል ያድርጉ"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "አነስተኛ የአድራሻ አሞሌ"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium እንደ ነባሪ ሊቀናበር አይችልም፣ ምክንያቱም <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> ፋይል በሚከተሉት ውስጥ አልተገኘም፡ ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications።"

--- a/i18n/translations/ar.json
+++ b/i18n/translations/ar.json
@@ -370,16 +370,6 @@
     "message": "استخدام Ctrl+S لتبديل علامات التبويب العمودية في التخطيط العمودي"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "توسيط شريط العناوين"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "شريط عناوين مصغّر"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "لا يمكن تعيين Helium كمتصفح افتراضي، لأنه لم يتم العثور على ملف <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> في أي من: ~/.local/share/applications، /usr/share/applications، /usr/local/share/applications."

--- a/i18n/translations/as.json
+++ b/i18n/translations/as.json
@@ -370,16 +370,6 @@
     "message": "উলম্ব বিন্যাসত উলম্ব টেব ট'গল কৰিবলৈ Ctrl+S ব্যৱহাৰ কৰক"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "ঠিকনা বাৰ কেন্দ্ৰত ৰাখক"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "নূন্যতম ঠিকনা বাৰ"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium-ক ডিফল্ট হিচাপে ছেট কৰিব নোৱাৰি, কাৰণ এই স্থানসমূহৰ কোনোটোতে কোনো <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> ফাইল পোৱা নগ'ল: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications।"

--- a/i18n/translations/az.json
+++ b/i18n/translations/az.json
@@ -370,16 +370,6 @@
     "message": "Şaquli tərtibatda şaquli tabları açıb-bağlamaq üçün Ctrl+S istifadə et"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "Ünvan çubuğunu ortala"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Minimal ünvan çubuğu"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium standart brauzer kimi təyin edilə bilmir, çünki aşağıdakı qovluqların heç birində <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> faylı tapılmadı: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/be.json
+++ b/i18n/translations/be.json
@@ -370,16 +370,6 @@
     "message": "Выкарыстоўваць Ctrl+S для пераключэння вертыкальных укладак у вертыкальнай кампаноўцы"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "Цэнтраваць адрасны радок"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Мінімальны адрасны радок"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium не можа быць усталяваны як стандартны, бо файл <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> не быў знойдзены ні ў адным з каталогаў: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/bg.json
+++ b/i18n/translations/bg.json
@@ -370,16 +370,6 @@
     "message": "Използване на Ctrl+S за превключване на вертикалните раздели във вертикалното оформление"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "Центриране на адресната лента"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Минимална адресна лента"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium не може да бъде зададен като браузър по подразбиране, тъй като не е намерен файл <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> в нито една от следните директории: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/bn.json
+++ b/i18n/translations/bn.json
@@ -370,16 +370,6 @@
     "message": "উল্লম্ব লেআউটে উল্লম্ব ট্যাব টগল করতে Ctrl+S ব্যবহার করুন"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "ঠিকানা বার কেন্দ্রে রাখুন"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "ন্যূনতম ঠিকানা বার"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium ডিফল্ট হিসেবে সেট করা যাচ্ছে না, কারণ ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications-এর কোনোটিতে কোনো <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> ফাইল পাওয়া যায়নি।"

--- a/i18n/translations/bs.json
+++ b/i18n/translations/bs.json
@@ -371,16 +371,6 @@
     "message": "Koristi Ctrl+S za prebacivanje vertikalnih kartica u Vertikalnom rasporedu"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "Centriraj adresnu traku"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Minimalna adresna traka"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium se ne može postaviti kao podrazumijevani, jer datoteka <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> nije pronađena ni u jednom od: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/ca.json
+++ b/i18n/translations/ca.json
@@ -371,16 +371,6 @@
     "message": "Utilitza Ctrl+S per alternar les pestanyes verticals en la disposició vertical"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "Centra la barra d'adreces"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Barra d'adreces mínima"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium no es pot establir com a navegador predeterminat perquè no s'ha trobat cap fitxer <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> en cap de: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/cs.json
+++ b/i18n/translations/cs.json
@@ -370,16 +370,6 @@
     "message": "Pomocí Ctrl+S přepínat vertikální karty ve vertikálním rozložení"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "Vycentrovat adresní řádek"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Minimální adresní řádek"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium nelze nastavit jako výchozí, protože nebyl nalezen soubor <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> v žádném z těchto umístění: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/cy.json
+++ b/i18n/translations/cy.json
@@ -370,16 +370,6 @@
     "message": "Defnyddio Ctrl+S i doglo tabiau fertigol yn y cynllun Fertigol"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "Canoli'r bar cyfeiriad"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Bar cyfeiriad syml"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Ni ellir gosod Helium fel y porwr diofyn, oherwydd na chanfuwyd ffeil <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> yn unrhyw un o: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/da.json
+++ b/i18n/translations/da.json
@@ -370,16 +370,6 @@
     "message": "Brug Ctrl+S til at slå lodrette faner til/fra i lodret layout"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "Centrér adresselinjen"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Minimal adresselinje"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium kan ikke angives som standard, fordi ingen <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph>-fil blev fundet i nogen af: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/de.json
+++ b/i18n/translations/de.json
@@ -370,16 +370,6 @@
     "message": "Strg+S zum Ein-/Ausblenden der vertikalen Tabs im Vertikal-Layout verwenden"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "Adressleiste zentrieren"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Minimale Adressleiste"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium kann nicht als Standard festgelegt werden, da keine <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph>-Datei in einem der folgenden Verzeichnisse gefunden wurde: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/el.json
+++ b/i18n/translations/el.json
@@ -370,16 +370,6 @@
     "message": "Χρήση Ctrl+S για εναλλαγή κάθετων καρτελών στην Κάθετη διάταξη"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "Κεντράρισμα της γραμμής διευθύνσεων"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Ελαχιστική γραμμή διευθύνσεων"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Το Helium δεν μπορεί να οριστεί ως προεπιλογή, επειδή δεν βρέθηκε αρχείο <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> σε κανένα από τα: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/en-GB.json
+++ b/i18n/translations/en-GB.json
@@ -370,16 +370,6 @@
     "message": "Use Ctrl+S to toggle vertical tabs in Vertical layout"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "Centre the address bar"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Minimal address bar"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/es-419.json
+++ b/i18n/translations/es-419.json
@@ -371,16 +371,6 @@
     "message": "Usar Ctrl+S para activar o desactivar las pestañas verticales en el diseño Vertical"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "Centrar la barra de direcciones"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Barra de direcciones minimalista"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium no se puede establecer como navegador predeterminado porque no se encontró ningún archivo <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> en ninguna de las siguientes ubicaciones: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/es.json
+++ b/i18n/translations/es.json
@@ -370,16 +370,6 @@
     "message": "Usar Ctrl+S para alternar las pestañas verticales en la disposición Vertical"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "Centrar la barra de direcciones"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Barra de direcciones minimalista"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "No se puede establecer Helium como predeterminado porque no se ha encontrado ningún archivo <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> en ninguna de las siguientes ubicaciones: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/et.json
+++ b/i18n/translations/et.json
@@ -370,16 +370,6 @@
     "message": "Kasuta vertikaalse paigutuse vahelehtede lülitamiseks klahvikombinatsiooni Ctrl+S"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "Keskenda aadressiriba"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Minimaalne aadressiriba"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Heliumit ei saa vaikebrauseriks määrata, kuna faili <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> ei leitud ühestki järgmisest asukohast: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/eu.json
+++ b/i18n/translations/eu.json
@@ -372,16 +372,6 @@
     "message": "Erabili Ctrl+S fitxa bertikalak txandakatzeko Bertikal diseinuan"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "Zentratu helbide-barra"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Helbide-barra minimala"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium ezin da nabigatzaile lehenetsi gisa ezarri, ez baita <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> fitxategirik aurkitu honako hauetan: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/fa.json
+++ b/i18n/translations/fa.json
@@ -370,16 +370,6 @@
     "message": "استفاده از Ctrl+S برای نمایش/مخفی کردن زبانه‌های عمودی در چیدمان عمودی"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "وسط‌چین کردن نوار نشانی"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "نوار نشانی مینیمال"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium نمی‌تواند به‌عنوان مرورگر پیش‌فرض تنظیم شود، زیرا فایل <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> در هیچ‌یک از مسیرهای زیر یافت نشد: ~/.local/share/applications، /usr/share/applications، /usr/local/share/applications."

--- a/i18n/translations/fi.json
+++ b/i18n/translations/fi.json
@@ -370,16 +370,6 @@
     "message": "Vaihda pystysuorat välilehdet näkyviin/piiloon näppäinyhdistelmällä Ctrl+S pystysuorassa asettelussa"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "Keskitä osoitepalkki"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Minimaalinen osoitepalkki"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Heliumia ei voi asettaa oletusselaimeksi, koska tiedostoa <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> ei löytynyt seuraavista sijainneista: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/fil.json
+++ b/i18n/translations/fil.json
@@ -370,16 +370,6 @@
     "message": "Gamitin ang Ctrl+S para i-toggle ang mga vertical tab sa Vertical layout"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "I-center ang address bar"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Minimal na address bar"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Hindi maitakda ang Helium bilang default, dahil walang nakitang <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file sa alinman sa: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/fr-CA.json
+++ b/i18n/translations/fr-CA.json
@@ -370,16 +370,6 @@
     "message": "Utiliser Ctrl+S pour afficher ou masquer les onglets verticaux dans la disposition verticale"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "Centrer la barre d'adresse"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Barre d'adresse minimale"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium ne peut pas être défini comme navigateur par défaut, car aucun fichier <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> n'a été trouvé dans : ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/fr.json
+++ b/i18n/translations/fr.json
@@ -371,16 +371,6 @@
     "message": "Utiliser Ctrl+S pour afficher/masquer les onglets verticaux en disposition Verticale"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "Centrer la barre d'adresse"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Barre d'adresse minimale"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium ne peut pas être défini comme navigateur par défaut, car aucun fichier <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> n'a été trouvé dans : ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/gl.json
+++ b/i18n/translations/gl.json
@@ -371,16 +371,6 @@
     "message": "Usar Ctrl+S para alternar as pestanas verticais na disposición Vertical"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "Centrar a barra de enderezos"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Barra de enderezos mínima"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Non se pode establecer Helium como predeterminado porque non se atopou ningún ficheiro <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> en ningún dos seguintes directorios: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/gu.json
+++ b/i18n/translations/gu.json
@@ -370,16 +370,6 @@
     "message": "વર્ટિકલ લેઆઉટમાં વર્ટિકલ ટૅબ્સ ટૉગલ કરવા Ctrl+S નો ઉપયોગ કરો"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "ઍડ્રેસ બાર કેન્દ્રમાં રાખો"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "ન્યૂનતમ ઍડ્રેસ બાર"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium ને ડિફૉલ્ટ તરીકે સેટ કરી શકાતું નથી, કારણ કે ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications માંથી કોઈપણમાં <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> ફાઇલ મળી નથી."

--- a/i18n/translations/he.json
+++ b/i18n/translations/he.json
@@ -370,16 +370,6 @@
     "message": "הקש ב-Ctrl+S להחלפת מצב לשוניות אנכיות בפריסה אנכית"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "רכז את שורת הכתובת"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "שורת כתובת מינימלית"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "לא ניתן להגדיר את Helium כברירת מחדל, כיוון שלא נמצא קובץ <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> באף אחד מהמיקומים: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/hi.json
+++ b/i18n/translations/hi.json
@@ -370,16 +370,6 @@
     "message": "वर्टिकल लेआउट में वर्टिकल टैब टॉगल करने के लिए Ctrl+S का उपयोग करें"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "एड्रेस बार को बीच में रखें"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "न्यूनतम एड्रेस बार"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium को डिफ़ॉल्ट के रूप में सेट नहीं किया जा सकता, क्योंकि निम्न में से किसी में भी कोई <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> फ़ाइल नहीं मिली: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications।"

--- a/i18n/translations/hr.json
+++ b/i18n/translations/hr.json
@@ -370,16 +370,6 @@
     "message": "Koristite Ctrl+S za uključivanje/isključivanje okomitih kartica u okomitom rasporedu"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "Centriraj adresnu traku"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Minimalna adresna traka"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium se ne može postaviti kao zadani jer datoteka <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> nije pronađena ni u jednom od sljedećih direktorija: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/hu.json
+++ b/i18n/translations/hu.json
@@ -370,16 +370,6 @@
     "message": "A Ctrl+S használata a függőleges lapok be- és kikapcsolásához függőleges elrendezésben"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "Címsor középre igazítása"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Minimális címsor"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "A Helium nem állítható be alapértelmezettként, mert nem található <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> fájl a következő helyeken: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/hy.json
+++ b/i18n/translations/hy.json
@@ -370,16 +370,6 @@
     "message": "Օգտագործել Ctrl+S՝ ուղղահայաց դասավորությունում ուղղահայաց ներդիրները փոխարկելու համար"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "Կենտրոնացնել հասցեագոտին"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Նվազագույն հասցեագոտի"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium-ը չի կարող սահմանվել որպես լռելյայն, քանի որ <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> ֆայլը չի գտնվել հետևյալ ուղիներից որևէ մեկում՝ ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications։"

--- a/i18n/translations/id.json
+++ b/i18n/translations/id.json
@@ -370,16 +370,6 @@
     "message": "Gunakan Ctrl+S untuk mengalihkan tab vertikal di tata letak Vertikal"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "Pusatkan bilah alamat"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Bilah alamat minimal"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium tidak dapat disetel sebagai default, karena tidak ditemukan file <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> di: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/is.json
+++ b/i18n/translations/is.json
@@ -370,16 +370,6 @@
     "message": "Nota Ctrl+S til að skipta um lóðrétta flipa í lóðréttu útliti"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "Miðja veffangastikuna"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Lágmarks veffangastika"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Ekki er hægt að setja Helium sem sjálfgefinn vafra, vegna þess að engin <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> skrá fannst í neinu af: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/it.json
+++ b/i18n/translations/it.json
@@ -370,16 +370,6 @@
     "message": "Usa Ctrl+S per mostrare/nascondere le schede verticali nel layout Verticale"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "Centra la barra degli indirizzi"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Barra degli indirizzi minimale"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Non è possibile impostare Helium come browser predefinito perché non è stato trovato alcun file <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> in: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/ja.json
+++ b/i18n/translations/ja.json
@@ -370,16 +370,6 @@
     "message": "Ctrl+S で垂直レイアウトの垂直タブを切り替える"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "アドレスバーを中央に配置する"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "ミニマルアドレスバー"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "<ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> ファイルが ~/.local/share/applications、/usr/share/applications、/usr/local/share/applications のいずれにも見つからなかったため、Helium を既定のブラウザに設定できません。"

--- a/i18n/translations/ka.json
+++ b/i18n/translations/ka.json
@@ -370,16 +370,6 @@
     "message": "Ctrl+S კლავიშებით ვერტიკალური ჩანართების გადართვა ვერტიკალურ განლაგებაში"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "მისამართის ზოლის ცენტრირება"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "მინიმალური მისამართის ზოლი"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium ვერ დაყენდება ნაგულისხმევად, რადგან <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> ფაილი ვერ მოიძებნა არცერთ ამ ადგილას: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/kk.json
+++ b/i18n/translations/kk.json
@@ -370,16 +370,6 @@
     "message": "Тік орналасуда тік қойындылардың күйін ауыстыру үшін Ctrl+S пайдалану"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "Мекенжай жолағын ортаға орналастыру"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Минималды мекенжай жолағы"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium әдепкі браузер ретінде орнатылмайды, себебі келесі жолдардың ешқайсысында <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> файлы табылмады: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/km.json
+++ b/i18n/translations/km.json
@@ -370,16 +370,6 @@
     "message": "ប្រើ Ctrl+S ដើម្បីបិទបើកផ្ទាំងបញ្ឈរក្នុងប្លង់បញ្ឈរ"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "ដាក់ Address Bar នៅកណ្ដាល"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Address Bar តូច"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium មិនអាចកំណត់ជាកម្មវិធីដើមបានទេ ពីព្រោះមិនអាចរកឃើញឯកសារ <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> នៅក្នុង៖ ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications។"

--- a/i18n/translations/kn.json
+++ b/i18n/translations/kn.json
@@ -370,16 +370,6 @@
     "message": "ಲಂಬ ವಿನ್ಯಾಸದಲ್ಲಿ ಲಂಬ ಟ್ಯಾಬ್‌ಗಳನ್ನು ಟಾಗಲ್ ಮಾಡಲು Ctrl+S ಬಳಸಿ"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "ವಿಳಾಸ ಪಟ್ಟಿಯನ್ನು ಕೇಂದ್ರೀಕರಿಸಿ"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "ಸರಳ ವಿಳಾಸ ಪಟ್ಟಿ"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium ಅನ್ನು ಡೀಫಾಲ್ಟ್ ಆಗಿ ಹೊಂದಿಸಲು ಸಾಧ್ಯವಿಲ್ಲ, ಏಕೆಂದರೆ ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications ಯಾವುದರಲ್ಲೂ <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> ಫೈಲ್ ಕಂಡುಬಂದಿಲ್ಲ."

--- a/i18n/translations/ko.json
+++ b/i18n/translations/ko.json
@@ -370,16 +370,6 @@
     "message": "Ctrl+S를 사용하여 세로 레이아웃에서 세로 탭 전환"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "주소 표시줄 가운데 정렬"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "최소화된 주소 표시줄"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "~/.local/share/applications, /usr/share/applications, /usr/local/share/applications 중 어디에서도 <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> 파일을 찾을 수 없어 Helium을 기본 브라우저로 설정할 수 없습니다."

--- a/i18n/translations/ky.json
+++ b/i18n/translations/ky.json
@@ -372,16 +372,6 @@
     "message": "Тик жайгашууда тик өтмөктөрдү көрсөтүү же жашыруу үчүн Ctrl+S колдонуу"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "Дарек тилкесин борборго жайгаштыруу"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Минималдуу дарек тилкеси"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium демейки браузер катары коюлбайт, анткени төмөнкү жерлердин бирөөсүнөн <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> файлы табылган жок: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/lo.json
+++ b/i18n/translations/lo.json
@@ -370,16 +370,6 @@
     "message": "ໃຊ້ Ctrl+S ເພື່ອສະຫຼັບແຖບແນວຕັ້ງໃນໂຄງຮ່າງແນວຕັ້ງ"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "ຈັດແຖບທີ່ຢູ່ໃຫ້ຢູ່ກາງ"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "ແຖບທີ່ຢູ່ແບບກະທັດຮັດ"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "ບໍ່ສາມາດຕັ້ງ Helium ເປັນຄ່າເລີ່ມຕົ້ນໄດ້, ເພາະວ່າບໍ່ພົບໄຟລ໌ <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> ໃນໂຟນເດີໃດໆຕໍ່ໄປນີ້: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/lt.json
+++ b/i18n/translations/lt.json
@@ -370,16 +370,6 @@
     "message": "Naudoti Ctrl+S vertikalioms kortelėms perjungti vertikaliame išdėstyme"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "Centruoti adreso juostą"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Minimali adreso juosta"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium negali būti nustatyta kaip numatytoji naršyklė, nes failas <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> nerastas nė viename iš šių katalogų: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/lv.json
+++ b/i18n/translations/lv.json
@@ -372,16 +372,6 @@
     "message": "Izmantot Ctrl+S, lai pārslēgtu vertikālās cilnes vertikālajā izkārtojumā"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "Centrēt adrešu joslu"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Minimāla adrešu josla"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium nevar iestatīt kā noklusējuma pārlūkprogrammu, jo nevienā no šīm atrašanās vietām netika atrasts fails <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph>: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/mk.json
+++ b/i18n/translations/mk.json
@@ -370,16 +370,6 @@
     "message": "Користи Ctrl+S за вклучување/исклучување на вертикалните јазичиња во Вертикален распоред"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "Центрирај ја лентата за адреси"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Минимална лента за адреси"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium не може да се постави како стандарден, бидејќи не беше пронајдена датотека <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> во ниту една од: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/ml.json
+++ b/i18n/translations/ml.json
@@ -370,16 +370,6 @@
     "message": "വെർട്ടിക്കൽ ലേഔട്ടിൽ വെർട്ടിക്കൽ ടാബുകൾ ടോഗിൾ ചെയ്യാൻ Ctrl+S ഉപയോഗിക്കുക"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "അഡ്രസ് ബാർ മധ്യഭാഗത്താക്കുക"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "മിനിമൽ അഡ്രസ് ബാർ"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium ഡിഫോൾട്ടായി സജ്ജീകരിക്കാൻ കഴിയില്ല, കാരണം ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications എന്നിവയിൽ ഒന്നിലും <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> ഫയൽ കണ്ടെത്തിയില്ല."

--- a/i18n/translations/mn.json
+++ b/i18n/translations/mn.json
@@ -370,16 +370,6 @@
     "message": "Vertical загварт босоо табуудыг сэлгэхийн тулд Ctrl+S ашиглах"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "Хаягийн мөрийг төвд байрлуулах"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Хялбаршуулсан хаягийн мөр"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium-ийг анхдагч хөтчөөр тохируулах боломжгүй, учир нь дараах байршлуудаас <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> файл олдсонгүй: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/mr.json
+++ b/i18n/translations/mr.json
@@ -370,16 +370,6 @@
     "message": "व्हर्टिकल लेआउटमध्ये व्हर्टिकल टॅब टॉगल करण्यासाठी Ctrl+S वापरा"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "अॅड्रेस बार मध्यभागी ठेवा"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "किमान अ‍ॅड्रेस बार"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium डीफॉल्ट म्हणून सेट करता येत नाही, कारण ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications यापैकी कोणत्याही ठिकाणी <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> फाइल सापडली नाही."

--- a/i18n/translations/ms.json
+++ b/i18n/translations/ms.json
@@ -370,16 +370,6 @@
     "message": "Gunakan Ctrl+S untuk togol tab menegak dalam reka letak Menegak"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "Tengahkan bar alamat"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Bar alamat minimal"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium tidak dapat ditetapkan sebagai lalai, kerana tiada fail <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> ditemui dalam mana-mana: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/my.json
+++ b/i18n/translations/my.json
@@ -370,16 +370,6 @@
     "message": "Vertical အပြင်အဆင်တွင် ဒေါင်လိုက်တက်ဘ်များကို Ctrl+S ဖြင့် ဖွင့်/ပိတ်ပါ"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "လိပ်စာဘားကို အလယ်တွင် ထားပါ"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "အနည်းဆုံး လိပ်စာဘား"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium ကို ပုံမှန်အဖြစ် သတ်မှတ်၍မရပါ၊ အကြောင်းမှာ ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications တို့တွင် <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> ဖိုင် ရှာမတွေ့ပါ။"

--- a/i18n/translations/nb.json
+++ b/i18n/translations/nb.json
@@ -370,16 +370,6 @@
     "message": "Bruk Ctrl+S til å veksle vertikale faner i vertikalt oppsett"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "Sentrer adressefeltet"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Minimalt adressefelt"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium kan ikke angis som standard fordi ingen <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph>-fil ble funnet i noen av: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/ne.json
+++ b/i18n/translations/ne.json
@@ -370,16 +370,6 @@
     "message": "ठाडो लेआउटमा ठाडो ट्याबहरू टगल गर्न Ctrl+S प्रयोग गर्नुहोस्"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "ठेगाना बार केन्द्रमा राख्नुहोस्"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "न्यूनतम ठेगाना बार"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium लाई पूर्वनिर्धारितमा सेट गर्न सकिँदैन, किनकि कुनै पनि: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications मा <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> फाइल फेला परेन।"

--- a/i18n/translations/nl.json
+++ b/i18n/translations/nl.json
@@ -370,16 +370,6 @@
     "message": "Gebruik Ctrl+S om verticale tabbladen in de verticale indeling in- of uitklappen"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "Adresbalk centreren"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Minimale adresbalk"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium kan niet als standaard worden ingesteld, omdat er geen <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph>-bestand is gevonden in: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/or.json
+++ b/i18n/translations/or.json
@@ -370,16 +370,6 @@
     "message": "ଭର୍ଟିକାଲ୍ ଲେଆଉଟ୍‌ରେ ଭର୍ଟିକାଲ୍ ଟ୍ୟାବ୍ ଟଗଲ୍ କରିବା ପାଇଁ Ctrl+S ବ୍ୟବହାର କରନ୍ତୁ"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "ଠିକଣା ବାର୍ କେନ୍ଦ୍ର କରନ୍ତୁ"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "ସର୍ବନିମ୍ନ ଠିକଣା ବାର୍"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium କୁ ଡିଫଲ୍ଟ ଭାବରେ ସେଟ୍ କରାଯାଇପାରିବ ନାହିଁ, କାରଣ ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications ମଧ୍ୟରୁ କୌଣସିଟିରେ <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> ଫାଇଲ୍ ମିଳିଲା ନାହିଁ।"

--- a/i18n/translations/pa.json
+++ b/i18n/translations/pa.json
@@ -370,16 +370,6 @@
     "message": "ਵਰਟੀਕਲ ਲੇਆਉਟ ਵਿੱਚ ਵਰਟੀਕਲ ਟੈਬਾਂ ਟੌਗਲ ਕਰਨ ਲਈ Ctrl+S ਵਰਤੋ"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "ਐਡਰੈੱਸ ਬਾਰ ਨੂੰ ਕੇਂਦਰ ਵਿੱਚ ਰੱਖੋ"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "ਘੱਟੋ-ਘੱਟ ਐਡਰੈੱਸ ਬਾਰ"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium ਨੂੰ ਡਿਫ਼ਾਲਟ ਵਜੋਂ ਸੈੱਟ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਦਾ, ਕਿਉਂਕਿ ਕੋਈ <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> ਫ਼ਾਈਲ ਇਹਨਾਂ ਵਿੱਚੋਂ ਕਿਸੇ ਵਿੱਚ ਨਹੀਂ ਮਿਲੀ: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/pl.json
+++ b/i18n/translations/pl.json
@@ -370,16 +370,6 @@
     "message": "Użyj Ctrl+S, aby przełączać widoczność paska kart w układzie pionowym"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "Wyśrodkuj pasek adresu"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Minimalny pasek adresu"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Nie można ustawić Helium jako domyślnej przeglądarki, ponieważ nie znaleziono pliku <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> w żadnej z następujących lokalizacji: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/pt-BR.json
+++ b/i18n/translations/pt-BR.json
@@ -371,16 +371,6 @@
     "message": "Usar Ctrl+S para alternar abas verticais no layout Vertical"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "Centralizar a barra de endereço"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Barra de endereço minimalista"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "O Helium não pode ser definido como padrão porque nenhum arquivo <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> foi encontrado em: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/pt-PT.json
+++ b/i18n/translations/pt-PT.json
@@ -370,16 +370,6 @@
     "message": "Utilizar Ctrl+S para alternar separadores verticais na disposição Vertical"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "Centrar a barra de endereço"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Barra de endereço minimalista"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Não é possível definir o Helium como predefinido, porque não foi encontrado nenhum ficheiro <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> em nenhum dos seguintes locais: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/ro.json
+++ b/i18n/translations/ro.json
@@ -370,16 +370,6 @@
     "message": "Folosiți Ctrl+S pentru a activa sau dezactiva filele verticale în aspectul Vertical"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "Centrați bara de adrese"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Bară de adrese minimală"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium nu poate fi setat ca implicit, deoarece nu a fost găsit niciun fișier <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> în niciunul dintre: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/ru.json
+++ b/i18n/translations/ru.json
@@ -370,16 +370,6 @@
     "message": "Использовать Ctrl+S для переключения состояния вертикальных вкладок"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "Расположить адресную строку по центру"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Минималистичная адресная строка"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium не может быть установлен браузером по умолчанию, поскольку файл <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> не найден ни в одном из каталогов: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/si.json
+++ b/i18n/translations/si.json
@@ -370,16 +370,6 @@
     "message": "සිරස් පිරිසැලැස්මේ සිරස් ටැබ් ටොගල් කිරීමට Ctrl+S භාවිතා කරන්න"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "ලිපින තීරුව මධ්‍යගත කරන්න"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "අවම ලිපින තීරුව"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium පෙරනිමි ලෙස සැකසිය නොහැක, මන්ද ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications යන කිසිදු ස්ථානයක <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> ගොනුවක් හමු නොවීය."

--- a/i18n/translations/sk.json
+++ b/i18n/translations/sk.json
@@ -370,16 +370,6 @@
     "message": "Použiť Ctrl+S na prepínanie kariet vo vertikálnom rozložení"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "Vycentrovať panel s adresou"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Minimálny panel s adresou"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium nemožno nastaviť ako predvolený prehliadač, pretože súbor <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> sa nenašiel v žiadnom z adresárov: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/sl.json
+++ b/i18n/translations/sl.json
@@ -370,16 +370,6 @@
     "message": "Uporabi Ctrl+S za preklop navpičnih zavihkov v navpični postavitvi"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "Sredinska naslovna vrstica"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Minimalna naslovna vrstica"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium ni mogoče nastaviti kot privzeti brskalnik, ker datoteka <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> ni bila najdena v nobeni od naslednjih map: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/sq.json
+++ b/i18n/translations/sq.json
@@ -371,16 +371,6 @@
     "message": "Përdor Ctrl+S për të ndërruar skedat vertikale në paraqitjen Vertikale"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "Qendërzo shiritin e adresës"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Shiriti minimal i adresës"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium nuk mund të caktohet si parazgjedhje, sepse nuk u gjet asnjë skedar <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> në asnjë nga: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/sr-Latn.json
+++ b/i18n/translations/sr-Latn.json
@@ -371,16 +371,6 @@
     "message": "Koristi Ctrl+S za preklapanje vertikalnih kartica u vertikalnom rasporedu"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "Centriraj traku za adresu"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Minimalna traka za adresu"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium ne može biti postavljen kao podrazumevani pregledač jer datoteka <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> nije pronađena ni u jednom od sledećih direktorijuma: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/sr.json
+++ b/i18n/translations/sr.json
@@ -370,16 +370,6 @@
     "message": "Користи Ctrl+S за приказивање/сакривање вертикалних картица у вертикалном распореду"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "Центрирај траку за адресу"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Минимална трака за адресу"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium не може бити постављен као подразумевани прегледач јер датотека <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> није пронађена ни у једном од: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/sv.json
+++ b/i18n/translations/sv.json
@@ -370,16 +370,6 @@
     "message": "Använd Ctrl+S för att visa/dölja vertikala flikar i vertikal layout"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "Centrera adressfältet"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Minimalt adressfält"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium kan inte ställas in som standard eftersom ingen <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph>-fil hittades i någon av: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/sw.json
+++ b/i18n/translations/sw.json
@@ -370,16 +370,6 @@
     "message": "Tumia Ctrl+S kubadilisha vichupo vya wima katika mpangilio wa Wima"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "Weka upau wa anwani katikati"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Upau wa anwani mdogo"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium haiwezi kuwekwa kama chaguo-msingi, kwa sababu faili <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> haikupatikana katika yoyote ya: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/ta.json
+++ b/i18n/translations/ta.json
@@ -370,16 +370,6 @@
     "message": "செங்குத்து அமைப்பில் செங்குத்து தாவல்களை மாற்ற Ctrl+S பயன்படுத்தவும்"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "முகவரிப் பட்டியை நடுவில் வைக்கவும்"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "குறைந்தபட்ச முகவரிப் பட்டி"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium-ஐ இயல்புநிலையாக அமைக்க முடியவில்லை, ஏனெனில் ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications ஆகியவற்றில் <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> கோப்பு கண்டறியப்படவில்லை."

--- a/i18n/translations/te.json
+++ b/i18n/translations/te.json
@@ -370,16 +370,6 @@
     "message": "వర్టికల్ లేఅవుట్‌లో వర్టికల్ ట్యాబ్‌లను టోగుల్ చేయడానికి Ctrl+S ఉపయోగించండి"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "అడ్రస్ బార్‌ను మధ్యలో ఉంచు"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "కనిష్ట అడ్రస్ బార్"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Heliumను డిఫాల్ట్‌గా సెట్ చేయడం సాధ్యం కాదు, ఎందుకంటే ~/.local/share/applications, /usr/share/applications, /usr/local/share/applicationsలో ఏదైనా <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> ఫైల్ కనుగొనబడలేదు."

--- a/i18n/translations/th.json
+++ b/i18n/translations/th.json
@@ -370,16 +370,6 @@
     "message": "ใช้ Ctrl+S เพื่อเปิด/ปิดแถบแท็บในรูปแบบการแสดงผลแนวตั้ง"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "จัดแถบที่อยู่ให้อยู่ตรงกลาง"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "แถบที่อยู่แบบเรียบง่าย"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "ไม่สามารถตั้ง Helium เป็นค่าเริ่มต้นได้ เนื่องจากไม่พบไฟล์ <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> ในตำแหน่งใดๆ ต่อไปนี้: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications"

--- a/i18n/translations/tr.json
+++ b/i18n/translations/tr.json
@@ -370,16 +370,6 @@
     "message": "Dikey düzende dikey sekmeleri açıp kapatmak için Ctrl+S kullan"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "Adres çubuğunu ortala"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Minimal adres çubuğu"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium varsayılan tarayıcı olarak ayarlanamıyor, çünkü şu konumlarda <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> dosyası bulunamadı: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/uk.json
+++ b/i18n/translations/uk.json
@@ -370,16 +370,6 @@
     "message": "Використовувати Ctrl+S для перемикання вертикальних вкладок у вертикальному макеті"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "Розмістити адресний рядок по центру"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Мінімальний адресний рядок"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium не може бути встановлений як стандартний браузер, оскільки файл <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> не знайдено в жодному з каталогів: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/ur.json
+++ b/i18n/translations/ur.json
@@ -372,16 +372,6 @@
     "message": "عمودی لے آؤٹ میں عمودی ٹیبز ٹوگل کرنے کے لیے Ctrl+S استعمال کریں"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "ایڈریس بار کو مرکز میں رکھیں"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "کم سے کم ایڈریس بار"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium کو ڈیفالٹ کے طور پر مقرر نہیں کیا جا سکتا، کیونکہ درج ذیل میں سے کسی بھی مقام پر <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> فائل نہیں ملی: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications۔"

--- a/i18n/translations/uz.json
+++ b/i18n/translations/uz.json
@@ -370,16 +370,6 @@
     "message": "Vertikal tartibda vertikal varaqlarni yoqish/o'chirish uchun Ctrl+S dan foydalanish"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "Manzil satrini markazlashtirish"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Minimal manzil satri"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium ni standart brauzer sifatida o'rnatib bo'lmaydi, chunki quyidagi joylarda <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> fayli topilmadi: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/vi.json
+++ b/i18n/translations/vi.json
@@ -370,16 +370,6 @@
     "message": "Sử dụng Ctrl+S để bật/tắt tab dọc trong bố cục Dọc"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "Căn giữa thanh địa chỉ"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Thanh địa chỉ tối giản"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Không thể đặt Helium làm trình duyệt mặc định vì không tìm thấy tệp <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> trong bất kỳ thư mục nào: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/i18n/translations/zh-CN.json
+++ b/i18n/translations/zh-CN.json
@@ -370,16 +370,6 @@
     "message": "使用 Ctrl+S 在垂直布局中切换垂直标签页折叠状态"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "居中显示地址栏"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "精简地址栏"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "无法将 Helium 设为默认浏览器，因为在以下任何位置均未找到 <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> 文件：~/.local/share/applications、/usr/share/applications、/usr/local/share/applications。"

--- a/i18n/translations/zh-HK.json
+++ b/i18n/translations/zh-HK.json
@@ -370,16 +370,6 @@
     "message": "使用 Ctrl+S 切換垂直佈局中的垂直分頁"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "置中網址列"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "精簡網址列"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "無法將 Helium 設為預設瀏覽器，因為在以下位置找不到 <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> 檔案：~/.local/share/applications、/usr/share/applications、/usr/local/share/applications。"

--- a/i18n/translations/zh-TW.json
+++ b/i18n/translations/zh-TW.json
@@ -370,16 +370,6 @@
     "message": "使用 Ctrl+S 在垂直版面配置中切換垂直分頁"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "置中網址列"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "精簡網址列"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "無法將 Helium 設定為預設瀏覽器，因為在以下路徑中找不到 <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> 檔案：~/.local/share/applications、/usr/share/applications、/usr/local/share/applications。"

--- a/i18n/translations/zu.json
+++ b/i18n/translations/zu.json
@@ -370,16 +370,6 @@
     "message": "Sebenzisa Ctrl+S ukuguqula amathebhu amile kusakhiwo Esimile"
   },
   {
-    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
-    "source": "Center the address bar",
-    "message": "Beka ibha yekheli phakathi"
-  },
-  {
-    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
-    "source": "Minimal address bar",
-    "message": "Ibha yekheli encane"
-  },
-  {
     "name": "IDS_SETTINGS_DEFAULT_BROWSER_SECONDARY",
     "source": "Helium cannot be set as default, because no <ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> file was found in any of: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications.",
     "message": "Helium ayikwazi ukusetwa njengezenzakalelayo, ngoba alikho ifayela le-<ph name=\"DESKTOP_FILENAME\">$1<ex>helium.desktop</ex></ph> elitholiwe kunoma yikuphi kwalokhu: ~/.local/share/applications, /usr/share/applications, /usr/local/share/applications."

--- a/patches/helium/ui/layout/centered-address-bar.patch
+++ b/patches/helium/ui/layout/centered-address-bar.patch
@@ -198,7 +198,7 @@
        Show vertical tabs on right side
      </message>
 +    <message name="IDS_SETTINGS_CENTERED_LOCATION_BAR" desc="Label for the toggle to use a centered address bar.">
-+      Center the address bar
++      Centered address bar
 +    </message>
      <message name="IDS_SETTINGS_SHOW_HOME_BUTTON" desc="Label for the checkbox which enables or disables showing the home button in the toolbar.">
        Show home button

--- a/patches/helium/ui/layout/minimal-location-bar.patch
+++ b/patches/helium/ui/layout/minimal-location-bar.patch
@@ -245,10 +245,10 @@
 +++ b/chrome/app/settings_strings.grdp
 @@ -292,6 +292,9 @@
      <message name="IDS_SETTINGS_CENTERED_LOCATION_BAR" desc="Label for the toggle to use a centered address bar.">
-       Center the address bar
+       Centered address bar
      </message>
-+    <message name="IDS_SETTINGS_MINIMAL_LOCATION_BAR" desc="Label for the toggle that enables the minimal address bar.">
-+      Minimal address bar
++    <message name="IDS_SETTINGS_MINIMAL_LOCATION_BAR" desc="Label for the toggle that enables the minimal URL in the address bar, showing only the site origin.">
++      Minimal URL in the address bar
 +    </message>
      <message name="IDS_SETTINGS_SHOW_HOME_BUTTON" desc="Label for the checkbox which enables or disables showing the home button in the toolbar.">
        Show home button

--- a/patches/helium/ui/layout/zen-mode-wiring.patch
+++ b/patches/helium/ui/layout/zen-mode-wiring.patch
@@ -14,8 +14,8 @@
  
      <!-- Appearance Page -->
 @@ -295,6 +301,18 @@
-     <message name="IDS_SETTINGS_MINIMAL_LOCATION_BAR" desc="Label for the toggle that enables the minimal address bar.">
-       Minimal address bar
+     <message name="IDS_SETTINGS_MINIMAL_LOCATION_BAR" desc="Label for the toggle that enables the minimal URL in the address bar, showing only the site origin.">
+       Minimal URL in the address bar
      </message>
 +    <message name="IDS_SETTINGS_BROWSER_ZEN_MODE" desc="Label for the toggle that enables zen mode, hiding browser chrome until hover.">
 +      Frameless mode


### PR DESCRIPTION
this makes the distinction between toggles clearer, and will make translations to other languages easier and more accurate.

closes #2062

i18n-no-notify

<img width="694" height="209" alt="image" src="https://github.com/user-attachments/assets/bb1e4f37-2c2b-4e66-a7eb-614b7a7eefee" />

