### PR TITLE
helium/ui: expose additional shortcut actions

### DIFF
--- a/i18n/source.gen.json
+++ b/i18n/source.gen.json
@@ -414,6 +414,30 @@
     "message": "Tab <ph name=\"TAB_NUMBER\">$1<ex>1</ex></ph>"
   },
   {
+    "name": "IDS_SHORTCUT_COMMAND_DUPLICATE_TAB",
+    "source": "chrome/app/generated_resources.grd",
+    "context": "Command name shown on the Settings shortcuts page for duplicating the current tab.",
+    "message": "Duplicate tab"
+  },
+  {
+    "name": "IDS_SHORTCUT_COMMAND_SWITCH_TO_CLASSIC_LAYOUT",
+    "source": "chrome/app/generated_resources.grd",
+    "context": "Command name shown on the Settings shortcuts page for switching to the Classic browser layout.",
+    "message": "Switch to Classic layout"
+  },
+  {
+    "name": "IDS_SHORTCUT_COMMAND_SWITCH_TO_COMPACT_LAYOUT",
+    "source": "chrome/app/generated_resources.grd",
+    "context": "Command name shown on the Settings shortcuts page for switching to the Compact browser layout.",
+    "message": "Switch to Compact layout"
+  },
+  {
+    "name": "IDS_SHORTCUT_COMMAND_SWITCH_TO_VERTICAL_LAYOUT",
+    "source": "chrome/app/generated_resources.grd",
+    "context": "Command name shown on the Settings shortcuts page for switching to the Vertical browser layout.",
+    "message": "Switch to Vertical layout"
+  },
+  {
     "name": "IDS_SHORTCUT_COMMAND_MOVE_TAB_NEXT",
     "source": "chrome/app/generated_resources.grd",
     "context": "Command name shown on the Settings shortcuts page for moving the current tab to the right.",
@@ -526,6 +550,18 @@
     "source": "chrome/app/generated_resources.grd",
     "context": "Command name shown on the Settings shortcuts page for toggling Developer Tools.",
     "message": "Toggle developer tools"
+  },
+  {
+    "name": "IDS_SHORTCUT_COMMAND_TOGGLE_PIN_TAB",
+    "source": "chrome/app/generated_resources.grd",
+    "context": "Command name shown on the Settings shortcuts page for pinning or unpinning the active tab.",
+    "message": "Pin or unpin tab"
+  },
+  {
+    "name": "IDS_SHORTCUT_COMMAND_TOGGLE_MUTE_SITE",
+    "source": "chrome/app/generated_resources.grd",
+    "context": "Command name shown on the Settings shortcuts page for muting or unmuting the current site.",
+    "message": "Mute or unmute site"
   },
   {
     "name": "IDS_APP_PLUS_KEY",

--- a/patches/helium/core/copy-url-tab-context-menu.patch
+++ b/patches/helium/core/copy-url-tab-context-menu.patch
@@ -1,6 +1,6 @@
 --- a/chrome/app/generated_resources.grd
 +++ b/chrome/app/generated_resources.grd
-@@ -12086,6 +12086,12 @@ Check your passwords anytime in <ph name
+@@ -12104,6 +12104,12 @@ Check your passwords anytime in <ph name
          <message name="IDS_TAB_CXMENU_HIBERNATE_OTHER_TABS" desc="The label of the 'Hibernate other tabs' Tab context menu item.">
            Hibernate other tabs
          </message>
@@ -13,7 +13,7 @@
          <message name="IDS_TAB_CXMENU_CLOSETAB" desc="The label of the tab context menu item for closing one or more tabs.">
            Close
          </message>
-@@ -12211,6 +12217,12 @@ Check your passwords anytime in <ph name
+@@ -12229,6 +12235,12 @@ Check your passwords anytime in <ph name
          <message name="IDS_TAB_CXMENU_HIBERNATE_OTHER_TABS" desc="In Title Case: The label of the 'Hibernate Other Tabs' Tab context menu item.">
            Hibernate Other Tabs
          </message>

--- a/patches/helium/core/custom-keyboard-shortcuts.patch
+++ b/patches/helium/core/custom-keyboard-shortcuts.patch
@@ -104,7 +104,7 @@
 +#endif  // CHROME_BROWSER_UI_BROWSER_SHORTCUTS_BROWSER_SHORTCUT_METADATA_H_
 --- /dev/null
 +++ b/chrome/browser/ui/browser_shortcuts/browser_shortcut_metadata.cc
-@@ -0,0 +1,263 @@
+@@ -0,0 +1,350 @@
 +// Copyright 2026 The Helium Authors
 +// You can use, redistribute, and/or modify this source code under
 +// the terms of the GPL-3.0 license that can be found in the LICENSE file.
@@ -117,6 +117,7 @@
 +#include <vector>
 +
 +#include "base/check.h"
++#include "build/build_config.h"
 +#include "chrome/app/chrome_command_ids.h"
 +#include "chrome/browser/ui/helium/helium_layout_state_controller.h"
 +#include "chrome/browser/ui/tabs/features.h"
@@ -147,14 +148,14 @@
 +    case IDC_DEBUG_TOGGLE_TABLET_MODE:
 +    case IDC_DEBUG_PRINT_VIEW_TREE:
 +    case IDC_DEBUG_PRINT_VIEW_TREE_DETAILS:
++#if BUILDFLAG(IS_MAC)
 +    case IDC_EXIT:
++#endif
 +    case IDC_HELP_PAGE_VIA_MENU:
 +    case IDC_HIDE_APP:
 +    case IDC_MINIMIZE_WINDOW:
-+    case IDC_OPTIONS:
 +    case IDC_PASTE:
 +    case IDC_TOGGLE_FULLSCREEN_TOOLBAR:
-+    case IDC_WEB_APP_SETTINGS:
 +    case IDC_CONTENT_CONTEXT_COPY:
 +    case IDC_CONTENT_CONTEXT_CUT:
 +    case IDC_CONTENT_CONTEXT_PASTE:
@@ -196,6 +197,8 @@
 +      return Label(IDS_APP_MENU_RELOAD);
 +    case IDC_RELOAD_BYPASSING_CACHE:
 +      return Label(IDS_RELOAD_MENU_HARD_RELOAD_ITEM);
++    case IDC_RELOAD_CLEARING_CACHE:
++      return Label(IDS_RELOAD_MENU_EMPTY_AND_HARD_RELOAD_ITEM);
 +    case IDC_STOP:
 +      return Label(IDS_TOOLTIP_STOP);
 +    case IDC_NEW_WINDOW:
@@ -206,6 +209,28 @@
 +      return Label(IDS_NEW_TAB);
 +    case IDC_NEW_SPLIT_TAB:
 +      return Label(IDS_SHORTCUT_COMMAND_NEW_SPLIT_TAB);
++    case IDC_DUPLICATE_TAB:
++      return Label(IDS_SHORTCUT_COMMAND_DUPLICATE_TAB);
++    case IDC_EXIT:
++      return Label(IDS_EXIT);
++    case IDC_MOVE_TAB_TO_NEW_WINDOW:
++      return Label(IDS_MOVE_TAB_TO_NEW_WINDOW);
++    case IDC_NEW_TAB_TO_RIGHT:
++      return Label(IDS_TAB_CXMENU_NEWTABTORIGHT);
++    case IDC_WINDOW_CLOSE_TABS_TO_RIGHT:
++      return Label(IDS_TAB_CXMENU_CLOSETABSTORIGHT);
++    case IDC_WINDOW_CLOSE_OTHER_TABS:
++      return Label(IDS_TAB_CXMENU_CLOSEOTHERTABS);
++    case IDC_WINDOW_PIN_TAB:
++      return Label(IDS_SHORTCUT_COMMAND_TOGGLE_PIN_TAB);
++    case IDC_SHOW_AS_TAB:
++      return Label(IDS_SHOW_AS_TAB);
++    case IDC_OPEN_IN_PWA_WINDOW:
++      return Label(IDS_INTENT_CHIP_OPEN_IN_APP);
++    case IDC_WEB_APP_SETTINGS:
++      return Label(IDS_WEB_APP_SETTINGS_TITLE);
++    case IDC_WEB_APP_MENU_APP_INFO:
++      return Label(IDS_APP_CONTEXT_MENU_SHOW_INFO);
 +    case IDC_CLOSE_TAB:
 +      return Label(IDS_TAB_SEARCH_CLOSE_TAB);
 +    case IDC_CLOSE_WINDOW:
@@ -264,6 +289,20 @@
 +      return Label(IDS_HISTORY_MENU);
 +    case IDC_SHOW_DOWNLOADS:
 +      return Label(IDS_SHOW_DOWNLOADS);
++    case IDC_CREATE_SHORTCUT:
++      return Label(IDS_ADD_TO_OS_LAUNCH_SURFACE);
++    case IDC_INSTALL_PWA:
++      return Label(IDS_INSTALL_DIY_TO_OS_LAUNCH_SURFACE);
++    case IDC_ROUTE_MEDIA:
++      return Label(IDS_MEDIA_ROUTER_MENU_ITEM_TITLE);
++    case IDC_WINDOW_MUTE_SITE:
++      return Label(IDS_SHORTCUT_COMMAND_TOGGLE_MUTE_SITE);
++    case IDC_QRCODE_GENERATOR:
++      return Label(IDS_SHARING_HUB_GENERATE_QR_CODE_LABEL);
++    case IDC_SHARING_HUB_SCREENSHOT:
++      return Label(IDS_SHARING_HUB_SCREENSHOT_LABEL);
++    case IDC_SHOW_FULL_URLS:
++      return Label(IDS_CONTEXT_MENU_SHOW_FULL_URLS);
 +    case IDC_OPEN_FILE:
 +      return Label(IDS_OPEN_FILE_DIALOG_TITLE);
 +    case IDC_SAVE_PAGE:
@@ -320,6 +359,24 @@
 +      return Label(IDS_SETTINGS_ENABLE_CARET_BROWSING_TITLE);
 +    case IDC_CLEAR_BROWSING_DATA:
 +      return Label(IDS_CLEAR_BROWSING_DATA);
++    case IDC_IMPORT_SETTINGS:
++      return Label(IDS_IMPORT_SETTINGS_MENU_LABEL);
++    case IDC_MANAGE_EXTENSIONS:
++      return Label(IDS_SHOW_EXTENSIONS);
++    case IDC_DEV_TOOLS_DEVICES:
++      return Label(IDS_DEV_TOOLS_DEVICES);
++    case IDC_SHOW_MANAGEMENT_PAGE:
++      return Label(IDS_OPENS_MANAGEMENT_PAGE);
++    case IDC_PERFORMANCE:
++      return Label(IDS_SHOW_PERFORMANCE);
++    case IDC_BROWSER_LAYOUT_CLASSIC:
++      return Label(IDS_SHORTCUT_COMMAND_SWITCH_TO_CLASSIC_LAYOUT);
++    case IDC_BROWSER_LAYOUT_COMPACT:
++      return Label(IDS_SHORTCUT_COMMAND_SWITCH_TO_COMPACT_LAYOUT);
++    case IDC_BROWSER_LAYOUT_VERTICAL:
++      return Label(IDS_SHORTCUT_COMMAND_SWITCH_TO_VERTICAL_LAYOUT);
++    case IDC_OPTIONS:
++      return Label(IDS_SETTINGS);
 +    case IDC_HELP_PAGE_VIA_KEYBOARD:
 +      return Label(IDS_HELP_PAGE);
 +    case IDC_TASK_MANAGER_SHORTCUT:
@@ -360,6 +417,36 @@
 +
 +  commands.push_back(ShouldUseCopyPageUrlLabel(prefs) ? IDC_DEV_TOOLS_INSPECT
 +                                                      : IDC_COPY_URL);
++  commands.push_back(IDC_DUPLICATE_TAB);
++#if !BUILDFLAG(IS_MAC)
++  commands.push_back(IDC_EXIT);
++#endif
++  commands.push_back(IDC_MOVE_TAB_TO_NEW_WINDOW);
++  commands.push_back(IDC_NEW_TAB_TO_RIGHT);
++  commands.push_back(IDC_WINDOW_CLOSE_TABS_TO_RIGHT);
++  commands.push_back(IDC_WINDOW_CLOSE_OTHER_TABS);
++  commands.push_back(IDC_WINDOW_PIN_TAB);
++  commands.push_back(IDC_SHOW_AS_TAB);
++  commands.push_back(IDC_OPEN_IN_PWA_WINDOW);
++  commands.push_back(IDC_WEB_APP_SETTINGS);
++  commands.push_back(IDC_WEB_APP_MENU_APP_INFO);
++  commands.push_back(IDC_CREATE_SHORTCUT);
++  commands.push_back(IDC_INSTALL_PWA);
++  commands.push_back(IDC_ROUTE_MEDIA);
++  commands.push_back(IDC_WINDOW_MUTE_SITE);
++  commands.push_back(IDC_QRCODE_GENERATOR);
++  commands.push_back(IDC_SHARING_HUB_SCREENSHOT);
++  commands.push_back(IDC_SHOW_FULL_URLS);
++  commands.push_back(IDC_RELOAD_CLEARING_CACHE);
++  commands.push_back(IDC_IMPORT_SETTINGS);
++  commands.push_back(IDC_MANAGE_EXTENSIONS);
++  commands.push_back(IDC_DEV_TOOLS_DEVICES);
++  commands.push_back(IDC_SHOW_MANAGEMENT_PAGE);
++  commands.push_back(IDC_PERFORMANCE);
++  commands.push_back(IDC_BROWSER_LAYOUT_CLASSIC);
++  commands.push_back(IDC_BROWSER_LAYOUT_COMPACT);
++  commands.push_back(IDC_BROWSER_LAYOUT_VERTICAL);
++  commands.push_back(IDC_OPTIONS);
 +  return commands;
 +}
 +
@@ -1583,7 +1670,7 @@
        ]
 --- a/chrome/app/generated_resources.grd
 +++ b/chrome/app/generated_resources.grd
-@@ -1874,6 +1874,96 @@ are declared in tools/grit/grit_args.gni
+@@ -1874,6 +1874,114 @@ are declared in tools/grit/grit_args.gni
        <message name="IDS_CHROME_WHATS_NEW" desc="The text label of the Help menu item which takes the user to the Chrome What's New page.">
          What's New
        </message>
@@ -1619,6 +1706,18 @@
 +      </message>
 +      <message name="IDS_SHORTCUT_COMMAND_SELECT_TAB" desc="Command name shown on the Settings shortcuts page for selecting a tab by number.">
 +        Tab <ph name="TAB_NUMBER">$1<ex>1</ex></ph>
++      </message>
++      <message name="IDS_SHORTCUT_COMMAND_DUPLICATE_TAB" desc="Command name shown on the Settings shortcuts page for duplicating the current tab.">
++        Duplicate tab
++      </message>
++      <message name="IDS_SHORTCUT_COMMAND_SWITCH_TO_CLASSIC_LAYOUT" desc="Command name shown on the Settings shortcuts page for switching to the Classic browser layout.">
++        Switch to Classic layout
++      </message>
++      <message name="IDS_SHORTCUT_COMMAND_SWITCH_TO_COMPACT_LAYOUT" desc="Command name shown on the Settings shortcuts page for switching to the Compact browser layout.">
++        Switch to Compact layout
++      </message>
++      <message name="IDS_SHORTCUT_COMMAND_SWITCH_TO_VERTICAL_LAYOUT" desc="Command name shown on the Settings shortcuts page for switching to the Vertical browser layout.">
++        Switch to Vertical layout
 +      </message>
 +      <message name="IDS_SHORTCUT_COMMAND_MOVE_TAB_NEXT" desc="Command name shown on the Settings shortcuts page for moving the current tab to the right.">
 +        Move tab right
@@ -1676,6 +1775,12 @@
 +      </message>
 +      <message name="IDS_SHORTCUT_COMMAND_TOGGLE_DEV_TOOLS" desc="Command name shown on the Settings shortcuts page for toggling Developer Tools.">
 +        Toggle developer tools
++      </message>
++      <message name="IDS_SHORTCUT_COMMAND_TOGGLE_PIN_TAB" desc="Command name shown on the Settings shortcuts page for pinning or unpinning the active tab.">
++        Pin or unpin tab
++      </message>
++      <message name="IDS_SHORTCUT_COMMAND_TOGGLE_MUTE_SITE" desc="Command name shown on the Settings shortcuts page for muting or unmuting the current site.">
++        Mute or unmute site
 +      </message>
        <if expr="not use_titlecase">
          <message name="IDS_IMPORT_SETTINGS_MENU_LABEL" desc="In sentence case: The app menu label to import bookmarks and settings.">

--- a/patches/helium/core/force-paste-action.patch
+++ b/patches/helium/core/force-paste-action.patch
@@ -183,7 +183,7 @@
  // Moves the WebContents of a hosted app Browser to a tabbed Browser. Returns
 --- a/chrome/browser/ui/browser_shortcuts/browser_shortcut_metadata.cc
 +++ b/chrome/browser/ui/browser_shortcuts/browser_shortcut_metadata.cc
-@@ -83,6 +83,8 @@ std::optional<BrowserShortcutCommandLabe
+@@ -84,6 +84,8 @@ std::optional<BrowserShortcutCommandLabe
        return Label(IDS_SHORTCUT_COMMAND_BACK);
      case IDC_FORWARD:
        return Label(IDS_SHORTCUT_COMMAND_FORWARD);
@@ -192,14 +192,14 @@
      case IDC_HOME:
        return Label(IDS_SHORTCUT_COMMAND_HOME);
      case IDC_RELOAD:
-@@ -253,6 +255,7 @@ std::vector<int> GetBrowserShortcutComma
+@@ -310,6 +312,7 @@ std::vector<int> GetBrowserShortcutComma
  
    commands.push_back(ShouldUseCopyPageUrlLabel(prefs) ? IDC_DEV_TOOLS_INSPECT
                                                        : IDC_COPY_URL);
 +  commands.push_back(IDC_FORCE_PASTE);
-   return commands;
- }
- 
+   commands.push_back(IDC_DUPLICATE_TAB);
+ #if !BUILDFLAG(IS_MAC)
+   commands.push_back(IDC_EXIT);
 --- a/tools/metrics/histograms/metadata/ui/enums.xml
 +++ b/tools/metrics/histograms/metadata/ui/enums.xml
 @@ -371,6 +371,7 @@ chromium-metrics-reviews@google.com.

--- a/patches/helium/ui/add-specific-error-for-disabled-extension-downloads.patch
+++ b/patches/helium/ui/add-specific-error-for-disabled-extension-downloads.patch
@@ -90,7 +90,7 @@
        warning_summary_ = l10n_util::GetStringUTF16(
 --- a/chrome/app/generated_resources.grd
 +++ b/chrome/app/generated_resources.grd
-@@ -3267,6 +3267,10 @@ are declared in tools/grit/grit_args.gni
+@@ -3285,6 +3285,10 @@ are declared in tools/grit/grit_args.gni
                 desc="Status text for a download item that was interrupted because the file path name is too long.">
          File name or location is too long
        </message>
@@ -101,7 +101,7 @@
        <message name="IDS_DOWNLOAD_BUBBLE_INTERRUPTED_SUBPAGE_SUMMARY_PATH_TOO_LONG"
                 desc="Subpage summary text for a download item that was interrupted because the file path name is too long.">
          Try using a shorter file name or saving to a different folder
-@@ -3287,6 +3291,10 @@ are declared in tools/grit/grit_args.gni
+@@ -3305,6 +3309,10 @@ are declared in tools/grit/grit_args.gni
                 desc="Status text for a download item that had something go wrong.">
          Something went wrong
        </message>

--- a/patches/helium/ui/layout/context-menu.patch
+++ b/patches/helium/ui/layout/context-menu.patch
@@ -24,7 +24,7 @@
  #define IDC_ADD_NEW_TAB_TO_GROUP      34100
 --- a/chrome/app/generated_resources.grd
 +++ b/chrome/app/generated_resources.grd
-@@ -10444,6 +10444,51 @@ Keep your key file in a safe place. You
+@@ -10462,6 +10462,51 @@ Keep your key file in a safe place. You
                 Bottom
        </message>
  

--- a/patches/helium/ui/layout/zen-mode-wiring.patch
+++ b/patches/helium/ui/layout/zen-mode-wiring.patch
@@ -238,7 +238,7 @@
      {IDC_SHOW_BOOKMARK_MANAGER, ui::EF_COMMAND_DOWN | ui::EF_ALT_DOWN,
 --- a/chrome/app/generated_resources.grd
 +++ b/chrome/app/generated_resources.grd
-@@ -19335,6 +19335,9 @@ Please help our engineers fix this probl
+@@ -19353,6 +19353,9 @@ Please help our engineers fix this probl
        <message name="IDS_LINK_COPIED_TOAST_BODY" desc="Text on a toast notification that is shown when a link is successfully copied.">
          Link copied
        </message>

--- a/patches/helium/ui/side-panel-webui-customize.patch
+++ b/patches/helium/ui/side-panel-webui-customize.patch
@@ -1,6 +1,6 @@
 --- a/chrome/app/generated_resources.grd
 +++ b/chrome/app/generated_resources.grd
-@@ -7911,6 +7911,9 @@ Keep your key file in a safe place. You
+@@ -7929,6 +7929,9 @@ Keep your key file in a safe place. You
        <message name="IDS_NTP_CUSTOMIZE_CHROME_CHANGE_THEME_LABEL" desc="The label for the action button for changing Chrome theme in the New Tab Page customize chrome side panel.">
          Change theme
        </message>

--- a/patches/helium/ui/toolbar-button-prefs.patch
+++ b/patches/helium/ui/toolbar-button-prefs.patch
@@ -569,7 +569,7 @@
    // The container (and extensions-menu button) should not be visible if we have
 --- a/chrome/app/generated_resources.grd
 +++ b/chrome/app/generated_resources.grd
-@@ -10946,6 +10946,9 @@ Keep your key file in a safe place. You
+@@ -10964,6 +10964,9 @@ Keep your key file in a safe place. You
        <message name="IDS_ACCNAME_FIND" desc="The accessible name for the find button.">
          Find
        </message>

--- a/patches/helium/ui/ublock-show-in-settings.patch
+++ b/patches/helium/ui/ublock-show-in-settings.patch
@@ -87,7 +87,7 @@
  };
 --- a/chrome/app/generated_resources.grd
 +++ b/chrome/app/generated_resources.grd
-@@ -13849,6 +13849,9 @@ Check your passwords anytime in <ph name
+@@ -13867,6 +13867,9 @@ Check your passwords anytime in <ph name
          <message name="IDS_EXTENSIONS_INSTALL_LOCATION_SHARED_MODULE" desc="The text explaining the the installation of the extension was because of extensions that depend on this shared module">
            Installed because of dependent extension(s).
          </message>


### PR DESCRIPTION
expose existing browser commands through the configurable keyboard shortcuts page without assigning new default accelerators:
 - Duplicate tab
 - Exit
 - Move active tab to new window
 - Open new tab to the right
 - Close tabs to the right
 - Close other tabs
 - Pin or unpin active tab
 - Show as tab
 - Open active tab in its PWA window
 - Open web app settings
 - Show web app information
 - Create application shortcut
 - Install PWA
 - Route media
 - Mute or unmute current site
 - Create QR code
 - Take screenshot
 - Show full URLs
 - Empty cache and hard reload
 - Import settings
 - Manage extensions
 - Inspect devices
 - Open browser management page
 - Open performance settings
 - Switch to Classic layout
 - Switch to Compact layout
 - Switch to Vertical layout
 - Open Settings

Fixes #335
Fixes #1467
Fixes #1527
Fixes #1528
Fixes #1837
Fixes #1975
Fixes #2246
Fixes imputnet/helium-windows#329
Related: #1711