### PR TITLE
helium/ui: reduce split view drag and drop delay to 500ms

### DIFF
--- a/patches/helium/ui/multi-contents-drop-target.patch
+++ b/patches/helium/ui/multi-contents-drop-target.patch
@@ -404,3 +404,28 @@
  
    double CalculateRatioWithSnapPoints(double start_size,
                                        double total_size) const;
+--- a/chrome/browser/ui/ui_features.cc
++++ b/chrome/browser/ui/ui_features.cc
+@@ -198,19 +198,19 @@ BASE_FEATURE_PARAM(base::TimeDelta,
+                    kShowDropTargetForTabDelay,
+                    &kSplitViewTabDraggingUpdates,
+                    "show_drop_target_for_tab_delay",
+-                   base::Milliseconds(1000));
++                   base::Milliseconds(500));
+ 
+ BASE_FEATURE(kSplitViewDragAndDropVelocity, base::FEATURE_ENABLED_BY_DEFAULT);
+ BASE_FEATURE_PARAM(base::TimeDelta,
+                    kSplitViewDragAndDropMinDelay,
+                    &kSplitViewDragAndDropVelocity,
+                    "min_delay",
+-                   base::Milliseconds(1000));
++                   base::Milliseconds(500));
+ BASE_FEATURE_PARAM(base::TimeDelta,
+                    kSplitViewDragAndDropMaxDelay,
+                    &kSplitViewDragAndDropVelocity,
+                    "max_delay",
+-                   base::Milliseconds(1000));
++                   base::Milliseconds(500));
+ BASE_FEATURE_PARAM(int,
+                    kSplitViewDragAndDropMinDistanceThreshold,
+                    &kSplitViewDragAndDropVelocity,


### PR DESCRIPTION
fixes #1472
