### PR TITLE
i18n/tr: translate remaining strings

### DIFF
--- a/i18n/translations/tr.json
+++ b/i18n/translations/tr.json
@@ -1208,5 +1208,130 @@
     "name": "IDS_HELIUM_ONBOARDING_SEARCH_ENGINES_BRAVE",
     "source": "Privacy-focused. Doesn't use Google or Bing. Promises not to track or profile you. May show promotions related to Brave services.",
     "message": "Gizlilik odaklı. Google veya Bing kullanmaz. Sizi izlemeyeceğine ve profillemeyeceğine söz verir. Brave hizmetleriyle ilgili tanıtımlar gösterebilir."
+  },
+  {
+    "name": "IDS_SETTINGS_GLOBAL_PRIVACY_CONTROL",
+    "source": "Global Privacy Control",
+    "message": "Global Gizlilik Denetimi"
+  },
+  {
+    "name": "IDS_SETTINGS_GLOBAL_PRIVACY_CONTROL_DESCRIPTION",
+    "source": "Tell websites to not sell or share your personal data",
+    "message": "Web sitelerinden kişisel verilerinizi satmamalarını veya paylaşmamalarını iste"
+  },
+  {
+    "name": "IDS_SETTINGS_DO_NOT_TRACK",
+    "source": "Send a \"Do Not Track\" signal with your browsing traffic",
+    "message": "Sitelere \"Beni İzleme (Do Not Track)\" isteği gönder"
+  },
+  {
+    "name": "IDS_SETTINGS_DO_NOT_TRACK_DESCRIPTION",
+    "source": "Ask sites to not track you, but they're unlikely to comply",
+    "message": "Sitelerden sizi izlememelerini isteyin, ancak onların buna uyma olasılıkları düşüktür"
+  },
+  {
+    "name": "IDS_SETTINGS_NETWORK_AND_SECURITY",
+    "source": "Network and security",
+    "message": "Ağ ve güvenlik"
+  },
+  {
+    "name": "IDS_SETTINGS_NETWORK_AND_SECURITY_DESCRIPTION",
+    "source": "Manage how Helium connects to sites, what privacy signals are allowed, and more",
+    "message": "Helium’un sitelere nasıl bağlandığını, hangi gizlilik sinyallerine izin verildiğini ve çok daha fazlasını yönetin"
+  },
+  {
+    "name": "IDS_SETTINGS_NETWORK_SECTION_TITLE",
+    "source": "Network",
+    "message": "Ağ"
+  },
+  {
+    "name": "IDS_SETTINGS_PRIVACY_SIGNALS_SECTION_TITLE",
+    "source": "Privacy signals",
+    "message": "Gizlilik sinyalleri"
+  },
+  {
+    "name": "IDS_SETTINGS_PRIVACY_SIGNALS_DESCRIPTION",
+    "source": "Privacy signals communicate your preferences, but do not determine how websites will act. Enabling more signals can make your browser easier to fingerprint by giving it a more unique set of characteristics. Global Privacy Control is more likely to be respected than Do Not Track.",
+    "message": "Gizlilik sinyalleri tercihlerinizi bildirir, ancak web sitelerinin nasıl davranacağını belirlemez. Daha fazla sinyali etkinleştirmek, tarayıcınıza daha benzersiz özellikler kazandırarak parmak izinin alınmasını kolaylaştırabilir. Global Gizlilik Denetimi sinyaline Do Not Track isteğine kıyasla daha fazla uyulur."
+  },
+  {
+    "name": "IDS_SETTINGS_HTTPS_FIRST_MODE_ENABLED_STRICT_LABEL",
+    "source": "Warn about insecure public and local network sites",
+    "message": "Güvenli olmayan herkese açık ve yerel ağ siteleri konusunda uyar"
+  },
+  {
+    "name": "IDS_SETTINGS_HTTPS_FIRST_MODE_ENABLED_BALANCED_LABEL",
+    "source": "Warn about insecure public sites",
+    "message": "Güvenli olmayan herkese açık siteler konusunda uyar"
+  },
+  {
+    "name": "IDS_SETTINGS_CENTERED_LOCATION_BAR",
+    "source": "Centered address bar",
+    "message": "Ortalanmış adres çubuğu"
+  },
+  {
+    "name": "IDS_SETTINGS_MINIMAL_LOCATION_BAR",
+    "source": "Minimal URL in the address bar",
+    "message": "Adres çubuğunda yalnızca sitenin kaynağını göster"
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_WELCOME_BODY",
+    "source": "Configure Helium to match your taste and import data from other browsers. Make it feel like home or jump straight to browsing.",
+    "message": "Helium’u zevkinize göre yapılandırın ve verilerinizi diğer tarayıcılardan içe aktarın. Helium’u eviniz gibi hissettirin veya doğrudan gezinmeye başlayın."
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_WELCOME_FOOTER",
+    "source": "If you use defaults, Helium services will be automatically enabled.",
+    "message": "Varsayılanları kullanırsanız Helium hizmetleri otomatik olarak etkinleştirilir."
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_FINISH_BODY",
+    "source": "The setup is complete, thank you for choosing Helium. Time to enjoy the internet again.",
+    "message": "Kurulum tamamlandı. Helium’u seçtiğiniz için teşekkür ederiz. İnternetin keyfini yeniden çıkarma zamanı."
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_SEARCH_TITLE",
+    "source": "Choose a search engine",
+    "message": "Bir arama motoru seçin"
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_SEARCH_SUBTITLE",
+    "source": "You can change your choice later in Settings. Search engines are sorted by privacy.",
+    "message": "Seçiminizi daha sonra Ayarlar’dan değiştirebilirsiniz. Arama motorları gizlilik düzeyine göre sıralanır."
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_DEFAULT_BROWSER_SUBTITLE",
+    "source": "Better privacy, speed, and comfort. All in one click. Wanna make links open in Helium by default?",
+    "message": "Daha iyi gizlilik, hız ve konfor. Hepsi tek tıkla. Bağlantıların varsayılan olarak Helium’da açılmasını ister misiniz?"
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_PASSWORD_SUBTITLE",
+    "source": "Helium doesn't have a built-in password manager. Would you like to install one from the Web Store?",
+    "message": "Helium’da yerleşik bir parola yöneticisi yok. Web Mağazası’ndan bir tane yüklemek ister misiniz?"
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_PASSWORD_MANAGERS_PROTON_PASS",
+    "source": "Secure and privacy-focused password manager with open-source clients. Stores data only in Europe. Free with an optional paid plan.",
+    "message": "Açık kaynaklı istemcilere sahip, güvenli ve gizlilik odaklı parola yöneticisi. Verileri yalnızca Avrupa’da saklar. Ücretsizdir; isteğe bağlı ücretli bir planı vardır."
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_PASSWORD_MANAGERS_BITWARDEN",
+    "source": "Secure and the most popular open-source password manager. Offers data storage in Europe or US. Free with an optional paid plan. Can be self-hosted.",
+    "message": "Güvenli ve en popüler açık kaynaklı parola yöneticisi. Veri depolama için Avrupa veya ABD seçeneklerini sunar. Ücretsizdir; isteğe bağlı ücretli bir planı vardır. Kendi sunucunuzda barındırılabilir."
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_PASSWORD_MANAGERS_ONE_PASSWORD",
+    "source": "Popular, paid, and closed-source password manager. Offers data storage in Europe or US. May not work correctly with Helium without extra configuration.",
+    "message": "Popüler, ücretli ve kapalı kaynaklı parola yöneticisi. Veri depolama için Avrupa veya ABD seçeneklerini sunar. Ek yapılandırma olmadan Helium’da düzgün çalışmayabilir."
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_PASSWORD_MANAGERS_ICLOUD_PASSWORDS",
+    "source": "Free and closed-source password manager by Apple. Nags about using Safari, requires re-authentication on browser restart, and can't generate passwords.",
+    "message": "Apple tarafından sunulan ücretsiz ve kapalı kaynaklı parola yöneticisi. Safari kullanmanız için ısrarcı uyarılar gösterir, tarayıcı her yeniden başlatıldığında yeniden kimlik doğrulama gerektirir ve parola oluşturamaz."
+  },
+  {
+    "name": "IDS_HELIUM_ONBOARDING_PASSWORD_MANAGERS_KEE_PASS_XC",
+    "source": "Free, local, and open-source password manager for advanced users. Requires technical knowledge to set up and use. Cannot sync without extra software.",
+    "message": "İleri düzey kullanıcılar için ücretsiz, yerel ve açık kaynaklı parola yöneticisi. Kurulum ve kullanım için teknik bilgi gerektirir. Ek yazılım olmadan senkronize edilemez."
   }
 ]


### PR DESCRIPTION
Adds the remaining Turkish translations for Helium-specific settings and onboarding strings.

Only i18n/translations/tr.json is changed.