### PR TITLE
helium/core: add starlark config for rbe builds

### DIFF
--- a/patches/helium/core/rbe-nativelink-config.patch
+++ b/patches/helium/core/rbe-nativelink-config.patch
@@ -1,0 +1,23 @@
+--- /dev/null
++++ b/build/config/siso/backend_config/nativelink.star
+@@ -0,0 +1,20 @@
++# -*- bazel-starlark -*-
++# Copyright 2026 The Helium Authors
++# You can use, redistribute, and/or modify this source code under
++# the terms of the GPL-3.0 license that can be found in the LICENSE file.
++
++load("@builtin//struct.star", "module")
++
++def __platform_properties(ctx):
++    properties = {
++        "cpu_count": "1",
++    }
++    return {
++        "default": properties,
++        "large": properties,
++    }
++
++backend = module(
++    "backend",
++    platform_properties = __platform_properties,
++)

--- a/patches/series
+++ b/patches/series
@@ -216,6 +216,7 @@ helium/core/shift-right-click-context-menu.patch
 helium/core/crash-reporter-privacy-tweaks.patch
 helium/core/crash-reporting-prefs.patch
 helium/core/disable-omnibox-webui.patch
+helium/core/rbe-nativelink-config.patch
 
 helium/settings/settings-page-icons.patch
 helium/settings/move-search-suggest.patch


### PR DESCRIPTION
this is a very simple nativelink config to be used instead of the google ones with a specified google proprietary image

